### PR TITLE
[Fix] Qna 전체 서비스 로직 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.example.backend.Common.BaseResponseStatus.NOT_FOUND_CATEGORY;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +33,7 @@ public class ErrorArchiveService {
                 .content(registerErrorArchiveReq.getContent())
                 .user(userRepository.findById(customUserDetails.getUserId())
                         .orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND)))
-                .category(categoryRepository.findById(registerErrorArchiveReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(NOT_FOUND_CATEGORY)))
+                .category(categoryRepository.findById(registerErrorArchiveReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(BaseResponseStatus.CATEGORY_NOT_FOUND_CATEGORY)))
                 .build();
 
         errorArchive.createdAt();

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -37,7 +37,7 @@ public class QuestionController {
 
     //qna 상세 조회
     @GetMapping("/detail")
-    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Long qnaBoardId) {
+    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId) {
         GetQuestionDetailRes questionDetailRes = qnaService.getQuestionDetail(qnaBoardId);
         return new BaseResponse<>(questionDetailRes);
 

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -23,13 +23,13 @@ public class QuestionController {
     //qna 등록
     @PostMapping()
     public BaseResponse<Long> saveQuestion(@RequestBody CreateQuestionReq createQuestionReq, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        Long id = qnaService.saveQuestion(createQuestionReq, customUserDetails);
+        Long id = qnaService.saveQuestion(createQuestionReq, customUserDetails.getUserId());
         return new BaseResponse<>(id);
     }
 
     //qna 목록 조회
-    @GetMapping("list")
-    public BaseResponse<List<GetQnaListRes>> getQnaList(@RequestBody GetQnaListReq getQnaListReq, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    @GetMapping("/list")
+    public BaseResponse<List<GetQnaListRes>> getQnaList(GetQnaListReq getQnaListReq) {
         List<GetQnaListRes> qnaListRes = qnaService.getQnaList(getQnaListReq);
         return new BaseResponse<>(qnaListRes);
 

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -39,9 +39,9 @@ public class QnaService {
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
 
-    public Long saveQuestion(CreateQuestionReq createQuestionReq, CustomUserDetails customUserDetails) {
+    public Long saveQuestion(CreateQuestionReq createQuestionReq, Long userId) {
         Optional<Category> category = categoryRepository.findById(createQuestionReq.getCategoryId());
-        Optional<User> user = userRepository.findById(customUserDetails.getUserId());
+        Optional<User> user = userRepository.findById(userId);
 
         if (category.isPresent() && user.isPresent()) {
             QnaBoard qnaBoard = QnaBoard.builder()
@@ -78,7 +78,8 @@ public class QnaService {
                         (qnaBoard -> GetQnaListRes.builder()
                                 .id(qnaBoard.getId())
                                 .title(qnaBoard.getTitle())
-                                .superCategoryName(qnaBoard.getCategory().getSuperCategory().getCategoryName())
+                                .superCategoryName(qnaBoard.getCategory().getSuperCategory() != null ?
+                                        qnaBoard.getCategory().getSuperCategory().getCategoryName() : null)
                                 .subCategoryName(qnaBoard.getCategory() != null ?
                                         qnaBoard.getCategory().getCategoryName() : null)
                                 .subCategoryName(qnaBoard.getCategory().getCategoryName())

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -67,7 +67,7 @@ public class QnaService {
         if (getQnaListReq.getSort().equals("latest")) {
             pageable = PageRequest.of(getQnaListReq.getPage(), getQnaListReq.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
         } else if (getQnaListReq.getSort().equals("like")) {
-            pageable = PageRequest.of(getQnaListReq.getPage(), getQnaListReq.getSize(), Sort.by(Sort.Direction.DESC, "likeCnt"));
+            pageable = PageRequest.of(getQnaListReq.getPage(), getQnaListReq.getSize(), Sort.by(Sort.Direction.DESC, "likeCount"));
         } else {
             throw new InvalidQnaException(BaseResponseStatus.QNA_INVALID_SEARCH_TYPE);
         }

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -93,15 +93,17 @@ public class QnaService {
                 .collect(Collectors.toList());
     }
 
-    public GetQuestionDetailRes getQuestionDetail(Long qnaBoardId) {
-        Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId);
+    public GetQuestionDetailRes getQuestionDetail(Integer qnaBoardId) {
+        Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId.longValue());
         GetQuestionDetailRes questionDetail;
         if (qnaBoard.isPresent()) {
             questionDetail = GetQuestionDetailRes.builder()
                     .title(qnaBoard.get().getTitle())
                     .content(qnaBoard.get().getContent())
-                    .superCategory(qnaBoard.get().getCategory().getSuperCategory().getCategoryName())
-                    .subCategory(qnaBoard.get().getCategory().getCategoryName())
+                    .superCategoryName(qnaBoard.get().getCategory().getSuperCategory() != null ?
+                            qnaBoard.get().getCategory().getSuperCategory().getCategoryName() : null)
+                    .subCategoryName(qnaBoard.get().getCategory() != null ?
+                            qnaBoard.get().getCategory().getCategoryName() : null)
                     .likeCnt(qnaBoard.get().getLikeCount())
                     .hateCnt(qnaBoard.get().getHateCount())
                     .checkLike(isQuestionLikeORHate(qnaBoard.get().getQnaLikeList()))

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/Res/GetQuestionDetailRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/Res/GetQuestionDetailRes.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class GetQuestionDetailRes {
     private String title;
     private String content;
-    private String superCategory;
-    private String subCategory;
+    private String superCategoryName;
+    private String subCategoryName;
     private Integer likeCnt;
     private Integer hateCnt;
     private boolean checkLike;


### PR DESCRIPTION
## 연관 이슈
close  #103 , #100, #101 


## 작업 내용
- customUserDetails를 컨트롤러에서 id 데이터로 처리하여 서비스로 전달하도록 로직 수정
- 상위 카테고리 데이터 조회 시 null에 대한 예외 처리
- qnaDetail 데이터 받는 형식 수정  

## 스크린샷 (선택)



## 리뷰 요구사항 혹은 기타 (선택)
