### PR TITLE
[Feat] 카테고리 모달 추가 (#74, #77, #68)

### DIFF
--- a/frontend/src/components/Category/CategoryItemComponent.vue
+++ b/frontend/src/components/Category/CategoryItemComponent.vue
@@ -1,0 +1,47 @@
+<template>
+    <li class="category-item" :class="{ selected: isSelected }" @click="selectCategory">
+        {{ category.categoryName }}
+    </li>
+</template>
+
+<script>
+    export default {
+        name: "CategoryItemComponent",
+        props: {
+            category: {
+            type: Object,
+            required: true
+        },
+            isSelected: {
+                type: Boolean,
+                default: false
+            }
+        },
+        methods: {
+            selectCategory() {
+                this.$emit("selectCategory", this.category);
+            }
+        }
+    }
+</script>
+
+<style scoped>
+.category-item {
+        padding: 10px 15px;
+        background-color: #fff;
+        border-radius: 25px;
+        cursor: pointer;
+        transition: background-color 0.3s, transform 0.2s;
+        font-size: 14px;
+        border: 1px solid #ddd;
+    }
+
+    .category-item:hover {
+        background-color: #e0e0e0;
+    }
+    .category-item.selected {
+        background-color: var(--main-color);
+        color: white;
+        border: 1px solid #fff;
+    }
+</style>

--- a/frontend/src/components/Category/SubCategoryModal.vue
+++ b/frontend/src/components/Category/SubCategoryModal.vue
@@ -1,0 +1,265 @@
+<template>
+    <div class="category-search-modal-body">
+        <div class="modal-background">
+            <div class="modal">
+                <div class="modal-header">
+                    하위 카테고리 선택
+                    <div class="super-category-name">상위 카테고리 : {{ superCategory.categoryName }}</div>
+                </div>
+                <div class="modal-search-container">
+                    <input type="text" class="search-box" v-model="searchKeyword" placeholder="카테고리를 검색하세요" />
+                    <button class="search-btn">
+                        <i class="fas fa-search"></i>
+                    </button>
+                </div>
+                <div class="category-list-wrapper">
+                    <div v-if="loading" style="text-align: center;">로딩 중...</div>
+                    <div v-if="filteredSubCategories && filteredSubCategories.length > 0">
+                        <ul class="category-list">
+                            <CategoryItemComponent 
+                                v-for="category in filteredSubCategories" 
+                                :key="category.id" 
+                                :category="category" 
+                                :isSelected="category.id === mySubCategory?.id" 
+                                @select-category="handleCategorySelect"/>
+                        </ul>
+                    </div>
+                    <div v-else style="text-align: center;">해당 카테고리 없음</div>
+                </div>
+                <div class="create-category">
+                    <button class="btn create-btn" @click="createSubCategory">하위 카테고리 생성</button>
+                </div>
+                <div class="button-group">
+                    <button class="btn close-btn" @click="closeModal">닫기</button>
+                    <button class="btn check-btn" @click="confirmSelection">확인</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { useCategoryStore } from '@/store/useCategoryStore';
+import CategoryItemComponent from './CategoryItemComponent.vue';
+
+export default {
+    name: "SubCategoryModal",
+    props: {
+        superCategory: {
+            type: Object,
+            required: true
+        }
+    },
+    data() {
+        return {
+            loading: false,
+            mySubCategory: null,
+            filteredSubCategories: [],
+            default: 1,
+        }
+    },
+    computed: {
+        searchKeyword: {
+            get() {
+                const categoryStore = useCategoryStore();
+                return categoryStore.searchKeyword;
+            },
+            set(value) {
+                const categoryStore = useCategoryStore();
+                categoryStore.updateSearchKeyword(value);
+            }
+        }
+    },
+    methods: {
+        loadSubCategories() {
+            this.loading = true;
+            const categoryStore = useCategoryStore();
+            categoryStore.loadSubCategories(this.superCategory.id)
+                .then(() => {
+                    this.loading = false;
+                    this.filteredSubCategories = categoryStore.filteredSubCategories;
+                })
+                .catch((error) => {
+                    console.log("error : " + error);
+                    this.loading = false;
+                });
+        },
+        handleCategorySelect(mySubCategory) {
+            this.mySubCategory = mySubCategory;
+        },
+        confirmSelection() {
+            if (this.mySubCategory) {
+                this.$emit('mySubCategory', this.mySubCategory);
+                this.$emit('closeSub');
+            } else {
+                alert("카테고리를 선택하세요.");
+            }
+        },
+        closeModal() {
+            this.$emit('closeSub');
+        },
+        createSubCategory() {
+            alert("등록 등록")
+        }
+    },
+    watch: {
+        searchKeyword() {
+            const categoryStore = useCategoryStore();
+            this.filteredSubCategories = categoryStore.filteredSubCategories;
+            this.mySubCategory = null;
+        }
+    },
+    created() {
+        this.loadSubCategories();
+    },
+    components: {
+        CategoryItemComponent
+    }
+}
+</script>
+
+<style scoped>
+    .modal-background {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .modal {
+        background-color: white;
+        padding: 30px;
+        border-radius: 16px;
+        width: 600px;
+        max-height: 80%;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        overflow: hidden;
+    }
+
+    .modal-header {
+        font-size: 24px;
+        margin-bottom: 20px;
+        color: #333;
+        font-weight: bold;
+    }
+
+    .super-category-name {
+        font-size: 18px;
+        color: #333;
+        font-weight: normal;
+        margin-top: 10px;
+        text-align: center;
+    }
+
+    .modal-search-container {
+        display: flex;
+        position: relative;
+        margin-bottom: 20px;
+    }
+
+    .search-box {
+        width: 100%;
+        padding: 12px 16px;
+        border: 1px solid #ddd;
+        border-radius: 10px;
+        margin-bottom: 20px;
+        font-size: 16px;
+        box-sizing: border-box;
+    }
+
+    .search-btn {
+        position: absolute;
+        right: 20px;
+        top: 40%;
+        transform: translateY(-50%);
+        background-color: transparent;
+        border: none;
+        cursor: default;
+        padding: 0;
+    }
+
+    .search-btn i {
+        font-size: 24px;
+        color: #666;
+        transition: color 0.1s;
+    }
+
+    .category-list-wrapper {
+        flex-grow: 1;
+        overflow-y: scroll;
+        margin-bottom: 20px;
+        padding-right: 10px;
+        height: 300px;
+    }
+
+    .category-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 0;
+        margin: 0;
+        list-style: none;
+    }
+
+    .button-group {
+        display: flex;
+        justify-content: center;
+        gap: 10px;
+    }
+
+    .btn {
+        padding: 10px 20px;
+        border-radius: 8px;
+        border: none;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: bold;
+        transition: background-color 0.3s, transform 0.2s;
+    }
+
+    .btn:focus {
+        outline: none;
+    }
+
+    .close-btn {
+        background-color: #e44e4e;
+        color: white;
+    }
+
+    .close-btn:hover {
+        background-color: #ff5c5c;
+    }
+
+    .check-btn {
+        background-color: var(--main-color);
+        color: white;
+    }
+
+    .check-btn:hover {
+        background-color: #67adfd;
+    }
+
+    .create-category {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 10px;
+    }
+
+    .create-btn {
+        background-color: #fff;
+        border: 1px solid #ddd;
+    }
+
+    .create-btn:hover {
+        background-color: var(--main-color);
+        color: #fff;
+    }
+</style>

--- a/frontend/src/components/Category/SuperCategoryModal.vue
+++ b/frontend/src/components/Category/SuperCategoryModal.vue
@@ -1,0 +1,229 @@
+<template>
+    <div class="category-search-modal-body">
+        <div class="modal-background">
+            <div class="modal">
+                <div class="modal-header">상위 카테고리 선택</div>
+                <div class="modal-search-container">
+                    <input type="text" class="search-box" v-model="searchKeyword" placeholder="카테고리를 검색하세요" />
+                    <button class="search-btn">
+                        <i class="fas fa-search"></i>
+                    </button>
+                </div>
+                <div class="category-list-wrapper">
+                    <div v-if="loading" style="text-align: center;">로딩 중...</div>
+                    <div v-if="filteredCategories && filteredCategories.length > 0">
+                        <ul class="category-list">
+                            <CategoryItemComponent 
+                                v-for="category in filteredCategories" 
+                                :key="category.id" 
+                                :category="category" 
+                                :isSelected="category.id === mySuperCategory?.id" 
+                                @select-category="handleCategorySelect"/>
+                        </ul>
+                    </div>
+                    <div v-else style="text-align: center;">해당 카테고리 없음</div>
+                </div>
+                <div class="button-group">
+                    <button class="btn close-btn" @click="closeModal">닫기</button>
+                    <button class="btn check-btn" @click="confirmSelection">확인</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { useCategoryStore } from '@/store/useCategoryStore';
+import CategoryItemComponent from './CategoryItemComponent.vue';
+
+export default {
+    name: "SuperCategoryModal",
+    data() {
+        return {
+            loading: false,
+            mySuperCategory: null,
+            filteredCategories: []
+        }
+    },
+    computed: {
+        searchKeyword: {
+            get() {
+                const categoryStore = useCategoryStore();
+                return categoryStore.searchKeyword;
+            },
+            set(value) {
+                const categoryStore = useCategoryStore();
+                categoryStore.updateSearchKeyword(value);
+            }
+        }
+    },
+    methods: {
+        loadSuperCategories() {
+            this.loading = true;
+            const categoryStore = useCategoryStore();
+            categoryStore.loadSuperCategories()
+                .then(() => {
+                    this.loading = false;
+                    this.filteredCategories = categoryStore.filteredCategories;
+                })
+                .catch((error) => {
+                    console.log("error : " + error);
+                    this.loading = false;
+                });
+        },
+        handleCategorySelect(mySuperCategory) {
+            this.mySuperCategory = mySuperCategory;
+        },
+        confirmSelection() {
+            if (this.mySuperCategory) {
+                this.$emit('mySuperCategory', this.mySuperCategory);
+                this.$emit('closeSuper');
+            } else {
+                alert("카테고리를 선택하세요.");
+            }
+        },
+        closeModal() {
+            this.$emit('closeSuper');
+        }
+    },
+    watch: {
+        searchKeyword() { // 변화가 있을 때마다 업데이트
+            const categoryStore = useCategoryStore();
+            this.filteredCategories = categoryStore.filteredCategories;
+            this.mySuperCategory = null;
+        }
+    },
+    created() {
+        this.loadSuperCategories();
+    },
+    components: {
+        CategoryItemComponent
+    }
+}
+</script>
+
+<style scoped>
+    .modal-background {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .modal {
+        background-color: white;
+        padding: 30px;
+        border-radius: 16px;
+        width: 600px;
+        max-height: 80%;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        overflow: hidden;
+    }
+
+    .modal-header {
+        font-size: 24px;
+        margin-bottom: 20px;
+        color: #333;
+        font-weight: bold;
+    }
+
+    .modal-search-container {
+        display: flex;
+        position: relative;
+        margin-bottom: 20px;
+    }
+
+    .search-box {
+        width: 100%;
+        padding: 12px 16px;
+        border: 1px solid #ddd;
+        border-radius: 10px;
+        margin-bottom: 20px;
+        font-size: 16px;
+        box-sizing: border-box;
+    }
+
+    .search-btn {
+        position: absolute;
+        right: 20px;
+        top: 40%;
+        transform: translateY(-50%);
+        background-color: transparent;
+        border: none;
+        cursor: default;
+        padding: 0;
+    }
+
+    .search-btn i {
+        font-size: 24px;
+        color: #666;
+        transition: color 0.1s;
+    }
+
+    /* .search-btn:hover i {
+        color: var(--main-color);
+    } */
+
+    .category-list-wrapper {
+        flex-grow: 1;
+        overflow-y: scroll;
+        margin-bottom: 20px;
+        padding-right: 10px;
+        height: 300px;
+    }
+
+    .category-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        padding: 0;
+        margin: 0;
+        list-style: none;
+    }
+
+    .button-group {
+        display: flex;
+        justify-content: center;
+        gap: 10px;
+    }
+
+    .btn {
+        padding: 10px 20px;
+        border-radius: 8px;
+        border: none;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: bold;
+        transition: background-color 0.3s, transform 0.2s;
+    }
+
+    .btn:focus {
+        outline: none;
+    }
+
+    .close-btn {
+        background-color: #e44e4e;
+        color: white;
+    }
+
+    .close-btn:hover {
+        background-color: #ff5c5c;
+    }
+
+    .check-btn {
+        background-color: var(--main-color);
+        color: white;
+    }
+
+    .check-btn:hover {
+        background-color: #67adfd;
+    }
+</style>

--- a/frontend/src/store/useCategoryStore.js
+++ b/frontend/src/store/useCategoryStore.js
@@ -1,0 +1,71 @@
+import { defineStore } from "pinia";
+import axios from "axios";
+
+const backend = "/api";
+
+export const useCategoryStore = defineStore("category", {
+    state: () => ({
+        superCategories: [],
+        subCategories: [],
+        loading: false,
+        searchKeyword: ""
+    }),
+    actions: {
+        async loadSuperCategories() {
+            this.loading = true;
+            try {
+                const response = await axios.get(backend + "/category/super");
+                this.superCategories = response.data.result;
+            } catch (error) {
+                console.log("상위 카테고리 로딩 실패");
+            } finally {
+                this.loading = false;
+            }
+        },
+        async loadSubCategories(superCategoryId) {
+            this.loading = true;
+            if (superCategoryId === null) superCategoryId = 1;
+            try {
+                if (!superCategoryId) {
+                    throw new Error("superCategoryId가 유효하지 않습니다.");
+                }
+                const response = await axios.get(`${backend}/category/sub?superCategoryId=${superCategoryId}`);
+                        this.subCategories = response.data.result;
+            } catch (error) {
+                if (error.response) {
+                    console.error("서버 응답 에러:", error.response.data);
+                    console.error("상태 코드:", error.response.status);
+                    console.error("헤더:", error.response.headers);
+                } else if (error.request) {
+                    console.error("응답 없음:", error.request);
+                } else {
+                    console.error("에러 메시지:", error.message);
+                }
+                console.error("전체 에러 객체:", error);
+            } finally {
+                this.loading = false;
+            }
+        },
+        updateSearchKeyword(keyword) {
+            this.searchKeyword = keyword;
+        }
+    },
+    getters: {
+        filteredCategories(state) {
+            if (state.searchKeyword === "") {
+                return state.superCategories;
+            }
+            return state.superCategories.filter(category =>
+                category.categoryName.toLowerCase().includes(state.searchKeyword.toLowerCase())
+            );
+        },
+        filteredSubCategories(state) {
+            if (state.searchKeyword === "") {
+                return state.subCategories;
+            }
+            return state.subCategories.filter(category =>
+                category.categoryName.toLowerCase().includes(state.searchKeyword.toLowerCase())
+            );
+        }
+    }
+});


### PR DESCRIPTION
## 연관 이슈
close #74, #77, #68
백엔드 카테고리 검색 로직 불필요 #49

## 작업 내용
- 상위 카테고리 선택, 하위 카테고리 선택 모달 UI 구현
- 선택한 카테고리 상위 컴포넌트로 전달 기능 추가 (객체로 id, categoryName 포함)
- useUserStore에 getters를 추가해서 백엔드에 검색 로직 필요 없이 불러온 값에서 검색 기능 구현

### 상위 카테고리 모달 emit 
선택하면 : @mySuperCategory(객체 변수명도 mySuperCategory )
그냥 닫기 : @closeSuper

### 하위 카테고리 모달 emit
선택하면 : @mySubCategory(객체 변수명도 mySubCategory )
그냥 닫기 : @closeSub

### 하위 카테고리 모달 props
superCategory 객체(id, categoryName) props로 전달 필요

## 스크린샷 (선택)
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/cbeb2617-dd87-4014-9840-a5c6d9ceba58">


## 리뷰 요구사항 혹은 기타 (선택)
머지 한 다음에 서브쪽 잘 작동하는지 확인 필요(props 값을 받았다 생각하고 구현)