### PR TITLE
[Feat] 깃허브 로그인, 회원가입 추가 (#2, #5)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'com.google.code.gson:gson'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -18,6 +18,8 @@ public enum BaseResponseStatus {
     USER_EMAIL_NOT_VERIFIED(false, 2007, "이메일 인증이 완료되지 않았습니다."),
     USER_INVALID_CREDENTIALS(false, 2008, "잘못된 자격 증명입니다."),
     USER_NOT_LOGIN(false, 2011, "로그인 하지 않은 사용자입니다."),
+    USER_EMAIL_NOT_FOUND_IN_GITHUB(false, 2021, "GitHub 이메일 정보를 가져올 수 없습니다."),
+    USER_INVALID_TYPE(false,2022,"소셜로 가입한 유저가 아닙니다."),
 
     // 마이페이지 기능 - 3000
 

--- a/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.example.backend.Config;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Config.Filter.JwtFilter;
 import org.example.backend.Config.Filter.LoginFilter;
+import org.example.backend.Security.OAuth2LoginSuccessHandler;
 import org.example.backend.Util.JwtUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,13 +18,13 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
@@ -32,13 +33,22 @@ public class SecurityConfig {
         http.formLogin((formLogin) ->
                 formLogin
                         .loginPage("/login")
-                        .usernameParameter("email")  // 기본 username을 email로 변경
+                        .usernameParameter("email") // 기본 username을 email로 변경
                         .passwordParameter("password")
                         .permitAll()
         );
+
+        // GitHub 로그인 추가
+        http.oauth2Login(oauth2 ->
+                oauth2
+                        .loginPage("/login")
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .permitAll()
+        );
+
         http.authorizeHttpRequests((auth) ->
                 auth
-                        .requestMatchers( "/**").permitAll()
+                        .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()
         );
         http.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.example.backend.Config;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Config.Filter.JwtFilter;
 import org.example.backend.Config.Filter.LoginFilter;
+import org.example.backend.Exception.CustomAuthenticationFailureHandler;
 import org.example.backend.Security.OAuth2LoginSuccessHandler;
 import org.example.backend.Util.JwtUtil;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +44,7 @@ public class SecurityConfig {
                 oauth2
                         .loginPage("/login")
                         .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(new CustomAuthenticationFailureHandler())
                         .permitAll()
         );
 

--- a/backend/src/main/java/org/example/backend/Exception/CustomAuthenticationFailureHandler.java
+++ b/backend/src/main/java/org/example/backend/Exception/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,39 @@
+package org.example.backend.Exception;
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    private final Gson gson = new Gson();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        BaseResponse baseResponse = new BaseResponse<>(BaseResponseStatus.FAIL);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        if (exception instanceof OAuth2AuthenticationException) {
+            OAuth2Error error = ((OAuth2AuthenticationException) exception).getError();
+            String errorCode = error.getErrorCode();
+
+            if ("No Email in GitHub".equals(errorCode)) {
+                baseResponse = new BaseResponse<>(BaseResponseStatus.USER_EMAIL_NOT_FOUND_IN_GITHUB);
+            } else if ("Type Error".equals(errorCode)) {
+                baseResponse = new BaseResponse<>(BaseResponseStatus.USER_INVALID_TYPE);
+            }
+        }
+
+        String jsonResponse = gson.toJson(baseResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/backend/src/main/java/org/example/backend/Security/CustomOAuth2User.java
+++ b/backend/src/main/java/org/example/backend/Security/CustomOAuth2User.java
@@ -1,0 +1,36 @@
+package org.example.backend.Security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuth2User oAuth2User;
+    @Getter
+    private final Long userId;
+    private final String email;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2User.getAttributes();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> "ROLE_USER");
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/Security/CustomOAuth2UserService.java
+++ b/backend/src/main/java/org/example/backend/Security/CustomOAuth2UserService.java
@@ -43,7 +43,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (email == null) {
             email = fetchEmailFromGitHub(userRequest.getAccessToken().getTokenValue());
             if (email == null) {
-                throw new OAuth2AuthenticationException("GitHub 이메일 정보를 가져올 수 없습니다.");
+                throw new OAuth2AuthenticationException("No Email in GitHub");
             }
         }
         Optional<User> existingUser = userRepository.findByEmail(email);
@@ -52,6 +52,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         if (existingUser.isPresent()) {
             User user = existingUser.get();
+            if (user.getType().equals("InApp")) {
+                throw new OAuth2AuthenticationException("Type Error");
+            }
             userId = user.getId();
         } else { // 회원가입 안 된 유저
             String nickname = (String) attributes.get("login");

--- a/backend/src/main/java/org/example/backend/Security/CustomOAuth2UserService.java
+++ b/backend/src/main/java/org/example/backend/Security/CustomOAuth2UserService.java
@@ -1,0 +1,110 @@
+package org.example.backend.Security;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.User.Model.Entity.User;
+import org.example.backend.User.Repository.UserRepository;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+//        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+//        String userNameAttributeName = userRequest.getClientRegistration()
+//                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+//        추후 다른 소셜 로그인 추가할 때 사용
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String email = (String) attributes.get("email");
+
+        if (email == null) {
+            email = fetchEmailFromGitHub(userRequest.getAccessToken().getTokenValue());
+            if (email == null) {
+                throw new OAuth2AuthenticationException("GitHub 이메일 정보를 가져올 수 없습니다.");
+            }
+        }
+        Optional<User> existingUser = userRepository.findByEmail(email);
+
+        Long userId;
+
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+            userId = user.getId();
+        } else { // 회원가입 안 된 유저
+            String nickname = (String) attributes.get("login");
+            String profileImg = (String) attributes.get("avatar_url");
+            User user = User.builder()
+                    .email(email)
+                    .nickname(setNickname(nickname))
+                    .profileImg(profileImg)
+                    .type("Github")
+                    .verify(true)
+                    .createdAt(LocalDateTime.now())
+                    .modifiedAt(LocalDateTime.now())
+                    .build();
+            User resultUser = userRepository.save(user);
+            userId = resultUser.getId();
+        }
+
+        return new CustomOAuth2User(oAuth2User, userId, email);
+    }
+
+    private String fetchEmailFromGitHub(String accessToken) {
+        String uri = "https://api.github.com/user/emails";
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // GitHub /user/emails API 호출
+        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+                uri,
+                HttpMethod.GET,
+                entity,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        return Optional.ofNullable(response.getBody())
+                .map(responseBody -> responseBody.stream())
+                .orElseGet(() -> Stream.empty())
+                .filter(emailInfo -> (Boolean) emailInfo.get("primary") && (Boolean) emailInfo.get("verified"))
+                .map(emailInfo -> (String) emailInfo.get("email"))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String setNickname(String nickname) {
+        String newNickname = nickname;
+        Random random = new Random();
+
+        while (userRepository.findByNickname(newNickname).isPresent()) {
+            int randomNumber = random.nextInt(1000);
+            newNickname = nickname + randomNumber;
+        }
+
+        return newNickname;
+    }
+}

--- a/backend/src/main/java/org/example/backend/Security/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/org/example/backend/Security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,33 @@
+package org.example.backend.Security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.backend.Util.JwtUtil;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    public OAuth2LoginSuccessHandler(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        String jwtToken = jwtUtil.createToken(oAuth2User.getUserId(), oAuth2User.getName(), "ROLE_USER");
+        Cookie jwtCookie = jwtUtil.createCookie(jwtToken);
+        response.addCookie(jwtCookie);
+
+        String redirectUrl = "http://localhost:8081/";
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/backend/src/main/java/org/example/backend/Security/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/org/example/backend/Security/OAuth2LoginSuccessHandler.java
@@ -27,7 +27,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         Cookie jwtCookie = jwtUtil.createCookie(jwtToken);
         response.addCookie(jwtCookie);
 
-        String redirectUrl = "http://localhost:8081/";
+        String redirectUrl = "http://localhost:8081/oauth?userId=" + oAuth2User.getUserId();
         response.sendRedirect(redirectUrl);
     }
 }

