### PR TITLE
[Fix] qna 목록 조회 customUserDetails를 활용한 유저 정보 데이터 조회 기능 추가

### DIFF
--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -28,7 +28,7 @@ public class QuestionController {
 
     //qna 목록 조회
     @GetMapping("list")
-    public BaseResponse<List<GetQnaListRes>> getQnaList(@RequestBody GetQnaListReq getQnaListReq) {
+    public BaseResponse<List<GetQnaListRes>> getQnaList(@RequestBody GetQnaListReq getQnaListReq, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         List<GetQnaListRes> qnaListRes = qnaService.getQnaList(getQnaListReq);
         return new BaseResponse<>(qnaListRes);
 

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -33,7 +33,7 @@ public class QnaService {
 
     public void saveQuestion(CreateQuestionReq createQuestionReq, CustomUserDetails customUserDetails) {
         Optional<Category> category = categoryRepository.findById(createQuestionReq.getCategoryId());
-        Optional<User> user = userRepository.findByEmail(customUserDetails.getUsername());
+        Optional<User> user = userRepository.findById(customUserDetails.getUserId());
 
         if (category.isPresent() && user.isPresent()) {
             QnaBoard qnaBoard = QnaBoard.builder()

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -53,14 +53,14 @@ public class QnaService {
         }
     }
 
-    public List<GetQnaListRes> getQnaList(GetQnaListReq req) {
+    public List<GetQnaListRes> getQnaList(GetQnaListReq getQnaListReq) {
         Pageable pageable;
         // 최신순 or 좋아요가 많은 순으로 정렬 type 지정, 둘 다 아니면 에러
-        if (req.getSort().equals("latest")) {
-            pageable = PageRequest.of(req.getPage(), req.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
+        if (getQnaListReq.getSort().equals("latest")) {
+            pageable = PageRequest.of(getQnaListReq.getPage(), getQnaListReq.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
         }
-        else if(req.getSort().equals("like")) {
-            pageable = PageRequest.of(req.getPage(), req.getSize(), Sort.by(Sort.Direction.DESC, "likeCnt"));
+        else if(getQnaListReq.getSort().equals("like")) {
+            pageable = PageRequest.of(getQnaListReq.getPage(), getQnaListReq.getSize(), Sort.by(Sort.Direction.DESC, "likeCnt"));
         }
         else {
             throw new InvalidQnaException(BaseResponseStatus.INVALID_SEARCH_TYPE);
@@ -72,10 +72,10 @@ public class QnaService {
                         (qnaBoard -> GetQnaListRes.builder()
                         .id(qnaBoard.getId())
                         .title(qnaBoard.getTitle())
-                        .superCategory(qnaBoard.getCategory() != null &&
-                                        qnaBoard.getCategory().getSuperCategory() != null ?
-                                        qnaBoard.getCategory().getSuperCategory().getCategoryName() : null)
-                        .subCategory(qnaBoard.getCategory().getCategoryName())
+                        .superCategoryName(qnaBoard.getCategory().getSuperCategory().getCategoryName())
+                        .subCategoryName(qnaBoard.getCategory() != null ?
+                                        qnaBoard.getCategory().getCategoryName() : null)
+                        .subCategoryName(qnaBoard.getCategory().getCategoryName())
                         .nickname(qnaBoard.getUser().getNickname())
                         .profileImage(qnaBoard.getUser().getProfileImg())
                         .grade(qnaBoard.getUser().getGrade())

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -67,26 +67,23 @@ public class QnaService {
         }
         // paging 처리 및 responseList 생성
         Page<QnaBoard> qnaBoardPage = questionRepository.findAll(pageable);
-        List<GetQnaListRes> responseList = qnaBoardPage.getContent().stream().map
+
+        return qnaBoardPage.getContent().stream().map
                         (qnaBoard -> GetQnaListRes.builder()
                         .id(qnaBoard.getId())
                         .title(qnaBoard.getTitle())
-                                // 이렇게 하면 top이 아니라 차상위로 지정됨 수정 필요
-                        .superCategory(qnaBoard.getCategory().getSuperCategory().getCategoryName())
+                        .superCategory(qnaBoard.getCategory() != null &&
+                                        qnaBoard.getCategory().getSuperCategory() != null ?
+                                        qnaBoard.getCategory().getSuperCategory().getCategoryName() : null)
                         .subCategory(qnaBoard.getCategory().getCategoryName())
-                        .nickname("ASHD89")
-                        .profileImage("example.img")
-                        .grade("god")
-//                        .nickname(qnaBoard.getUser().getNickname())
-//                        .profileImage(qnaBoard.getUser().getProfileImg())
-//                        .grade(qnaBoard.getUser().getGrade())
+                        .nickname(qnaBoard.getUser().getNickname())
+                        .profileImage(qnaBoard.getUser().getProfileImg())
+                        .grade(qnaBoard.getUser().getGrade())
                         .likeCnt(qnaBoard.getLikeCount())
                         .answerCnt(qnaBoard.getAnswerCount())
                         .createdAt(qnaBoard.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
-
-        return responseList;
     }
 
 

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/Res/GetQnaListRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/Res/GetQnaListRes.java
@@ -12,8 +12,8 @@ import lombok.*;
 public class GetQnaListRes {
         private Long id;
         private String title;
-        private String superCategory;
-        private String subCategory;
+        private String superCategoryName;
+        private String subCategoryName;
         private String nickname;
         private String profileImage;
         private String grade;


### PR DESCRIPTION
## 연관 이슈
close #36 

## 작업 내용
- customUserDetails를 활용 user데이터를 넣어, 목록 조회 구현

## 스크린샷 (선택)
화면이 변경되었다면 어떻게 수정되었는지 사진을 첨부한다.


## 리뷰 요구사항 혹은 기타 (선택)
- 카테고리 쪽에 sub나 super에 null 값을 넣는 것, 즉 둘 중 하나의 데이터만 넣을 수 있는 것에 대한 처리가 필요함
- 일시적으로
![image](https://github.com/user-attachments/assets/cdd818a5-7b72-4616-b72f-6580ee7e4e33)
이런식으로 처리함 => 후에 카테고리 단계에서 처리 되면 지울 예정
- 또한 db상에서 관계 키 문제라고는 뜨는데 정확한 이유는 모르겠으나 동일한 카테고리id를 사용하여, 서로 다른 qna에 등록할 수 없는 문제가 확인됨 (논의 필요)
