### PR TITLE
[Feat] 위키 목록 조회 API 구현 (#26)

### DIFF
--- a/backend/src/main/java/org/example/backend/BackendApplication.java
+++ b/backend/src/main/java/org/example/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package org.example.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -2,10 +2,11 @@ package org.example.backend.Wiki.Controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
-import org.example.backend.Wiki.Model.Req.WikiListReq;
+import org.example.backend.Wiki.Model.Req.GetWikiListReq;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
@@ -18,7 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static org.example.backend.Common.BaseResponseStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,13 +35,13 @@ public class WikiController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         if (wikiRegisterReq.getTitle().isEmpty()) {
-            throw new InvalidWikiException(WIKI_TITLE_REGIST_FAIL);
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_TITLE_REGIST_FAIL);
         }
         if (wikiRegisterReq.getCategoryId() == null) {
-            throw new InvalidWikiException(WIKI_CATEGORY_REGIST_FAIL);
+            throw new InvalidWikiException(BaseResponseStatus.CATEGORY_NOT_FOUND_CATEGORY);
         }
         if (wikiRegisterReq.getContent().isEmpty()) {
-            throw new InvalidWikiException(WIKI_CONTENT_REGIST_FAIL);
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_CONTENT_REGIST_FAIL);
         }
         // 썸네일 등록 확인 로직
         String thumbnailUrl;
@@ -56,15 +56,15 @@ public class WikiController {
 
     // 위키 목록 조회
     @GetMapping("/list")
-    public BaseResponse<List<WikiListRes>> list(WikiListReq wikiListReq) {
-        if (wikiListReq.getPage() == null) {
-            wikiListReq.setPage(0);
+    public BaseResponse<List<WikiListRes>> list(GetWikiListReq getWikiListReq) {
+        if (getWikiListReq.getPage() == null) {
+            getWikiListReq.setPage(0);
         }
-        if (wikiListReq.getSize() == null || wikiListReq.getSize() == 0) {
-            wikiListReq.setSize(20);
+        if (getWikiListReq.getSize() == null || getWikiListReq.getSize() == 0) {
+            getWikiListReq.setSize(20);
 
         }
-        List<WikiListRes> wikiList = wikiService.wikiList(wikiListReq);
+        List<WikiListRes> wikiList = wikiService.wikiList(getWikiListReq);
         return new BaseResponse<>(wikiList);
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -5,7 +5,9 @@ import org.example.backend.Common.BaseResponse;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
+import org.example.backend.Wiki.Model.Req.WikiListReq;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
+import org.example.backend.Wiki.Model.Res.WikiListRes;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
 import org.example.backend.Wiki.Service.WikiService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 import static org.example.backend.Common.BaseResponseStatus.*;
 
@@ -33,7 +37,7 @@ public class WikiController {
         if (wikiRegisterReq.getTitle().isEmpty()) {
             throw new InvalidWikiException(WIKI_TITLE_REGIST_FAIL);
         }
-        if (wikiRegisterReq.getCategoryId() == null){
+        if (wikiRegisterReq.getCategoryId() == null) {
             throw new InvalidWikiException(WIKI_CATEGORY_REGIST_FAIL);
         }
         if (wikiRegisterReq.getContent().isEmpty()) {
@@ -41,12 +45,26 @@ public class WikiController {
         }
         // 썸네일 등록 확인 로직
         String thumbnailUrl;
-        if(thumbnail == null || thumbnail.isEmpty()){
+        if (thumbnail == null || thumbnail.isEmpty()) {
             thumbnailUrl = cloudFileUploadService.getBasicThumbnailUrl();
         } else {
             thumbnailUrl = cloudFileUploadService.uploadImg(thumbnail);
         }
 
         return new BaseResponse<>(wikiService.register(wikiRegisterReq, thumbnailUrl, customUserDetails));
+    }
+
+    // 위키 목록 조회
+    @GetMapping("/list")
+    public BaseResponse<List<WikiListRes>> list(WikiListReq wikiListReq) {
+        if (wikiListReq.getPage() == null) {
+            wikiListReq.setPage(0);
+        }
+        if (wikiListReq.getSize() == null || wikiListReq.getSize() == 0) {
+            wikiListReq.setSize(20);
+
+        }
+        List<WikiListRes> wikiList = wikiService.wikiList(wikiListReq);
+        return new BaseResponse<>(wikiList);
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -21,8 +22,8 @@ public class LatestWiki {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @Builder.Default
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     @Column(nullable = false)
     private Integer version;

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiListReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiListReq.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Setter
 @Getter
-public class WikiListReq {
+public class GetWikiListReq {
 
     private Integer page;
     private Integer size;

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiListReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiListReq.java
@@ -1,0 +1,12 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class WikiListReq {
+
+    private Integer page;
+    private Integer size;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiRegisterReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiRegisterReq.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.antlr.v4.runtime.misc.NotNull;
 
-@Builder
 @Getter
 @Setter
 public class WikiRegisterReq {

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiListRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiListRes.java
@@ -1,0 +1,17 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class WikiListRes {
+    private Long id;
+    private String title;
+    private String content;
+    private String category;
+    private String thumbnail;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -12,7 +12,7 @@ import org.example.backend.User.Repository.UserRepository;
 import org.example.backend.Wiki.Model.Entity.LatestWiki;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
-import org.example.backend.Wiki.Model.Req.WikiListReq;
+import org.example.backend.Wiki.Model.Req.GetWikiListReq;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
@@ -22,7 +22,6 @@ import org.example.backend.Wiki.Repository.WikiRepository;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -79,8 +78,8 @@ public class WikiService {
     }
 
     // 위키 목록 조회
-    public List<WikiListRes> wikiList(WikiListReq wikiListReq) {
-        Pageable pageable = PageRequest.of(wikiListReq.getPage(), 20, Sort.by(Sort.Direction.DESC, "latestWiki.createdAt"));
+    public List<WikiListRes> wikiList(GetWikiListReq getWikiListReq) {
+        Pageable pageable = PageRequest.of(getWikiListReq.getPage(), getWikiListReq.getSize(), Sort.by(Sort.Direction.DESC, "latestWiki.createdAt"));
         Page<Wiki> wikiPage = wikiRepository.findAll(pageable);
 
         return wikiPage.getContent().stream().map


### PR DESCRIPTION
## 연관 이슈
close #26 


## 작업 내용
📌 위키 목록 전체 조회 기능
- 생성일 기준으로 최신순 정렬 처리
- 제목, 내용, 썸네일, 카테고리 출력
- 페이징 처리 (eq에 page, size 입력 안해도 size 20으로 고정 처리)

## 스크린샷 (선택)

## 리뷰 요구사항 혹은 기타 (선택)
예외처리는 필요없는 것 같아서 안했는데, 확인해보고 리뷰 부탁드려용