### PR TITLE
[Fix] Qna 질문 등록 기능 CustomUserDetails를 활용한 유저 데이터 연결

### DIFF
--- a/backend/src/main/java/org/example/backend/Category/Repository/CategoryRepository.java
+++ b/backend/src/main/java/org/example/backend/Category/Repository/CategoryRepository.java
@@ -4,6 +4,7 @@ import org.example.backend.Category.Model.Entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
   List<Category> findBySuperCategory_IdNull();

--- a/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:8081");
+        config.addAllowedOrigin("*");
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -7,6 +7,8 @@ import org.example.backend.Qna.Service.QnaService;
 import org.example.backend.Qna.model.Entity.Res.GetQnaListRes;
 import org.example.backend.Qna.model.Entity.req.CreateQuestionReq;
 import org.example.backend.Qna.model.Entity.req.GetQnaListReq;
+import org.example.backend.Security.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,15 +21,15 @@ public class QuestionController {
 
     //qna 등록
     @PostMapping()
-    public BaseResponse<Void> saveQuestion(@RequestBody CreateQuestionReq req) {
-        qnaService.saveQuestion(req);
+    public BaseResponse<Void> saveQuestion(@RequestBody CreateQuestionReq createQuestionReq, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        qnaService.saveQuestion(createQuestionReq, customUserDetails);
         return new BaseResponse<>();
     }
 
     //qna 목록 조회
     @GetMapping("list")
-    public BaseResponse<List<GetQnaListRes>> getQnaList(@RequestBody GetQnaListReq req) {
-        List<GetQnaListRes> qnaListRes = qnaService.getQnaList(req);
+    public BaseResponse<List<GetQnaListRes>> getQnaList(@RequestBody GetQnaListReq getQnaListReq) {
+        List<GetQnaListRes> qnaListRes = qnaService.getQnaList(getQnaListReq);
         return new BaseResponse<>(qnaListRes);
 
     }

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -4,13 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.Category.Repository.CategoryRepository;
 import org.example.backend.Common.BaseResponseStatus;
-import org.example.backend.Exception.custom.InvalidFileException;
 import org.example.backend.Exception.custom.InvalidQnaException;
+import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.Qna.Repository.QuestionRepository;
 import org.example.backend.Qna.model.Entity.QnaBoard;
 import org.example.backend.Qna.model.Entity.Res.GetQnaListRes;
 import org.example.backend.Qna.model.Entity.req.CreateQuestionReq;
 import org.example.backend.Qna.model.Entity.req.GetQnaListReq;
+import org.example.backend.Security.CustomUserDetails;
+import org.example.backend.User.Model.Entity.User;
+import org.example.backend.User.Repository.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -26,29 +29,34 @@ import java.util.stream.Collectors;
 public class QnaService {
     private final QuestionRepository questionRepository;
     private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
 
-    public void saveQuestion(CreateQuestionReq req) {
-        Optional<Category> category = categoryRepository.findById(req.getCategoryId());
+    public void saveQuestion(CreateQuestionReq createQuestionReq, CustomUserDetails customUserDetails) {
+        Optional<Category> category = categoryRepository.findById(createQuestionReq.getCategoryId());
+        Optional<User> user = userRepository.findByEmail(customUserDetails.getUsername());
 
-        if (category.isPresent()) {
+        if (category.isPresent() && user.isPresent()) {
             QnaBoard qnaBoard = QnaBoard.builder()
-                    .title(req.getTitle())
-                    .content(req.getContent())
+                    .user(user.get())
+                    .title(createQuestionReq.getTitle())
+                    .content(createQuestionReq.getContent())
                     .category(category.get())
                     .build();
 
             qnaBoard.createdAt();
             questionRepository.save(qnaBoard);
         }
-        else {
+        else if (category.isEmpty()) {
             throw new InvalidQnaException(BaseResponseStatus.INVALID_CATEGORY_DATA);
+        } else {
+            throw new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND);
         }
     }
 
     public List<GetQnaListRes> getQnaList(GetQnaListReq req) {
         Pageable pageable;
         // 최신순 or 좋아요가 많은 순으로 정렬 type 지정, 둘 다 아니면 에러
-        if(req.getSort().equals("latest")) {
+        if (req.getSort().equals("latest")) {
             pageable = PageRequest.of(req.getPage(), req.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
         }
         else if(req.getSort().equals("like")) {


### PR DESCRIPTION
## 연관 이슈
close #34 

## 작업 내용
- 질문 등록 시 CustomUserDetails를 받을 수 있도록 설정
- CustomUserDetails의 email 데이터를 이용하여 해당 이메일을 username으로 가지는 USER를 조회
- 해당 USER를 QnA DB에 저장  

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)