### PR TITLE
[Feat] 채팅방 리스트 조회 API 구현 (#55)

### DIFF
--- a/backend/src/main/java/org/example/backend/Chat/Controller/ChatController.java
+++ b/backend/src/main/java/org/example/backend/Chat/Controller/ChatController.java
@@ -1,0 +1,25 @@
+package org.example.backend.Chat.Controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Chat.Model.ChatRoomRes;
+import org.example.backend.Chat.Service.ChatService;
+import org.example.backend.Common.BaseResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatController {
+    private final ChatService chatService;
+
+    @GetMapping("/chatRoomList")
+    public BaseResponse<List<ChatRoomRes>> chatRoomList() {
+        List<ChatRoomRes> myChatRoomResList = chatService.getMyChatRoomList(1L);
+        return new BaseResponse<>(myChatRoomResList);
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/Chat/Model/ChatRoomRes.java
+++ b/backend/src/main/java/org/example/backend/Chat/Model/ChatRoomRes.java
@@ -1,0 +1,16 @@
+package org.example.backend.Chat.Model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomRes {
+    private Long chatRoomId;
+    private String recipientName;
+    private String recipientProfile;
+    private String lastMessage;
+    private LocalDateTime lastMessageDay;
+}

--- a/backend/src/main/java/org/example/backend/Chat/Repository/ChatRoomRepository.java
+++ b/backend/src/main/java/org/example/backend/Chat/Repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package org.example.backend.Chat.Repository;
+
+import org.example.backend.Chat.Model.Entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    List<ChatRoom> findAllByUser1Id(Long userId);
+    List<ChatRoom> findAllByUser2Id(Long userId);
+}

--- a/backend/src/main/java/org/example/backend/Chat/Service/ChatService.java
+++ b/backend/src/main/java/org/example/backend/Chat/Service/ChatService.java
@@ -8,7 +8,6 @@ import org.example.backend.Chat.Repository.ChatRoomRepository;
 import org.example.backend.User.Model.Entity.User;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/backend/src/main/java/org/example/backend/Chat/Service/ChatService.java
+++ b/backend/src/main/java/org/example/backend/Chat/Service/ChatService.java
@@ -1,0 +1,58 @@
+package org.example.backend.Chat.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Chat.Model.ChatRoomRes;
+import org.example.backend.Chat.Model.Entity.Chat;
+import org.example.backend.Chat.Model.Entity.ChatRoom;
+import org.example.backend.Chat.Repository.ChatRoomRepository;
+import org.example.backend.User.Model.Entity.User;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+
+    public List<ChatRoomRes> getMyChatRoomList(Long userId) {
+        List<ChatRoom> myChatRoomList1 = chatRoomRepository.findAllByUser1Id(userId);
+        List<ChatRoom> myChatRoomList2 = chatRoomRepository.findAllByUser2Id(userId);
+
+        List<ChatRoomRes> myChatRoomResList = new ArrayList<>();
+        makeChatRoomResList(1, myChatRoomList1, myChatRoomResList);
+        makeChatRoomResList(2, myChatRoomList2, myChatRoomResList);
+        myChatRoomResList.sort((chatRoomRes1, chatRoomRes2) -> chatRoomRes2.getLastMessageDay().compareTo(chatRoomRes1.getLastMessageDay()));
+        return myChatRoomResList;
+    }
+
+    private static void makeChatRoomResList(Integer userSequence, List<ChatRoom> myChatRoomList1, List<ChatRoomRes> myChatRoomResList) {
+        for (ChatRoom chatRoom : myChatRoomList1) {
+            User user;
+            if (userSequence == 1) {
+                user = chatRoom.getUser2();
+            } else {
+                user = chatRoom.getUser1();
+            }
+            List<Chat> chatList = chatRoom.getChatList();
+            String lastMessage = "";
+            LocalDateTime lastSendTime = LocalDateTime.now();
+            if (chatList != null) {
+                chatList.sort((chat1, chat2) -> chat2.getSendTime().compareTo(chat1.getSendTime()));
+                lastMessage = chatList.get(0).getMessage();
+                lastSendTime = chatList.get(0).getSendTime();
+            }
+            ChatRoomRes chatRoomRes = ChatRoomRes.builder()
+                    .chatRoomId(chatRoom.getId())
+                    .recipientName(user.getNickname())
+                    .recipientProfile(user.getProfileImg())
+                    .lastMessage(lastMessage)
+                    .lastMessageDay(lastSendTime)
+                    .build();
+            myChatRoomResList.add(chatRoomRes);
+        }
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #55

## 작업 내용
- 채팅방 목록 조회 API 구현
  - 로그인한 사용자의 정보는 임의로 id=1인 유저로 구현
  - ChatRoom 엔티티의 user1_id 와 user2_id 중 하나라도 값이 id 인 ChatRoom 엔티티를 모두 조회 후 상대방의 닉네임과 프로필 이미지를 가져오고, 해당 ChatRoom을 외래키로 가지는 chat 엔티티중 가장 최신 데이터의 메세지와 send_time을 가져온다.
  - 위에서 가져온 데이터로 response 객체를 만들고 리스트에 담는다.
  - 리스트의 lastMessageDay 값으로 정렬하여 응답으로 보낸다.
```
{
    "code": 1000,
    "isSuccess": true,
    "message": "요청이 성공하였습니다.",
    "result": [
        {
            "chatRoomId": 2,
            "recipientName": "김우혁",
            "recipientProfile": "https://enadu.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/95b69c0a-b44c-43f4-bebf-4d86e77d735c",
            "lastMessage": "메세지4",
            "lastMessageDay": "2024-09-08T16:02:10"
        },
        {
            "chatRoomId": 1,
            "recipientName": "혁우김",
            "recipientProfile": "https://enadu.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/95b69c0a-b44c-43f4-bebf-4d86e77d735c",
            "lastMessage": "메세지3",
            "lastMessageDay": "2024-09-08T15:56:30"
        }
    ]
}
```

## 스크린샷 (선택)

## 리뷰 요구사항 (선택)