--- a/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
@@ -1,10 +1,7 @@
 package org.example.backend.User.Model.Entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.example.backend.Answer.Model.Entity.Answer;
 import org.example.backend.Answer.Model.Entity.AnswerComment;
 import org.example.backend.Answer.Model.Entity.AnswerLike;
@@ -35,25 +32,29 @@ public class User {
     private String email;
     private String password;
     @Column(nullable = false, length = 50)
-    private String name;
-    @Column(nullable = false, length = 50)
     private String nickname;
+    @Builder.Default
     @Column(nullable = false)
-    private String profileImg;
+    private String profileImg = "https://dayun2024-s3.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/11/0d7ca962-ccee-4fbb-9b5d-f5deec5808c6";
+    @Builder.Default
     @Column(nullable = false, length = 50)
-    private String grade;
+    private String grade = "뉴비";
+    @Builder.Default
     @Column(nullable = false)
-    private Integer point;
+    private Integer point = 10;
+    @Builder.Default
     @Column(nullable = false)
-    private Boolean verify;
+    private Boolean verify = false;
     @Column(nullable = false)
     private LocalDateTime createdAt;
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
+    @Builder.Default
     @Column(nullable = false)
-    private Boolean enable;
+    private Boolean enable = true;
+    @Builder.Default
     @Column(nullable = false, length = 20)
-    private String type;
+    private String type = "InApp";
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<PointDetail> pointDetails;
@@ -72,18 +73,25 @@ public class User {
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<Answer> answerList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<AnswerLike> answerLikeList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<AnswerComment> answerCommentList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<WikiContent> wikiContentList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<WikiScrap> wikiScrapList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<ErrorArchive> errorArchiveList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<ErrorLike> errorLikeList;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<ErrorScrap> ErrorScrapList;
 }

--- a/backend/src/main/java/org/example/backend/User/Repository/UserRepository.java
+++ b/backend/src/main/java/org/example/backend/User/Repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String username);
+    Optional<User> findByNickname(String nickname);
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
 
-
   jpa:
     database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
@@ -21,6 +20,23 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_SECRET}
+            scope: read:user, user:email
+            redirect-uri: http://localhost:8080/login/oauth2/code/{registrationId}
+            client-name: Enadu
+        provider:
+          github:
+            authorization-uri: https://github.com/login/oauth/authorize
+            token-uri: https://github.com/login/oauth/access_token
+            user-info-uri: https://api.github.com/user
+            user-name-attribute: id
 
 logging:
   level:


### PR DESCRIPTION
## 연관 이슈
close #2 
close #5 


## 작업 내용
- /oauth2/authorization/github에서 깃허브 계정으로 로그인 후 로직 처리
- 이메일 가져와서 db에서 검사 후 없으면 회원가입 후 로그인 처리, 있으면 바로 로그인 처리
- 일반 로그인과 동일하게 JWT 토큰 쿠키에 추가


## 스크린샷 (선택)
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/0823b093-a9a1-4bf1-a6cc-162b2005770a">


## 리뷰 요구사항 혹은 기타 (선택)
본인 깃허브 계정으로 잘 되는지 :8080/oauth2/authorization/github 로 접속해서 확인해주세용