### PR TITLE
[Feat] 위키 등록 백엔드 API (#23)

### DIFF
--- a/backend/src/main/java/org/example/backend/Category/Model/Entity/Category.java
+++ b/backend/src/main/java/org/example/backend/Category/Model/Entity/Category.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.backend.Wiki.Model.Entity.Wiki;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +24,12 @@ public class Category {
     private String categoryName;
 
     @ManyToOne
-    @JoinColumn(name = "super_category_id")
+    @JoinColumn(name = "super_category_id", nullable = true)
     private Category superCategory;
 
     @OneToMany(mappedBy = "superCategory", cascade = CascadeType.ALL)
     private List<Category> subCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "category")
+    private List<Wiki>  wikiList = new ArrayList<>();
 }

--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -14,7 +14,10 @@ public enum BaseResponseStatus {
     // 포인트 기능 - 4000
 
     // 위키 기능 - 5000
-
+    WIKI_REGIST_FAIL(false, 5001,"위키 등록을 실패했습니다."),
+    WIKI_TITLE_REGIST_FAIL(false, 5002,"제목을 입력해주세요."),
+    WIKI_CATEGORY_REGIST_FAIL(false, 5002,"카테고리를 입력해주세요."),
+    WIKI_CONTENT_REGIST_FAIL(false, 5003,"내용을 입력해주세요."),
     // 에러 아카이브 기능 - 6000
 
     // 에러 QnA 기능 - 7000

--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -22,7 +22,7 @@ public enum BaseResponseStatus {
     // 채팅 기능 - 8000
 
     // 카테고리 기능 - 9000
-
+    NOT_FOUND_CATEGORY(false, 9011, "카테고리를 찾을 수 없습니다."),
     // 기타 기능 - 10000
     EMPTY_FILE(false, 10011, "빈 파일입니다."),
     INVALID_FILE_TYPE(false, 10012, "지원하지 않는 파일 형식입니다."),

--- a/backend/src/main/java/org/example/backend/Exception/custom/InvalidCategoryException.java
+++ b/backend/src/main/java/org/example/backend/Exception/custom/InvalidCategoryException.java
@@ -1,0 +1,11 @@
+package org.example.backend.Exception.custom;
+
+import org.example.backend.Common.BaseResponseStatus;
+
+public class InvalidCategoryException extends InvalidCustomException {
+
+    public InvalidCategoryException(BaseResponseStatus status) {
+        super(status);
+    }
+}
+

--- a/backend/src/main/java/org/example/backend/Exception/custom/InvalidWikiException.java
+++ b/backend/src/main/java/org/example/backend/Exception/custom/InvalidWikiException.java
@@ -1,0 +1,10 @@
+package org.example.backend.Exception.custom;
+
+import org.example.backend.Common.BaseResponseStatus;
+
+public class InvalidWikiException extends InvalidCustomException {
+
+    public InvalidWikiException(BaseResponseStatus status) {
+        super(status);
+    }
+}

--- a/backend/src/main/java/org/example/backend/File/Service/CloudFileUploadService.java
+++ b/backend/src/main/java/org/example/backend/File/Service/CloudFileUploadService.java
@@ -2,6 +2,7 @@ package org.example.backend.File.Service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidFileException;
@@ -12,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -82,4 +84,13 @@ public class CloudFileUploadService {
         }
         return amazonS3Client.getUrl(bucketName, fileName).toString();
     }
+
+    // 썸네일 기본이미지 반환
+    public List<String> basicThumbnailList = Arrays.asList("https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg3.png","https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg2.png","https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg1.png");
+
+    public String getBasicThumbnailUrl() {
+        int random = (int) (Math.random() * basicThumbnailList.size());
+        return basicThumbnailList.get(random);
+    }
 }
+

