### PR TITLE
[Fix] 위키 등록 기능 CustomUserDetails를 활용한 유저 데이터 연결 (#23)

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -29,6 +29,7 @@ public enum BaseResponseStatus {
     WIKI_TITLE_REGIST_FAIL(false, 5002,"제목을 입력해주세요."),
     WIKI_CATEGORY_REGIST_FAIL(false, 5002,"카테고리를 입력해주세요."),
     WIKI_CONTENT_REGIST_FAIL(false, 5003,"내용을 입력해주세요."),
+    WIKI_CONTENT_DUPLICATION_FAIL(false, 5004,"중복되는 위키입니다."),
     // 에러 아카이브 기능 - 6000
 
     // 에러 QnA 기능 - 7000

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -47,7 +47,6 @@ public class WikiController {
             thumbnailUrl = cloudFileUploadService.uploadImg(thumbnail);
         }
 
-        WikiRegisterRes wikiRegisterRes = wikiService.register(wikiRegisterReq, thumbnailUrl, customUserDetails);
-        return new BaseResponse<>(wikiRegisterRes);
+        return new BaseResponse<>(wikiService.register(wikiRegisterReq, thumbnailUrl, customUserDetails));
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.File.Service.CloudFileUploadService;
+import org.example.backend.Security.CustomUserDetails;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
 import org.example.backend.Wiki.Service.WikiService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,9 +26,9 @@ public class WikiController {
     // 위키 등록
     @PostMapping
     public BaseResponse<WikiRegisterRes> register(
-            //  ToDo : customUserDetails
             @RequestPart WikiRegisterReq wikiRegisterReq,
-            @RequestPart(required = false) MultipartFile thumbnail
+            @RequestPart(required = false) MultipartFile thumbnail,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         if (wikiRegisterReq.getTitle().isEmpty()) {
             throw new InvalidWikiException(WIKI_TITLE_REGIST_FAIL);
@@ -45,7 +47,7 @@ public class WikiController {
             thumbnailUrl = cloudFileUploadService.uploadImg(thumbnail);
         }
 
-        WikiRegisterRes wikiRegisterRes = wikiService.register(wikiRegisterReq, thumbnailUrl);
+        WikiRegisterRes wikiRegisterRes = wikiService.register(wikiRegisterReq, thumbnailUrl, customUserDetails);
         return new BaseResponse<>(wikiRegisterRes);
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.Category.Repository.CategoryRepository;
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidCategoryException;
+import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.Security.CustomUserDetails;
 import org.example.backend.User.Model.Entity.User;
@@ -38,7 +39,7 @@ public class WikiService {
         // 유저 정보 확인 로직
         Optional<User> user = userRepository.findById(customUserDetails.getUserId());
         if (user.isEmpty()) {
-            throw new InvalidWikiException(BaseResponseStatus.UNREGISTERED_USER);
+            throw new InvalidUserException(BaseResponseStatus.UNREGISTERED_USER);
         }
         // Wiki 등록
         Wiki registerWiki = Wiki.builder()

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -2,8 +2,12 @@ package org.example.backend.Wiki.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Category.Repository.CategoryRepository;
+import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidCategoryException;
 import org.example.backend.Exception.custom.InvalidWikiException;
+import org.example.backend.Security.CustomUserDetails;
+import org.example.backend.User.Model.Entity.User;
+import org.example.backend.User.Repository.UserRepository;
 import org.example.backend.Wiki.Model.Entity.LatestWiki;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
@@ -14,7 +18,7 @@ import org.example.backend.Wiki.Repository.WikiContentRepository;
 import org.example.backend.Wiki.Repository.WikiRepository;
 import org.springframework.stereotype.Service;
 
-import static org.example.backend.Common.BaseResponseStatus.*;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,15 +27,22 @@ public class WikiService {
     private final CategoryRepository categoryRepository;
     private final WikiContentRepository wikiContentRepository;
     private final LatestWikiRepository latestWikiRepository;
+    private final UserRepository userRepository;
 
-    // 위키 등록 ToDo : 매개변수 customUserDetails 유저정보 추가
-    public WikiRegisterRes register(WikiRegisterReq wikiRegisterReq, String thumbnail) {
+    public WikiRegisterRes register(WikiRegisterReq wikiRegisterReq, String thumbnail, CustomUserDetails customUserDetails
+                                     ) {
+        // 위키 등록시 중복 확인 로직
         if (wikiRepository.findByTitle(wikiRegisterReq.getTitle()).isPresent()) {
-            throw new InvalidWikiException(WIKI_REGIST_FAIL);
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_CONTENT_DUPLICATION_FAIL);
+        }
+        // 유저 정보 확인 로직
+        Optional<User> user = userRepository.findById(customUserDetails.getUserId());
+        if (user.isEmpty()) {
+            throw new InvalidWikiException(BaseResponseStatus.UNREGISTERED_USER);
         }
         // Wiki 등록
         Wiki registerWiki = Wiki.builder()
-                .category(categoryRepository.findById(wikiRegisterReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(NOT_FOUND_CATEGORY)))
+                .category(categoryRepository.findById(wikiRegisterReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(BaseResponseStatus.NOT_FOUND_CATEGORY)))
                 .title(wikiRegisterReq.getTitle())
                 .build();
         wikiRepository.save(registerWiki);
@@ -39,7 +50,7 @@ public class WikiService {
         // Wiki Content 등록
         WikiContent registerContent = WikiContent.builder()
                 .wiki(registerWiki)
-                //.user() ToDo : 위키 등록 작성자 정보
+                .user(user.get())
                 .content(wikiRegisterReq.getContent())
                 .version(1) //최초 버전
                 .thumbnail(thumbnail)


### PR DESCRIPTION
## 연관 이슈
close #23


## 작업 내용
- 위키 등록시 CustomUserDetails를 활용하여 유저ID 조회 후 등록 가능하게 수정
- 위키 등록시 작성자 ID wiki content에 저장


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9e6dc225-2034-4d39-98ba-462e73631675)
![image](https://github.com/user-attachments/assets/76f97473-2ea8-4558-a511-412a7b3fdfa8)


## 리뷰 요구사항 혹은 기타 (선택)
