### PR TITLE
[Feat] 채팅 내역 조회 컴포넌트, 채팅 페이지 생성 (#96, #82)

### DIFF
--- a/frontend/src/components/Chat/ChatComponent.vue
+++ b/frontend/src/components/Chat/ChatComponent.vue
@@ -19,7 +19,7 @@
                                   :idx="idx" :chatMessage="chatMessage"
                                   :recipientId="chatStore.chatMessageList.recipientId"
             />
-            <li class="date_check">
+            <li v-if="chatStore.chatMessageList.messageList.length !== 0"  class="date_check">
               <span>
                 <em><strong> {{ chatStore.chatMessageList.messageList.at(-1).sendTime.split("T")[0] }}</strong></em>
               </span>
@@ -33,7 +33,8 @@
             <div class="chat_write_wrap">
               <div class="input_btn_wrap"></div>
               <div class="chat_input_area">
-                <textarea @input="autoResize" ref="textarea"  title="메시지 입력창" class="chat_input" maxlength="2000" placeholder="메시지를 입력하세요."></textarea>
+                <textarea @input="autoResize" ref="textarea" title="메시지 입력창" class="chat_input" maxlength="2000"
+                          placeholder="메시지를 입력하세요." v-model="content"></textarea>
               </div>
               <div class="submit_btn_wrap">
                 <button class="btn_submit " type="submit" aria-disabled="true"><img src="@/assets/img/send_icon.png"
@@ -69,17 +70,21 @@ export default {
     return {
       isLoading: true,
       page: 0,
+      content: "",
     }
   },
   methods: {
     async getChatMessageList() {
-      await this.chatStore.getChatMessageList(1, this.page);
+      await this.chatStore.getChatMessageList(this.page);
       this.isLoading = false;
     },
     autoResize() {
       const textarea = this.$refs.textarea;
       textarea.style.height = 'auto'; // 높이를 초기화하여 줄 수를 재계산
       textarea.style.height = textarea.scrollHeight + 'px'; // 내용에 맞게 높이 조절
+      if (this.content === "") {
+        textarea.style.height = 20+"px";
+      }
     },
   },
   mounted() {
@@ -89,6 +94,18 @@ export default {
 </script>
 
 <style scoped>
+
+.content {
+  position: relative;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  min-width: 445px;
+  margin-left: 10px;
+  border: 1px solid #e6e6ea;
+}
 
 /* class:chat_section 정확하게  채팅방 section */
 .chat_section {
@@ -100,7 +117,7 @@ export default {
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
   flex-direction: column;
-  height: 100%;
+  height: 600px;
 }
 
 .chat_section {

--- a/frontend/src/components/Chat/ChatComponent.vue
+++ b/frontend/src/components/Chat/ChatComponent.vue
@@ -1,0 +1,572 @@
+<template>
+  <div id="content" class="content">
+    <section class="chat_section">
+      <header class="chat_header" aria-hidden="false">
+        <div class="chat_header_top">
+          <div class="info_area">
+            <div class="text_wrap">
+              <div class="name_area"><strong class="name">{{ chatStore.chatMessageList.recipientNickname }}</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <section class="chat_area _chatWindow" aria-hidden="false">
+        <div class="chat_reverse">
+          <ul class="group_message_balloon" style="visibility: visible;">
+            <li v-if="isLoading"></li>
+            <ChatMessageComponent v-else v-for="(chatMessage, idx) in chatStore.chatMessageList.messageList" :key=idx
+                                  :idx="idx" :chatMessage="chatMessage"
+                                  :recipientId="chatStore.chatMessageList.recipientId"
+            />
+          </ul>
+        </div>
+      </section>
+      <footer class="chat_write" aria-hidden="false">
+        <div>
+          <div class="chat_write_area">
+            <div class="chat_write_wrap">
+              <div class="input_btn_wrap"></div>
+              <div class="chat_input_area">
+                <textarea @input="autoResize" ref="textarea"  title="메시지 입력창" class="chat_input" maxlength="2000" placeholder="메시지를 입력하세요."></textarea>
+              </div>
+              <div class="submit_btn_wrap">
+                <button class="btn_submit " type="submit" aria-disabled="true"><img src="@/assets/img/send_icon.png"
+                                                                                    style="width: 20px; height: 20px;"
+                                                                                    alt=""></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chat_faq_area">
+          <div class="chat_composite_option_area hide ">
+            <ul class="list_btn_option"></ul>
+          </div>
+          <div class="ly_chat_toast hide" role="alert" style="opacity: 0;"></div>
+        </div>
+      </footer>
+    </section>
+  </div>
+</template>
+
+<script>
+import ChatMessageComponent from "@/components/Chat/ChatMessageComponent.vue";
+import {mapStores} from "pinia";
+import {useChatStore} from "@/store/useChatStore";
+
+export default {
+  name: "ChatComponent",
+  components: {ChatMessageComponent},
+  computed: {
+    ...mapStores(useChatStore) // 어떤 저장소랑 연결시켜 주겠다.
+  },
+  data() {
+    return {
+      isLoading: true,
+      prevMessageDate: "1900-01-01"
+    }
+  },
+  methods: {
+    async getChatMessageList() {
+      await this.chatStore.getChatMessageList();
+      this.isLoading = false;
+    },
+    autoResize() {
+      const textarea = this.$refs.textarea;
+      textarea.style.height = 'auto'; // 높이를 초기화하여 줄 수를 재계산
+      textarea.style.height = textarea.scrollHeight + 'px'; // 내용에 맞게 높이 조절
+    },
+  },
+  mounted() {
+    this.getChatMessageList();
+  }
+}
+</script>
+
+<style scoped>
+
+/* class:chat_section 정확하게  채팅방 section */
+.chat_section {
+  position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.chat_section {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background: #f0f2f5;
+}
+
+/* class: chat_header 채팅방 헤더 */
+.chat_header {
+  position: relative;
+  z-index: 1000;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 9px 20px;
+  border-bottom: 1px solid rgba(0, 0, 0, .06);
+  background-color: rgba(240, 242, 245, .95);
+}
+
+.chat_header_top {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 38px;
+}
+
+.chat_header_top .info_area {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  min-width: 0;
+  color: #1e1e23;
+}
+
+/* .info_area {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+} */
+.chat_header_top .text_wrap {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.chat_header_top .name_area {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.chat_header_top .text_wrap .name {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 18px;
+}
+
+/* class: chat_area _chatWindow, 채팅 에리어 */
+.chat_area {
+  z-index: 100;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.chat_area {
+  position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.chat_reverse {
+  display: flex;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: reverse;
+  flex-direction: column-reverse;
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 100%;
+  flex: 1 1 100%;
+}
+
+.group_message_balloon {
+  position: sticky;
+  bottom: 0;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding: 20px 14px;
+}
+
+ul {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+/* 채팅 지역에 날짜 */
+.group_message_balloon .date_check {
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+li {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+.group_message_balloon .date_check > span {
+  display: inline-block;
+  padding: 0 12px 1px;
+  border-radius: 15px;
+  background-color: rgba(161, 173, 184, .7);
+}
+
+.group_message_balloon .date_check em {
+  display: inline-block;
+  height: 25px;
+  color: #fff;
+  font-size: 12px;
+  line-height: 25px;
+}
+
+em {
+  font-style: normal;
+}
+
+.group_message_balloon .date_check em > strong {
+  font-size: 13px;
+  font-weight: 400;
+  vertical-align: bottom;
+}
+
+/* 채팅 메세지 */
+.group_message_balloon .new_message_balloon_area {
+  position: relative;
+}
+
+li {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+.group_message_balloon .message_balloon.rgt.card_inform, .group_message_balloon .message_balloon.rgt.card_message {
+  border-color: #c5e8fe;
+  background: #d9f0ff;
+}
+
+.group_message_balloon .message_balloon.rgt.type_text {
+  max-width: 80%;
+}
+
+.group_message_balloon .message_balloon.rgt {
+  float: right;
+  max-width: 290px;
+  margin-right: 5px;
+}
+
+.group_message_balloon .message_balloon {
+  position: relative;
+  float: left;
+  max-width: 290px;
+  margin-bottom: 0;
+  margin-left: 40px;
+  border: 1px solid rgba(0, 0, 0, .12);
+  border-radius: 12px;
+  background-color: #fff;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.group_message_balloon .message_balloon > p {
+  padding: 11px 13px;
+  border-radius: 11px;
+  color: #1e1e23;
+  font-size: 14px;
+}
+
+p {
+  padding: 0;
+  margin: 0;
+}
+
+.group_message_balloon .message_balloon.rgt .txt_confirm {
+  right: 100%;
+  left: inherit;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0 10px 0 0;
+  text-align: right;
+}
+
+.group_message_balloon .message_balloon .txt_confirm {
+  position: absolute;
+  bottom: 1px;
+  left: 100%;
+  min-width: 60px;
+  margin-left: 10px;
+  color: #929294;
+  font-size: 11px;
+}
+
+.group_message_balloon .message_balloon.rgt .txt_confirm > span {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+em {
+  font-style: normal;
+}
+
+.group_message_balloon .message_balloon.rgt.card_message:after {
+  background: url(@/assets/img/message_tail_request_re.svg) no-repeat;
+}
+
+.group_message_balloon .message_balloon.rgt.card_message:after {
+  top: 1px;
+  right: -7px;
+  left: inherit;
+  width: 10px;
+}
+
+.group_message_balloon .message_balloon.card_message:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -5px;
+  width: 10px;
+  height: 10.99px;
+  background: url(@/assets/img/message_tail_re.svg) no-repeat;
+}
+
+.group_message_balloon .new_message_balloon_area:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.group_message_balloon .new_message_balloon_area + li {
+  margin-top: 30px;
+}
+
+/* 상대가 보낸 채팅 메세지의 프로필이미지,유저이름 */
+li {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity .2s ease-in-out;
+  transition: opacity .2s ease-in-out;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile .thumbnail_link {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #fff;
+  text-align: center;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile .thumbnail_link img {
+  position: absolute;
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 100%;
+  margin: auto;
+}
+
+img {
+  max-width: 100%;
+  border: 0;
+  vertical-align: top;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  content: "";
+  border: 1px solid rgba(0, 0, 0, .06);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.group_message_balloon .new_message_balloon_area .chat_message_nickname {
+  margin: 1px 5px 10px 40px;
+}
+
+.group_message_balloon .new_message_balloon_area .chat_message_nickname strong {
+  color: #666f7a;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* class: chat_write채팅방 푸터 (메세지 입력 부분) */
+.chat_write {
+  position: relative;
+  z-index: 100;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.chat_write_area {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-top: 1px solid #e6e6ea;
+  background-color: #fff;
+}
+
+.chat_write_wrap {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.input_btn_wrap {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  height: 49px;
+  padding-left: 16px;
+}
+
+.chat_input_area {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 0;
+  flex: 1 0;
+  padding: 15px 0 14px;
+  margin-left: 1px;
+}
+
+.chat_input {
+  overflow-y: auto;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  height: 20px;
+  max-height: 200px;
+  padding: 0 17px 0 6px;
+  color: #000;
+  font-size: 15px;
+  line-height: 20px;
+}
+
+textarea {
+  border: none;
+  outline: none;
+  resize: none;
+}
+
+textarea {
+  font-family: -apple-system, BlinkMacSystemFont, Apple SD Gothic Neo, Arial, Malgun Gothic, 맑은 고딕, Dotum, sans-serif;
+  font-size: 12px;
+}
+
+textarea {
+  padding: 0;
+  margin: 0;
+}
+
+.submit_btn_wrap {
+  margin-right: 12px;
+}
+
+.submit_btn_wrap .btn_submit {
+  width: 40px;
+  height: 49px;
+  color: #c7c9cf;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+img {
+  max-width: 100%;
+  border: 0;
+  vertical-align: top;
+}
+</style>

--- a/frontend/src/components/Chat/ChatComponent.vue
+++ b/frontend/src/components/Chat/ChatComponent.vue
@@ -63,12 +63,13 @@ export default {
   data() {
     return {
       isLoading: true,
-      prevMessageDate: "1900-01-01"
+      page: 0,
+      prevMessageDate: "1900-01-01",
     }
   },
   methods: {
     async getChatMessageList() {
-      await this.chatStore.getChatMessageList();
+      await this.chatStore.getChatMessageList(1, this.page);
       this.isLoading = false;
     },
     autoResize() {

--- a/frontend/src/components/Chat/ChatComponent.vue
+++ b/frontend/src/components/Chat/ChatComponent.vue
@@ -19,6 +19,11 @@
                                   :idx="idx" :chatMessage="chatMessage"
                                   :recipientId="chatStore.chatMessageList.recipientId"
             />
+            <li class="date_check">
+              <span>
+                <em><strong> {{ chatStore.chatMessageList.messageList.at(-1).sendTime.split("T")[0] }}</strong></em>
+              </span>
+            </li>
           </ul>
         </div>
       </section>
@@ -64,7 +69,6 @@ export default {
     return {
       isLoading: true,
       page: 0,
-      prevMessageDate: "1900-01-01",
     }
   },
   methods: {
@@ -218,6 +222,8 @@ export default {
   -ms-flex-positive: 1;
   flex-grow: 1;
   padding: 20px 14px;
+  display: flex;
+  flex-direction: column-reverse;
 }
 
 ul {

--- a/frontend/src/components/Chat/ChatMessageComponent.vue
+++ b/frontend/src/components/Chat/ChatMessageComponent.vue
@@ -1,0 +1,325 @@
+<template>
+  <li v-if="showDate" class="date_check">
+    <span>
+      <em><strong> {{ chatMessageDate }}</strong></em>
+    </span>
+  </li>
+  <li class="new_message_balloon_area  _message _msgId2">
+    <div v-if="recipientId===chatMessage.userId" class="thumbnail_profile _thmbnail">
+      <button role="link" class="thumbnail_link ">
+        <img :src="chatMessage.profileImg"
+             alt="유저 프로필" width="31">
+      </button>
+    </div>
+    <div v-if="recipientId===chatMessage.userId" class="chat_message_nickname _nickname">
+      <strong>{{chatMessage.nickname}}</strong>
+    </div>
+    <div v-if="recipientId===chatMessage.userId" class="message_balloon card_message type_text" role="heading" aria-level="5">
+      <p class="_copy_area">{{ chatMessage.message }}</p>
+      <div class="txt_confirm _status">
+        <span class="_time"><em>{{ day }}</em> <span>{{hour}}:{{minute}}</span></span>
+      </div>
+    </div>
+    <div v-else class="message_balloon card_message type_text rgt" role="heading" aria-level="5">
+      <p class="_copy_area">{{ chatMessage.message }}</p>
+      <div class="txt_confirm _status">
+        <span class="_time"><em>{{ day }}</em> <span>{{hour}}:{{minute}}</span></span>
+      </div>
+    </div>
+  </li>
+
+</template>
+
+<script>
+import {mapStores} from "pinia";
+import {useChatStore} from "@/store/useChatStore";
+
+export default {
+  name: "ChatMessageComponent",
+  props: ['chatMessage', "recipientId", "idx"],
+  computed: {
+    ...mapStores(useChatStore) // 어떤 저장소랑 연결시켜 주겠다.
+  },
+  data() {
+    return {
+      chatMessageDate: this.chatMessage.sendTime.split("T")[0],
+      day: "오전",
+      hour: "",
+      minute: "",
+    }
+  },
+  methods: {
+    showDate() {
+      return this.chatMessageDate === this.chatStore.chatMessageList.messageList[this.key].sendTime.split("T")[0]
+    },
+    setTime() {
+      let time = this.chatMessage.sendTime.split("T")[1].split(":");
+      if(Number(time[0]) >= 12) {
+        this.day = "오후"
+        this.hour = Number(time[0]) == 12 ? 12 : Number(Math.abs(time[0]-12))
+      } else {
+        this.hour = Number(time[0])
+      }
+      this.minute = Number(time[1])
+    }
+  },
+  mounted() {
+    this.setTime()
+  }
+
+
+}
+</script>
+
+<style scoped>
+.group_message_balloon {
+  position: sticky;
+  bottom: 0;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding: 20px 14px;
+}
+
+ul {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+/* 채팅 지역에 날짜 */
+.group_message_balloon .date_check {
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+li {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+.group_message_balloon .date_check > span {
+  display: inline-block;
+  padding: 0 12px 1px;
+  border-radius: 15px;
+  background-color: rgba(161, 173, 184, .7);
+}
+
+.group_message_balloon .date_check em {
+  display: inline-block;
+  height: 25px;
+  color: #fff;
+  font-size: 12px;
+  line-height: 25px;
+}
+
+em {
+  font-style: normal;
+}
+
+.group_message_balloon .date_check em > strong {
+  font-size: 13px;
+  font-weight: 400;
+  vertical-align: bottom;
+}
+
+/* 채팅 메세지 */
+.group_message_balloon .new_message_balloon_area {
+  position: relative;
+}
+
+li {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+.group_message_balloon .message_balloon.rgt.card_inform, .group_message_balloon .message_balloon.rgt.card_message {
+  border-color: #c5e8fe;
+  background: #d9f0ff;
+}
+
+.group_message_balloon .message_balloon.rgt.type_text {
+  max-width: 80%;
+}
+
+.group_message_balloon .message_balloon.rgt {
+  float: right;
+  max-width: 290px;
+  margin-right: 5px;
+}
+
+.group_message_balloon .message_balloon {
+  position: relative;
+  float: left;
+  max-width: 290px;
+  margin-bottom: 0;
+  margin-left: 40px;
+  border: 1px solid rgba(0, 0, 0, .12);
+  border-radius: 12px;
+  background-color: #fff;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.group_message_balloon .message_balloon > p {
+  padding: 11px 13px;
+  border-radius: 11px;
+  color: #1e1e23;
+  font-size: 14px;
+}
+
+p {
+  padding: 0;
+  margin: 0;
+}
+
+.group_message_balloon .message_balloon.rgt .txt_confirm {
+  right: 100%;
+  left: inherit;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0 10px 0 0;
+  text-align: right;
+}
+
+.group_message_balloon .message_balloon .txt_confirm {
+  position: absolute;
+  bottom: 1px;
+  left: 100%;
+  min-width: 60px;
+  margin-left: 10px;
+  color: #929294;
+  font-size: 11px;
+}
+
+.group_message_balloon .message_balloon.rgt .txt_confirm > span {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+em {
+  font-style: normal;
+}
+
+.group_message_balloon .message_balloon.rgt.card_message:after {
+  background: url(@/assets/img/message_tail_request_re.svg) no-repeat;
+}
+
+.group_message_balloon .message_balloon.rgt.card_message:after {
+  top: 1px;
+  right: -7px;
+  left: inherit;
+  width: 10px;
+}
+
+.group_message_balloon .message_balloon.card_message:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -5px;
+  width: 10px;
+  height: 10.99px;
+  background: url(@/assets/img/message_tail_re.svg) no-repeat;
+}
+
+.group_message_balloon .new_message_balloon_area:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.group_message_balloon .new_message_balloon_area + li {
+  margin-top: 30px;
+}
+
+/* 상대가 보낸 채팅 메세지의 프로필이미지,유저이름 */
+li {
+  padding: 0;
+  margin: 0;
+}
+
+li, ol, ul {
+  list-style: none;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile {
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity .2s ease-in-out;
+  transition: opacity .2s ease-in-out;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile .thumbnail_link {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #fff;
+  text-align: center;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile .thumbnail_link img {
+  position: absolute;
+  top: -50%;
+  right: -50%;
+  bottom: -50%;
+  left: -50%;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 100%;
+  margin: auto;
+}
+
+img {
+  max-width: 100%;
+  border: 0;
+  vertical-align: top;
+}
+
+.group_message_balloon .new_message_balloon_area .thumbnail_profile:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  content: "";
+  border: 1px solid rgba(0, 0, 0, .06);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.group_message_balloon .new_message_balloon_area .chat_message_nickname {
+  margin: 1px 5px 10px 40px;
+}
+
+.group_message_balloon .new_message_balloon_area .chat_message_nickname strong {
+  color: #666f7a;
+  font-size: 12px;
+  font-weight: 600;
+}
+</style>

--- a/frontend/src/components/Chat/ChatMessageComponent.vue
+++ b/frontend/src/components/Chat/ChatMessageComponent.vue
@@ -1,7 +1,7 @@
 <template>
-  <li v-if="showDate" class="date_check">
+  <li v-if="showDate()" class="date_check">
     <span>
-      <em><strong> {{ chatMessageDate }}</strong></em>
+      <em><strong> {{ chatStore.chatMessageList.messageList[idx-1].sendTime.split("T")[0] }}</strong></em>
     </span>
   </li>
   <li class="new_message_balloon_area  _message _msgId2">
@@ -12,18 +12,19 @@
       </button>
     </div>
     <div v-if="recipientId===chatMessage.userId" class="chat_message_nickname _nickname">
-      <strong>{{chatMessage.nickname}}</strong>
+      <strong>{{ chatMessage.nickname }}</strong>
     </div>
-    <div v-if="recipientId===chatMessage.userId" class="message_balloon card_message type_text" role="heading" aria-level="5">
+    <div v-if="recipientId===chatMessage.userId" class="message_balloon card_message type_text" role="heading"
+         aria-level="5">
       <p class="_copy_area">{{ chatMessage.message }}</p>
       <div class="txt_confirm _status">
-        <span class="_time"><em>{{ day }}</em> <span>{{hour}}:{{minute}}</span></span>
+        <span class="_time"><em>{{ day }}</em> <span>{{ hour }}:{{ minute }}</span></span>
       </div>
     </div>
     <div v-else class="message_balloon card_message type_text rgt" role="heading" aria-level="5">
       <p class="_copy_area">{{ chatMessage.message }}</p>
       <div class="txt_confirm _status">
-        <span class="_time"><em>{{ day }}</em> <span>{{hour}}:{{minute}}</span></span>
+        <span class="_time"><em>{{ day }}</em> <span>{{ hour }}:{{ minute }}</span></span>
       </div>
     </div>
   </li>
@@ -50,13 +51,16 @@ export default {
   },
   methods: {
     showDate() {
-      return this.chatMessageDate === this.chatStore.chatMessageList.messageList[this.key].sendTime.split("T")[0]
+      if (this.idx === 0 ){
+        return false;
+      }
+      return this.chatMessageDate !== this.chatStore.chatMessageList.messageList[this.idx-1].sendTime.split("T")[0]
     },
     setTime() {
       let time = this.chatMessage.sendTime.split("T")[1].split(":");
-      if(Number(time[0]) >= 12) {
+      if (Number(time[0]) >= 12) {
         this.day = "오후"
-        this.hour = Number(time[0]) == 12 ? 12 : Number(Math.abs(time[0]-12))
+        this.hour = Number(time[0]) == 12 ? 12 : Number(Math.abs(time[0] - 12))
       } else {
         this.hour = Number(time[0])
       }
@@ -241,7 +245,7 @@ em {
   clear: both;
 }
 
-.group_message_balloon .new_message_balloon_area + li {
+.group_message_balloon .new_message_balloon_area {
   margin-top: 30px;
 }
 

--- a/frontend/src/components/Chat/ChatNavComponent.vue
+++ b/frontend/src/components/Chat/ChatNavComponent.vue
@@ -9,8 +9,7 @@
         <ul class="chat_list">
           <li v-if="isLoading"></li>
           <ChatRoomComponent v-else v-for="(chatRoom, idx) in chatRoomList" :key="idx"
-                             :chatRoom="chatRoom" :selectedChatRoomId="selectedChatRoomId"
-                             @update-select-chatRoom="handleSelectChatRoom"/>
+                             :chatRoom="chatRoom" @reload-chatRoom="reloadChatRoom"/>
         </ul>
       </div>
     </section>
@@ -31,7 +30,6 @@ export default {
   data() {
     return {
       isLoading: true,
-      selectedChatRoomId: 0,
       chatRoomList:[],
     }
   },
@@ -43,11 +41,12 @@ export default {
       await this.chatStore.getChatRoomList();
       this.isLoading=false;
       this.chatRoomList=this.chatStore.chatRoomList;
+      this.$emit("loading")
 
     },
-    handleSelectChatRoom(chatRoomId){
-      this.selectedChatRoomId = chatRoomId;
-    },
+    reloadChatRoom(){
+      this.$emit("reload-chatRoom")
+    }
   },
   mounted() {
     this.getChatRoomList();

--- a/frontend/src/components/Chat/ChatRoomComponent.vue
+++ b/frontend/src/components/Chat/ChatRoomComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <li :class="[ chatRoom.chatRoomId == selectedChatRoomId ? 'on': '' ]" @click="selected">
+  <li :class="[ chatRoom.chatRoomId == chatStore.selectedChatRoomId ? 'on': '' ]" @click="selected">
     <div role="link" tabindex="0" class="div_button chat_list_link" aria-current="page">
       <div class="info_area">
         <div class="profile_wrap" aria-hidden="true">
@@ -17,19 +17,27 @@
 </template>
 
 <script>
+import {mapStores} from "pinia";
+import {useChatStore} from "@/store/useChatStore";
+
 export default {
   name: "ChatRoomComponent",
-  props: ['chatRoom', 'selectedChatRoomId'],
+  computed: {
+    ...mapStores(useChatStore) // 어떤 저장소랑 연결시켜 주겠다.
+  },
+  props: ['chatRoom'],
   data() {
     return {
       isSelected: false,
       lastMessageDay: "",
     }
   },
+
   methods: {
-    selected() {
+    async selected() {
       this.isSelected = true
-      this.$emit("update-select-chatRoom", this.chatRoom.chatRoomId)
+      this.chatStore.selectedChatRoomId = this.chatRoom.chatRoomId
+      this.$emit("reload-chatRoom")
     },
     formatDateTime(dateTimeString) {
       // 입력 문자열을 Date 객체로 변환
@@ -53,6 +61,7 @@ export default {
   },
   mounted() {
     this.lastMessageDay = this.formatDateTime(this.chatRoom.lastMessageDay.toString())
+    this.selectedChatRoomId = this.chatStore.selectedChatRoomId
   }
 }
 </script>

--- a/frontend/src/pages/ChatPgae.vue
+++ b/frontend/src/pages/ChatPgae.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="body">
+    <div class="container">
+      <div id="__next">
+        <div id="warp">
+          <main id="chat-container">
+            <ChatNavComponent @loading="loading" @reload-chatRoom="reloadChatRoom"/>
+            <ChatComponent v-if="isLoading" :key="chatKey"/>
+          </main>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+
+<script>
+import ChatNavComponent from "@/components/Chat/ChatNavComponent.vue";
+import ChatComponent from "@/components/Chat/ChatComponent.vue";
+
+export default {
+  name: "ChatPage",
+  components: {ChatNavComponent, ChatComponent},
+  data() {
+    return {
+      chatKey: 0,
+      isLoading: false,
+    }
+  },
+  methods: {
+    reloadChatRoom(){
+      this.chatKey += 1
+    },
+    loading(){
+      this.isLoading = true;
+    }
+  }
+
+
+}
+</script>
+
+
+<style scoped>
+
+/* id=wrap */
+#wrap {
+  position: relative;
+  z-index: 100;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  overflow-x: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+#__next, #wrap {
+  height: 600px;
+}
+.body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: 100vh;
+  background: #fff;
+}
+.container{
+  border-right: 10px;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.08), 0 10x 10px rgba(0, 0, 0, 0.08);
+  position: relative;
+  overflow: hidden;
+  width: 800px;
+  max-width: 100%;
+  min-height: 700px;
+}
+/* id: container */
+#chat-container, #snb {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+#chat-container {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 100%;
+  max-width: 1068px;
+  min-height: 0;
+  padding: 0 10px;
+  margin: 18px auto 0;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,16 +1,14 @@
-import { createRouter, createWebHistory } from "vue-router";
+import {createRouter, createWebHistory} from "vue-router";
 import QnaListPage from "@/pages/QnaListPage.vue";
-import ChatNavComponent from "@/components/Chat/ChatNavComponent.vue";
 import WikiRegisterPage from "@/pages/wiki/WikiRegisterPage.vue";
-import ChatComponent from "@/components/Chat/ChatComponent.vue";
+import ChatPgae from "@/pages/ChatPgae.vue";
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: "/qna-list", component: QnaListPage },
     { path: "/wiki", component: WikiRegisterPage },
-    { path: "/chat", component: ChatNavComponent },
-    { path: "/chat/message", component: ChatComponent },
+    { path: "/chat", component: ChatPgae },
 
   ]
 });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import QnaListPage from "@/pages/QnaListPage.vue";
 import ChatNavComponent from "@/components/Chat/ChatNavComponent.vue";
 import WikiRegisterPage from "@/pages/wiki/WikiRegisterPage.vue";
+import ChatComponent from "@/components/Chat/ChatComponent.vue";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -9,6 +10,8 @@ const router = createRouter({
     { path: "/qna-list", component: QnaListPage },
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatNavComponent },
+    { path: "/chat/message", component: ChatComponent },
+
   ]
 });
 

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -49,9 +49,18 @@ export const useChatStore = defineStore("chat", {
             const res = await axios.get(backend + "/chat/chatRoomList")
             this.chatRoomList = res.data.result;
         },
-        async getChatMessageList() {
-            // const res = await axios.get("");
-            // 브랜치
+        async getChatMessageList(chatRoomId, page) {
+            const res = await axios.get(backend + "/chat/messageList", {
+                params: {
+                    chatRoomId: chatRoomId,
+                    page: page,
+                    size: 20
+                },
+                withCredentials: true
+            });
+            this.chatMessageList = res.data.result;
+            console.log(this.chatMessageList);
+
         }
     }
 })

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -5,6 +5,7 @@ const backend = "/api";
 
 export const useChatStore = defineStore("chat", {
     state: () => ({
+        selectedChatRoomId: 0,
         chatRoomList: [
             {
                 recipientName: "",
@@ -15,30 +16,15 @@ export const useChatStore = defineStore("chat", {
             },
         ],
         chatMessageList: {
-            prevMessageDate: "1900-01-01",
-            recipientNickname: "길동홍",
-            recipientId: 1,
+            recipientNickname: "",
+            recipientId: 0,
             messageList: [
                 {
-                    nickname: "길동홍",
-                    userId: 1,
-                    message: "채팅 내용",
-                    sendTime: "2024-09-09T10:12:12",
-                    profileImg: "http://img.url"
-                },
-                {
-                    nickname: "길동홍",
-                    userId: 2,
-                    message: "채팅 내용",
-                    sendTime: "2024-09-10T12:13:13",
-                    profileImg: "http://img.url"
-                },
-                {
-                    nickname: "길동홍",
-                    userId: 2,
-                    message: "채팅 내용",
-                    sendTime: "2024-09-11T15:4:14",
-                    profileImg: "http://img.url"
+                    nickname: "",
+                    userId: 0,
+                    message: "",
+                    sendTime: "",
+                    profileImg: ""
                 }
             ]
         },
@@ -46,20 +32,20 @@ export const useChatStore = defineStore("chat", {
     }),
     actions: {
         async getChatRoomList() {
-            const res = await axios.get(backend + "/chat/chatRoomList")
+            const res = await axios.get(backend + "/chat/chatRoomList",{withCredentials: true})
             this.chatRoomList = res.data.result;
+            this.selectedChatRoomId = this.chatRoomList[0].chatRoomId;
         },
-        async getChatMessageList(chatRoomId, page) {
+        async getChatMessageList(page) {
             const res = await axios.get(backend + "/chat/messageList", {
                 params: {
-                    chatRoomId: chatRoomId,
+                    chatRoomId: this.selectedChatRoomId,
                     page: page,
                     size: 20
                 },
                 withCredentials: true
             });
             this.chatMessageList = res.data.result;
-            console.log(this.chatMessageList);
 
         }
     }

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -13,12 +13,45 @@ export const useChatStore = defineStore("chat", {
                 lastMessage: "",
                 lastMessageDay: ""
             },
-        ]
+        ],
+        chatMessageList: {
+            prevMessageDate: "1900-01-01",
+            recipientNickname: "길동홍",
+            recipientId: 1,
+            messageList: [
+                {
+                    nickname: "길동홍",
+                    userId: 1,
+                    message: "채팅 내용",
+                    sendTime: "2024-09-09T10:12:12",
+                    profileImg: "http://img.url"
+                },
+                {
+                    nickname: "길동홍",
+                    userId: 2,
+                    message: "채팅 내용",
+                    sendTime: "2024-09-10T12:13:13",
+                    profileImg: "http://img.url"
+                },
+                {
+                    nickname: "길동홍",
+                    userId: 2,
+                    message: "채팅 내용",
+                    sendTime: "2024-09-11T15:4:14",
+                    profileImg: "http://img.url"
+                }
+            ]
+        },
+
     }),
     actions: {
         async getChatRoomList() {
             const res = await axios.get(backend + "/chat/chatRoomList")
             this.chatRoomList = res.data.result;
         },
+        async getChatMessageList() {
+            // const res = await axios.get("");
+            // 브랜치
+        }
     }
-});
+})


### PR DESCRIPTION
## 연관 이슈
close #96, #82 

## 작업 내용
- 채팅방 컴포넌트 생성
  - ul 태그의 column 순서를 reverse로 설정하여 무한 스크롤로 새로운 페이지 불러오면 맨 위에 메세지가 생성됨

- 채팅 메세지 컴포넌트 생성
  - 응답으로 들어온 userId와 recipientId가 같으면 상대방이므로 프로필 이미지, 상대방 닉네임, 메세지, 보낸 시간이 뜬다.
  - 만약 이전 메세지의 보낸 날짜와 현재 메세지의 보낸 날짜가 다르면 날짜를 표시해준다.
  - 만약 맨 마지막 메세지일 경우에도 날짜를 표시해준다.

- 백엔드 API 연결
  - 요청으로 chatRoomId, page, size를 보낸다. 

- 채팅 페이지로 종합

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b3a080af-44e4-4164-b0b7-5f46a9c5aee4)
![image](https://github.com/user-attachments/assets/ff70343f-388c-45af-8865-665ce06fcc9a)



## 리뷰 요구사항 (선택)