### PR TITLE
[Feat] 깃허브 로그인 추가(#66)

### DIFF
--- a/frontend/src/components/user/SignInComponent.vue
+++ b/frontend/src/components/user/SignInComponent.vue
@@ -6,7 +6,8 @@
       <input type="password" placeholder="비밀번호" v-model="user.password" />
       <button type="button" @click="submit">로그인</button>
       <img class="github"
-        src="https://user-images.githubusercontent.com/9599/61177475-2ddce800-a58b-11e9-9bf6-aa4794a99f2a.png">
+        src="https://user-images.githubusercontent.com/9599/61177475-2ddce800-a58b-11e9-9bf6-aa4794a99f2a.png"
+        @click="githubLogin">
     </form>
   </div>
 </template>
@@ -39,6 +40,9 @@
           return;
         }
         this.$emit('login', this.user);
+      },
+      githubLogin() {
+        window.location.href = "http://localhost:8080/oauth2/authorization/github"
       }
     }
   };

--- a/frontend/src/pages/OAuthLoginPage.vue
+++ b/frontend/src/pages/OAuthLoginPage.vue
@@ -1,0 +1,40 @@
+<template>
+    <div>
+    </div>
+</template>
+
+<script>
+import { useUserStore } from '@/store/useUserStore';
+import { useRouter, useRoute } from 'vue-router';
+
+export default {
+    name: 'OAuthLoginPage',
+    data() {
+        return {
+            userId: null 
+        };
+    },
+    created() {
+        this.loginSuccess();
+    },
+    methods: {
+        loginSuccess() {
+            const userStore = useUserStore();
+            const router = useRouter();
+            const route = useRoute();
+
+            this.userId = route.query.userId;
+
+            if (this.userId) {
+                userStore.setUserLoggedIn(this.userId);
+                router.push('/');
+            } else {
+                console.error('userId가 쿼리 파라미터에 없습니다.');
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,6 +4,7 @@ import QnaListPage from "@/pages/QnaListPage.vue";
 import WikiRegisterPage from "@/pages/wiki/WikiRegisterPage.vue";
 import ChatPgae from "@/pages/ChatPgae.vue";
 import QnaRegisterComponent from "@/components/qna/QnaRegisterComponent.vue";
+import OAuthLoginPage from "@/pages/OAuthLoginPage.vue";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -13,6 +14,7 @@ const router = createRouter({
     { path: "/qna/register", component: QnaRegisterComponent },
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPgae },
+    { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } }
   ]
 });
 

--- a/frontend/src/store/useUserStore.js
+++ b/frontend/src/store/useUserStore.js
@@ -55,6 +55,10 @@ export const useUserStore = defineStore('user', {
             } catch (error) {
                 return false;
             }
-        }
+        },
+        setUserLoggedIn(userId) {
+            this.isLoggedIn = true;
+            this.userId = userId;
+        },
     }
 });


### PR DESCRIPTION
## 연관 이슈
close #66


## 작업 내용
- 깃허브 버튼 누르면 백엔드에 /oauth2/authorization/github로 리다이렉트
- /oauth로 오면 userStore에 로그인 정보 저장


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
프론트 테스트 한번만 해주세용