--- a/backend/src/main/java/org/example/backend/File/Service/CloudFileUploadService.java
+++ b/backend/src/main/java/org/example/backend/File/Service/CloudFileUploadService.java
@@ -86,7 +86,7 @@ public class CloudFileUploadService {
     }
 
     // 썸네일 기본이미지 반환
-    public List<String> basicThumbnailList = Arrays.asList("https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg3.png","https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg2.png","https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg1.png");
+    private final static List<String> basicThumbnailList = Arrays.asList("https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg3.png","https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg2.png","https://jimmny.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/08/BasicImg1.png");
 
     public String getBasicThumbnailUrl() {
         int random = (int) (Math.random() * basicThumbnailList.size());

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -2,6 +2,7 @@ package org.example.backend.Wiki.Controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
+import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import static org.example.backend.Common.BaseResponseStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,15 +24,28 @@ public class WikiController {
     // 위키 등록
     @PostMapping
     public BaseResponse<WikiRegisterRes> register(
+            //  ToDo : customUserDetails
             @RequestPart WikiRegisterReq wikiRegisterReq,
-            @RequestPart MultipartFile thumbnail
+            @RequestPart(required = false) MultipartFile thumbnail
     ) {
-        //  ToDo : customUserDetails, 위키 등록 예외처리
-//        if (req == null) {
-//            throw new InvalidWikiException(Wiki_REGIST_FAIL);
-//        }
-        String thumbnailImgUrl = cloudFileUploadService.uploadImg(thumbnail); //thumbnail 경로를 thumbnailImgUrl 에 반환
-        WikiRegisterRes wikiRegisterRes = wikiService.register(wikiRegisterReq, thumbnailImgUrl);
+        if (wikiRegisterReq.getTitle().isEmpty()) {
+            throw new InvalidWikiException(WIKI_TITLE_REGIST_FAIL);
+        }
+        if (wikiRegisterReq.getCategoryId() == null){
+            throw new InvalidWikiException(WIKI_CATEGORY_REGIST_FAIL);
+        }
+        if (wikiRegisterReq.getContent().isEmpty()) {
+            throw new InvalidWikiException(WIKI_CONTENT_REGIST_FAIL);
+        }
+        // 썸네일 등록 확인 로직
+        String thumbnailUrl;
+        if(thumbnail == null || thumbnail.isEmpty()){
+            thumbnailUrl = cloudFileUploadService.getBasicThumbnailUrl();
+        } else {
+            thumbnailUrl = cloudFileUploadService.uploadImg(thumbnail);
+        }
+
+        WikiRegisterRes wikiRegisterRes = wikiService.register(wikiRegisterReq, thumbnailUrl);
         return new BaseResponse<>(wikiRegisterRes);
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -1,0 +1,35 @@
+package org.example.backend.Wiki.Controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.File.Service.CloudFileUploadService;
+import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
+import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
+import org.example.backend.Wiki.Service.WikiService;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/wiki")
+public class WikiController {
+    private final WikiService wikiService;
+    private final CloudFileUploadService cloudFileUploadService;
+
+    // 위키 등록
+    @PostMapping
+    public BaseResponse<WikiRegisterRes> register(
+            @RequestPart WikiRegisterReq wikiRegisterReq,
+            @RequestPart MultipartFile thumbnail
+    ) {
+        //  ToDo : customUserDetails, 위키 등록 예외처리
+//        if (req == null) {
+//            throw new InvalidWikiException(Wiki_REGIST_FAIL);
+//        }
+        String thumbnailImgUrl = cloudFileUploadService.uploadImg(thumbnail); //thumbnail 경로를 thumbnailImgUrl 에 반환
+        WikiRegisterRes wikiRegisterRes = wikiService.register(wikiRegisterReq, thumbnailImgUrl);
+        return new BaseResponse<>(wikiRegisterRes);
+    }
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/Wiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/Wiki.java
@@ -1,10 +1,8 @@
 package org.example.backend.Wiki.Model.Entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.antlr.v4.runtime.misc.NotNull;
 import org.example.backend.Category.Model.Entity.Category;
 
 import java.util.List;
@@ -14,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 public class Wiki {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +20,7 @@ public class Wiki {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
+    @NotNull
     private Category category;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "wiki")
@@ -31,5 +31,10 @@ public class Wiki {
     private LatestWiki latestWiki;
 
     @Column(nullable = false)
+    @NotNull
     private String title;
+
+    public void updateLatestWiki(LatestWiki latestWiki) {
+        this.latestWiki = latestWiki;
+    }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/Wiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/Wiki.java
@@ -19,7 +19,7 @@ public class Wiki {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 
@@ -29,4 +29,7 @@ public class Wiki {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "latest_wiki_id")
     private LatestWiki latestWiki;
+
+    @Column(nullable = false)
+    private String title;
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
@@ -1,10 +1,7 @@
 package org.example.backend.Wiki.Model.Entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.example.backend.User.Model.Entity.User;
 
 import java.time.LocalDateTime;
@@ -20,6 +17,7 @@ public class WikiContent {
     private Long id;
 
     @Column(columnDefinition = "TEXT", nullable = false)
+    @NonNull
     private String content;
 
     @Builder.Default

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiRegisterReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiRegisterReq.java
@@ -1,0 +1,20 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.antlr.v4.runtime.misc.NotNull;
+
+@Builder
+@Getter
+@Setter
+public class WikiRegisterReq {
+
+    @NotNull
+    private String title;
+    @NotNull
+    private Long categoryId;
+    @NotNull
+    private String content;
+
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiRegisterRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiRegisterRes.java
@@ -1,0 +1,10 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class WikiRegisterRes {
+    private Long wikiId;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/LatestWikiRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/LatestWikiRepository.java
@@ -1,0 +1,7 @@
+package org.example.backend.Wiki.Repository;
+
+import org.example.backend.Wiki.Model.Entity.LatestWiki;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LatestWikiRepository extends JpaRepository<LatestWiki, Long> {
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
@@ -1,0 +1,7 @@
+package org.example.backend.Wiki.Repository;
+
+import org.example.backend.Wiki.Model.Entity.WikiContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WikiContentRepository extends JpaRepository<WikiContent, Long> {
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
@@ -1,0 +1,7 @@
+package org.example.backend.Wiki.Repository;
+
+import org.example.backend.Wiki.Model.Entity.Wiki;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WikiRepository extends JpaRepository<Wiki, Long> {
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
@@ -3,5 +3,8 @@ package org.example.backend.Wiki.Repository;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface WikiRepository extends JpaRepository<Wiki, Long> {
+    Optional<Wiki> findByTitle(String title);
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -3,6 +3,7 @@ package org.example.backend.Wiki.Service;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Category.Repository.CategoryRepository;
 import org.example.backend.Exception.custom.InvalidCategoryException;
+import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.Wiki.Model.Entity.LatestWiki;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
@@ -13,7 +14,7 @@ import org.example.backend.Wiki.Repository.WikiContentRepository;
 import org.example.backend.Wiki.Repository.WikiRepository;
 import org.springframework.stereotype.Service;
 
-import static org.example.backend.Common.BaseResponseStatus.NOT_FOUND_CATEGORY;
+import static org.example.backend.Common.BaseResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,9 @@ public class WikiService {
 
     // 위키 등록 ToDo : 매개변수 customUserDetails 유저정보 추가
     public WikiRegisterRes register(WikiRegisterReq wikiRegisterReq, String thumbnail) {
+        if (wikiRepository.findByTitle(wikiRegisterReq.getTitle()).isPresent()) {
+            throw new InvalidWikiException(WIKI_REGIST_FAIL);
+        }
         // Wiki 등록
         Wiki registerWiki = Wiki.builder()
                 .category(categoryRepository.findById(wikiRegisterReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(NOT_FOUND_CATEGORY)))
@@ -49,6 +53,9 @@ public class WikiService {
                 .thumbnailImgUrl(registerContent.getThumbnail())
                 .build();
         latestWikiRepository.save(registerLatestWiki);
+
+        registerWiki.updateLatestWiki(registerLatestWiki);
+        wikiRepository.save(registerWiki);
 
         return WikiRegisterRes.builder().wikiId(registerWiki.getId()).build();
     }

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -1,0 +1,55 @@
+package org.example.backend.Wiki.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Category.Repository.CategoryRepository;
+import org.example.backend.Exception.custom.InvalidCategoryException;
+import org.example.backend.Wiki.Model.Entity.LatestWiki;
+import org.example.backend.Wiki.Model.Entity.Wiki;
+import org.example.backend.Wiki.Model.Entity.WikiContent;
+import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
+import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
+import org.example.backend.Wiki.Repository.LatestWikiRepository;
+import org.example.backend.Wiki.Repository.WikiContentRepository;
+import org.example.backend.Wiki.Repository.WikiRepository;
+import org.springframework.stereotype.Service;
+
+import static org.example.backend.Common.BaseResponseStatus.NOT_FOUND_CATEGORY;
+
+@Service
+@RequiredArgsConstructor
+public class WikiService {
+    private final WikiRepository wikiRepository;
+    private final CategoryRepository categoryRepository;
+    private final WikiContentRepository wikiContentRepository;
+    private final LatestWikiRepository latestWikiRepository;
+
+    // 위키 등록 ToDo : 매개변수 customUserDetails 유저정보 추가
+    public WikiRegisterRes register(WikiRegisterReq wikiRegisterReq, String thumbnail) {
+        // Wiki 등록
+        Wiki registerWiki = Wiki.builder()
+                .category(categoryRepository.findById(wikiRegisterReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(NOT_FOUND_CATEGORY)))
+                .title(wikiRegisterReq.getTitle())
+                .build();
+        wikiRepository.save(registerWiki);
+
+        // Wiki Content 등록
+        WikiContent registerContent = WikiContent.builder()
+                .wiki(registerWiki)
+                //.user() ToDo : 위키 등록 작성자 정보
+                .content(wikiRegisterReq.getContent())
+                .version(1) //최초 버전
+                .thumbnail(thumbnail)
+                .build();
+        wikiContentRepository.save(registerContent);
+
+        // Latest Wiki 등록
+        LatestWiki registerLatestWiki = LatestWiki.builder()
+                .content(registerContent.getContent())
+                .version(registerContent.getVersion())
+                .thumbnailImgUrl(registerContent.getThumbnail())
+                .build();
+        latestWikiRepository.save(registerLatestWiki);
+
+        return WikiRegisterRes.builder().wikiId(registerWiki.getId()).build();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
 
 
   jpa:
+    database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
       ddl-auto: update
     properties:


### PR DESCRIPTION
## 연관 이슈
close #23

## 작업 내용
- 위키 등록시 사용자 Req에 의해 썸네일, 위키 내용 저장
- 위키 등록할 때(수정 x, 젤 처음 등록) 제목, 내용, 카테고리가 필요한데 위키 Entity에는 title이 없었음. => Wiki Entity에 title 추가
- Wiki와 Category 연관관계 수정. => OneToOne에서 ManyToOne
- content 안의 사진 업로드시, 사진 경로 URL은 컬럼의 content에 같이 저장 처리
- Response는 위키의 ID 반환

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/85ea3d1f-00cc-458e-a3c5-b11ae2a97c53)
![image](https://github.com/user-attachments/assets/511b3b51-edb6-48c7-9f42-f58af8337bd4)


## 리뷰 요구사항 (선택)
- 유저 권한 설정은 추후에 추가 예정
- 위키 등록 예외처리 추후에 추가 예정
- 위키 등록 시  해당 위키 제목, 버전(1)이 있으면 등록 불가 처리 예정