### PR TITLE
[Feat] GlobalExceptionHandler, InvalidCustomException 생성 (#123)

### DIFF
--- a/backend/src/main/java/org/example/backend/Exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/example/backend/Exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package org.example.backend.Exception;
+
+
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.Exception.custom.InvalidCustomException;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Order(value = 1)
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public BaseResponse<String> handleGlobalException(InvalidCustomException e) {
+        return new BaseResponse<>(e.getStatus());
+    }
+}

--- a/backend/src/main/java/org/example/backend/Exception/custom/InvalidCustomException.java
+++ b/backend/src/main/java/org/example/backend/Exception/custom/InvalidCustomException.java
@@ -1,0 +1,13 @@
+package org.example.backend.Exception.custom;
+
+import lombok.Getter;
+import org.example.backend.Common.BaseResponseStatus;
+
+@Getter
+public class InvalidCustomException extends RuntimeException {
+    private final BaseResponseStatus status;
+
+    public InvalidCustomException(BaseResponseStatus status) {
+        this.status = status;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #123 

## 작업 내용
- GlobalExceptionHandler 생성
```
@RestControllerAdvice
@Order(value = 1)
public class GlobalExceptionHandler {

    @ExceptionHandler(RuntimeException.class)
    public BaseResponse<String> handleGlobalException(InvalidCustomException e) {
        return new BaseResponse<>(e.getStatus());
    }
}
```
- InvalidCustomException 생성
```
@Getter
public class InvalidCustomException extends RuntimeException {
    private final BaseResponseStatus status;

    public InvalidCustomException(BaseResponseStatus status) {
        this.status = status;
    }
}
```
- InvalidCutomExceptio을 상속 받는 예외가 RestController에서throw 되면,  GlobalExceptionHandler가 잡아서 해당 예외의 BaseResponseStatus를 읽어서 응답을 보낸다.


## 스크린샷 (선택)

## 리뷰 요구사항(선택)