### PR TITLE
[Fix] qna 상세 조회 (질문/답변/댓글) 전체 조회 구현 

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,20 +1,28 @@
 <!DOCTYPE html>
 <html lang="">
-  <head>
+<head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link
+            rel="stylesheet"
+            href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css"
+    />
     <title><%= htmlWebpackPlugin.options.title %></title>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.13/vue.min.js"></script>
+    <script src="https://unpkg.com/semantic-ui-vue/dist/commonjs/semantic-ui-vue.js"></script>
+
     <script src="https://cdn.tailwindcss.com"></script>
-  </head>
-  <body>
-    <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
-    </noscript>
-    <div id="app"></div>
-    <!-- built files will be auto injected -->
-  </body>
+</head>
+<body>
+<noscript>
+    <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled.
+        Please enable it to continue.</strong>
+</noscript>
+<div id="app"></div>
+<!-- built files will be auto injected -->
+</body>
 </html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@
 <script>
   import HeaderComponent from "./components/header/HeaderComponent.vue";
 
+
   export default {
 
     name: "App",

--- a/frontend/src/components/Common/PaginationComponent.vue
+++ b/frontend/src/components/Common/PaginationComponent.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="ui pagination menu">
+    <a
+        v-for="number in pageNumbers"
+        :key="number"
+        :class="{'active item': currentPage === number, 'item': currentPage !== number}"
+        @click="setActivePage(number)"
+    >
+      {{ number }}
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PaginationComponent",
+  data() {
+    return {
+      currentPage: 1,
+      pageNumbers: [1, 2, 3, 4, 5],
+    };
+  },
+  methods: {
+    setActivePage(number) {
+      this.currentPage = number
+      this.$emit('updatePage',this.currentPage);
+    },
+  },
+};
+</script>
+
+<style>
+.ui.pagination.menu .active.item {
+  border-top: none;
+  border-top-width: initial;
+  border-top-style: none;
+  border-top-color: initial;
+  padding-top: .92857143em;
+  background-color: #e1e8e8;
+  color: rgba(0, 0, 0, .95);
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.ui.menu {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem 0;
+  font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  background: #fff;
+  font-weight: 900;
+  border: 1px solid rgba(34, 36, 38, .15);
+  -webkit-box-shadow: 0 1px 2px 0 rgba(34, 36, 38, .15);
+  box-shadow: 0 1px 2px 0 rgba(34, 36, 38, .15);
+  border-radius: .28571429rem;
+  min-height: 0px;
+}
+</style>

--- a/frontend/src/components/Common/SortTypeComponent.vue
+++ b/frontend/src/components/Common/SortTypeComponent.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="radio-input">
     <label>
-      <input value="value-1" name="value-radio" id="value-1" type="radio" />
+      <input value="value-1" name="value-radio" id="value-1" type="radio" v-model="selectedSort"
+             @change="emitSortChange('checkLatest')"/>
       <span>최신 순</span>
     </label>
     <label>
-      <input value="value-2" name="value-radio" id="value-2" type="radio" />
+      <input value="value-2" name="value-radio" id="value-2" type="radio" v-model="selectedSort"
+             @change="emitSortChange('checkLike')"/>
       <span>좋아요 순</span>
     </label>
     <span class="selection"></span>
@@ -13,6 +15,30 @@
 </template>
 
 <script>
+import {mapStores} from "pinia";
+import {useQnaStore} from "@/store/useQnaStore";
+
+export default {
+  name: "QnaListPage",
+  data() {
+    return {
+      selectedSort: null
+    };
+  },
+  computed: {
+    ...mapStores(useQnaStore),
+  },
+  mounted() {
+    this.selectedSort="latest"
+  },
+  methods: {
+    emitSortChange(sortType) {
+      this.$emit(sortType);
+    },
+  },
+  components: {
+  },
+};
 
 </script>
 
@@ -22,7 +48,7 @@
 }
 
 .radio-input {
-  --container_width: 300px;
+  --container_width: 160px;
   position: relative;
   display: flex;
   align-items: center;
@@ -31,7 +57,8 @@
   color: #000000;
   width: var(--container_width);
   overflow: hidden;
-  border: 1px solid rgba(53, 52, 52, 0.226);
+  border: 2px solid rgba(53, 52, 52, 0.226);
+  margin-bottom: 20px;
 }
 
 .radio-input label {
@@ -42,7 +69,7 @@
   justify-content: center;
   align-items: center;
   z-index: 1;
-  font-weight: 600;
+  font-weight: 800;
   letter-spacing: -1px;
   font-size: 14px;
 }

--- a/frontend/src/components/qna/QnaAnswerDetailComponent.vue
+++ b/frontend/src/components/qna/QnaAnswerDetailComponent.vue
@@ -5,27 +5,24 @@
         <div class="mantine-1uguyhf">
           <a
               class="mantine-Avatar-root mantine-18l6s09"
-              href="https://www.inflearn.com/users/14769/@weekendcode"
           ><img
               class="mantine-9rx0rd mantine-Avatar-image"
-              src="https://cdn.inflearn.com/public/users/thumbnails/14769/aa751976-0548-441b-9084-d71ff6327348?w=76"
-              alt="주말코딩님의 프로필 이미지"
+              src="@/assets/logo.png"
           /></a>
           <div class="mantine-Stack-root mantine-1l47z8p">
             <div class="mantine-824czz">
               <a
                   class="mantine-Text-root mantine-3qdwx9 answer-name-text"
-                  href="https://www.inflearn.com/users/14769/@weekendcode"
-              >MR KIM</a
+              >{{ qnaAnswer.nickname }}</a
               >
               <div class="mantine-Badge-root mantine-11jjpd0">
                           <span class="mantine-1jlwn9k mantine-Badge-inner"
-                          >답변자</span
+                          >{{ qnaAnswer.grade }}</span
                           >
               </div>
             </div>
             <p class="mantine-Text-root mantine-1q4x896">
-              2024. 09. 04. 12:06
+              {{ formatDateTime(qnaAnswer.createdAt) }}
             </p>
           </div>
         </div>
@@ -40,15 +37,11 @@
         >
         </div>
       </div>
-      <p>
-        BentoML’s code-first approach makes it highly flexible for developers to
-        architect multi-model, multi-component distributed systems, offering the
-        key building blocks for defining custom AI APIs, inference workers, async
-        task queues, scaling behavior, batching optimization, and model
-        composition.
-      </p>
     </div>
     <div class="" style="font-size: 13px">
+      <p>
+        {{ qnaAnswer.answer }}
+      </p>
       <div>
         <aside class="bg-black text-white p-6 rounded-lg w-full max-w-md font-mono">
           <div class="flex justify-between items-center">
@@ -88,9 +81,9 @@
       <div class="like-dislike-container">
         <div class="icons-box">
           <div class="icons">
-            <label class="btn-label" for="like-checkbox">
-              <span class="like-text-content">123</span>
-              <input class="input-box" id="like-checkbox" type="checkbox">
+            <label class="btn-label" for="a-ike-checkbox">
+              <span class="like-text-content">{{ qnaAnswer.likeCnt }}</span>
+              <input class="input-box" id="a-like-checkbox" type="checkbox">
               <svg class="svgs" id="icon-like-solid" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                 <path
                     d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"></path>
@@ -100,15 +93,15 @@
                     d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"></path>
               </svg>
               <div class="fireworks">
-                <div class="checked-like-fx"></div>
+                <div class="a-checked-like-fx"></div>
               </div>
             </label>
           </div>
           <div class="icons">
-            <label class="btn-label" for="dislike-checkbox">
-              <input class="input-box" id="dislike-checkbox" type="checkbox">
+            <label class="btn-label" for="a-dislike-checkbox">
+              <input class="input-box" id="a-dislike-checkbox" type="checkbox">
               <div class="fireworks">
-                <div class="checked-dislike-fx"></div>
+                <div class="a-checked-dislike-fx"></div>
               </div>
               <svg class="svgs" id="icon-dislike-solid" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
                 <path
@@ -118,25 +111,42 @@
                 <path
                     d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"></path>
               </svg>
-              <span class="dislike-text-content">4</span>
+              <span class="dislike-text-content">{{ qnaAnswer.hateCnt }}</span>
             </label>
           </div>
         </div>
       </div>
     </div>
   </div>
-
+  <div v-if="isLoading"></div>
+  <QnaCommentDetailComponent v-else
+                             v-for="qnaComment in qnaAnswer.comments"
+                             :key="qnaComment.id"
+                             :qnaComment="qnaComment"
+  />
 </template>
 
 <script>
+import {formatDateTime} from "@/utils/FormatDate";
+import QnaCommentDetailComponent from "@/components/qna/QnaCommentDetailComponent.vue";
+
 export default {
   name: "QnaAnswerDetailComponent",
   data() {
-    return {};
+    return {
+      isLoading: true
+    };
   },
-  // props: ["qnaAnswers"],
-  methods: {},
-  components: {},
+  props: ["qnaAnswer"],
+  methods: {
+    formatDateTime
+  },
+  mounted() {
+    this.isLoading=false
+  },
+  components: {
+    QnaCommentDetailComponent
+  },
 }
 </script>
 
@@ -356,12 +366,12 @@ img {
   animation: rotate-icon-like 0.7s ease-in-out both;
 }
 
-.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-regular {
+.like-dislike-container .icons #a-like-checkbox:checked ~ #icon-like-regular {
   display: none;
   animation: checked-icon-like 0.5s;
 }
 
-.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-solid {
+.like-dislike-container .icons #a-like-checkbox:checked ~ #icon-like-solid {
   display: block;
   animation: checked-icon-like 0.5s;
 }
@@ -384,13 +394,13 @@ img {
 
 .like-dislike-container
 .icons
-#dislike-checkbox:checked
+#a-dislike-checkbox:checked
 ~ #icon-dislike-regular {
   display: none;
   animation: checked-icon-dislike 0.5s;
 }
 
-.like-dislike-container .icons #dislike-checkbox:checked ~ #icon-dislike-solid {
+.like-dislike-container .icons #a-dislike-checkbox:checked ~ #icon-dislike-solid {
   display: block;
   animation: checked-icon-dislike 0.5s;
 }
@@ -401,9 +411,9 @@ img {
 
 .like-dislike-container
 .icons
-#like-checkbox:checked
+#a-like-checkbox:checked
 ~ .fireworks
-> .checked-like-fx {
+> .a-checked-like-fx {
   position: absolute;
   width: 10px;
   height: 10px;
@@ -425,9 +435,9 @@ img {
 
 .like-dislike-container
 .icons
-#dislike-checkbox:checked
+#a-dislike-checkbox:checked
 ~ .fireworks
-> .checked-dislike-fx {
+> .a-checked-dislike-fx {
   position: absolute;
   width: 10px;
   height: 10px;
@@ -671,8 +681,9 @@ element.style {
 }
 
 .bg-black.text-white.p-6.rounded-lg.w-full.max-w-md.font-mono {
-  max-width: 70rem;
+  width: 700px;
   margin: auto;
+
 }
 
 /* 댓글 */
@@ -1350,6 +1361,7 @@ html {
   -webkit-print-color-scheme: light;
   color-scheme: light;
 }
+
 q {
   quotes: none;
 }
@@ -1375,7 +1387,7 @@ q:before {
 }
 
 #answer-title-text {
-  margin-top: 4rem;
+  margin-top: 2rem;
 }
 
 #user-profile-image {

--- a/frontend/src/components/qna/QnaAnswerDetailComponent.vue
+++ b/frontend/src/components/qna/QnaAnswerDetailComponent.vue
@@ -1,0 +1,1384 @@
+<template>
+  <div class="rounded-box p-5 mb-10 md:p-8 bento-card" style="background: #efefef; border: 1px solid #19192c">
+    <div class="mb-10">
+      <div class="mantine-2j9uwr">
+        <div class="mantine-1uguyhf">
+          <a
+              class="mantine-Avatar-root mantine-18l6s09"
+              href="https://www.inflearn.com/users/14769/@weekendcode"
+          ><img
+              class="mantine-9rx0rd mantine-Avatar-image"
+              src="https://cdn.inflearn.com/public/users/thumbnails/14769/aa751976-0548-441b-9084-d71ff6327348?w=76"
+              alt="주말코딩님의 프로필 이미지"
+          /></a>
+          <div class="mantine-Stack-root mantine-1l47z8p">
+            <div class="mantine-824czz">
+              <a
+                  class="mantine-Text-root mantine-3qdwx9 answer-name-text"
+                  href="https://www.inflearn.com/users/14769/@weekendcode"
+              >MR KIM</a
+              >
+              <div class="mantine-Badge-root mantine-11jjpd0">
+                          <span class="mantine-1jlwn9k mantine-Badge-inner"
+                          >답변자</span
+                          >
+              </div>
+            </div>
+            <p class="mantine-Text-root mantine-1q4x896">
+              2024. 09. 04. 12:06
+            </p>
+          </div>
+        </div>
+        <button class="red-button-size ui inverted red button">edit</button>
+      </div>
+      <div class="flex justify-between">
+        <div id="answer-title-text" class="question-answer mb-5 build-section-card-title">
+          Answer
+        </div>
+        <div
+            class="w-16 h-8 transition"
+        >
+        </div>
+      </div>
+      <p>
+        BentoML’s code-first approach makes it highly flexible for developers to
+        architect multi-model, multi-component distributed systems, offering the
+        key building blocks for defining custom AI APIs, inference workers, async
+        task queues, scaling behavior, batching optimization, and model
+        composition.
+      </p>
+    </div>
+    <div class="" style="font-size: 13px">
+      <div>
+        <aside class="bg-black text-white p-6 rounded-lg w-full max-w-md font-mono">
+          <div class="flex justify-between items-center">
+            <div class="flex space-x-2 text-red-500">
+              <div class="w-3 h-3 rounded-full bg-red-500"></div>
+              <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
+              <div class="w-3 h-3 rounded-full bg-green-500"></div>
+            </div>
+            <p class="text-sm">spring</p>
+          </div>
+          <div class="mt-4">
+            <p class="text-green-400">@RestController</p>
+            <p class="text-green-400">@RequestMapping("/test")</p>
+            <p class="text-white">&nbsp;public class TestJenController {</p>
+            <p class="text-green-400">&nbsp;&nbsp;@GetMapping()</p>
+            <p class="text-white">&nbsp;&nbsp;public String saveTest() {</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;return "test";</p>
+            <p class="text-white">&nbsp;&nbsp;}</p>
+            <p class="text-white">}</p>
+          </div>
+        </aside>
+      </div>
+      <div class="mt-auto pt-10">
+        <div class="flex flex-col md:flex-row gap-5 justify-start">
+          <a
+              href="https://github.com/bentoml/rag-tutorials"
+              target="_blank"
+              rel="noopener noreferrer"
+          ></a
+          ><a
+            href="https://docs.bentoml.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+        ></a>
+        </div>
+      </div>
+      <div class="like-dislike-container">
+        <div class="icons-box">
+          <div class="icons">
+            <label class="btn-label" for="like-checkbox">
+              <span class="like-text-content">123</span>
+              <input class="input-box" id="like-checkbox" type="checkbox">
+              <svg class="svgs" id="icon-like-solid" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path
+                    d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"></path>
+              </svg>
+              <svg class="svgs" id="icon-like-regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path
+                    d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"></path>
+              </svg>
+              <div class="fireworks">
+                <div class="checked-like-fx"></div>
+              </div>
+            </label>
+          </div>
+          <div class="icons">
+            <label class="btn-label" for="dislike-checkbox">
+              <input class="input-box" id="dislike-checkbox" type="checkbox">
+              <div class="fireworks">
+                <div class="checked-dislike-fx"></div>
+              </div>
+              <svg class="svgs" id="icon-dislike-solid" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path
+                    d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"></path>
+              </svg>
+              <svg class="svgs" id="icon-dislike-regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path
+                    d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"></path>
+              </svg>
+              <span class="dislike-text-content">4</span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</template>
+
+<script>
+export default {
+  name: "QnaAnswerDetailComponent",
+  data() {
+    return {};
+  },
+  // props: ["qnaAnswers"],
+  methods: {},
+  components: {},
+}
+</script>
+
+<style>
+.rounded-box {
+  border-radius: 20px;
+}
+
+.circle {
+  margin-left: 25px;
+  margin-bottom: 10px;
+  width: 120px;
+  height: 120px;
+  overflow: hidden;
+  border-radius: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.circle img {
+  width: 200%;
+  height: auto;
+}
+
+img {
+  max-width: 200%;
+  height: auto;
+}
+
+/* 원형 이미지 */
+
+.title-text {
+  font-family: "auto";
+  margin-left: 50px;
+  font-size: 43px;
+  font-weight: 900;
+}
+
+.username-text {
+  margin-left: 20px;
+  margin-bottom: 10px;
+  font-size: 20px;
+  font-weight: 900;
+}
+
+.datetime-text {
+  margin-left: 10px;
+  margin-bottom: 10px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.label-custom {
+  margin-left: 20px;
+}
+
+.qna-background-color {
+  background-color: #efefef;
+}
+
+/* like */
+.like-dislike-container {
+  --dark-grey: #353535;
+  --middle-grey: #767676;
+  --border-radius-icon: 50px;
+  position: relative;
+  display: flex;
+  text-align: center;
+  flex-direction: row;
+  align-items: center;
+  cursor: default;
+  color: var(--dark-grey);
+  opacity: 0.9;
+  margin-left: auto;
+  padding: 0rem;
+  font-weight: 600;
+  background: var(--lightest-grey);
+  max-width: max-content;
+  border-radius: var(--border-radius-main);
+  box-shadow: var(--shadow);
+  transition: 0.2s ease all;
+}
+
+.like-dislike-container:hover {
+  box-shadow: var(--shadow-active);
+}
+
+.like-dislike-container .tool-box {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  top: 0;
+  right: 0;
+  border-radius: var(--border-radius-main);
+}
+
+.like-dislike-container .btn-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 0.8rem;
+  height: 0.8rem;
+  color: transparent;
+  font-size: 0;
+  cursor: pointer;
+  background-color: #ff000080;
+  border: none;
+  border-radius: var(--border-radius-main);
+  transition: 0.2s ease all;
+}
+
+.like-dislike-container .btn-close:hover {
+  width: 1rem;
+  height: 1rem;
+  font-size: 1rem;
+  color: #ffffff;
+  background-color: #ff0000cc;
+  box-shadow: var(--shadow-active);
+}
+
+.like-dislike-container .btn-close:active {
+  width: 0.9rem;
+  height: 0.9rem;
+  font-size: 0.9rem;
+  color: #ffffffde;
+  --shadow-btn-close: 0 3px 3px 0 #00000026;
+  box-shadow: var(--shadow-btn-close);
+}
+
+.like-dislike-container .text-content {
+  margin-bottom: 1rem;
+  font-size: 18px;
+  line-height: 1.6;
+  cursor: default;
+}
+
+.like-dislike-container .icons-box {
+  display: flex;
+}
+
+.like-dislike-container .icons {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0.6;
+  margin: 0 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid var(--middle-grey);
+  border-radius: var(--border-radius-icon);
+  transition: 0.2s ease all;
+}
+
+.like-dislike-container .icons:hover {
+  opacity: 0.9;
+  box-shadow: var(--shadow);
+}
+
+.like-dislike-container .icons:active {
+  opacity: 0.9;
+  box-shadow: var(--shadow-active);
+}
+
+.like-dislike-container .icons .btn-label {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 0.5rem;
+  cursor: pointer;
+  position: relative;
+}
+
+.like-dislike-container .like-text-content {
+  border-right: 0.1rem solid var(--dark-grey);
+  padding: 0 0.6rem 0 0.5rem;
+  pointer-events: none;
+}
+
+.like-dislike-container .dislike-text-content {
+  border-left: 0.1rem solid var(--dark-grey);
+  padding: 0 0.5rem 0 0.6rem;
+  pointer-events: none;
+}
+
+.like-dislike-container .icons .svgs {
+  width: 1.3rem;
+  fill: #000000;
+  box-sizing: content-box;
+  padding: 10px 10px;
+  transition: 0.2s ease all;
+}
+
+/* Hide the default checkbox */
+.like-dislike-container .icons .input-box {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+.like-dislike-container .icons #icon-like-regular {
+  display: block;
+}
+
+.like-dislike-container .icons #icon-like-solid {
+  display: none;
+}
+
+.like-dislike-container .icons:hover :is(#icon-like-solid, #icon-like-regular) {
+  animation: rotate-icon-like 0.7s ease-in-out both;
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-regular {
+  display: none;
+  animation: checked-icon-like 0.5s;
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-solid {
+  display: block;
+  animation: checked-icon-like 0.5s;
+}
+
+.like-dislike-container .icons #icon-dislike-regular {
+  display: block;
+  transform: rotate(180deg);
+}
+
+.like-dislike-container .icons #icon-dislike-solid {
+  display: none;
+  transform: rotate(180deg);
+}
+
+.like-dislike-container
+.icons:hover
+:is(#icon-dislike-solid, #icon-dislike-regular) {
+  animation: rotate-icon-dislike 0.7s ease-in-out both;
+}
+
+.like-dislike-container
+.icons
+#dislike-checkbox:checked
+~ #icon-dislike-regular {
+  display: none;
+  animation: checked-icon-dislike 0.5s;
+}
+
+.like-dislike-container .icons #dislike-checkbox:checked ~ #icon-dislike-solid {
+  display: block;
+  animation: checked-icon-dislike 0.5s;
+}
+
+.like-dislike-container .icons .fireworks {
+  transform: scale(0.4);
+}
+
+.like-dislike-container
+.icons
+#like-checkbox:checked
+~ .fireworks
+> .checked-like-fx {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  right: 40px;
+  border-radius: 50%;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s fireworks-bang ease-out forwards,
+  1s fireworks-gravity ease-in forwards, 5s fireworks-position linear forwards;
+  animation-duration: 1.25s, 1.25s, 6.25s;
+}
+
+.like-dislike-container
+.icons
+#dislike-checkbox:checked
+~ .fireworks
+> .checked-dislike-fx {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  left: 40px;
+  border-radius: 50%;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s fireworks-bang ease-out forwards,
+  1s fireworks-gravity ease-in forwards, 5s fireworks-position linear forwards;
+  animation-duration: 1.25s, 1.25s, 6.25s;
+}
+
+/* Shake Animation */
+@keyframes rotate-icon-like {
+  0% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+
+  25% {
+    transform: rotate(3deg) translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: rotate(-3deg) translate3d(0, 0, 0);
+  }
+
+  75% {
+    transform: rotate(1deg) translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+}
+
+@keyframes rotate-icon-dislike {
+  0% {
+    transform: rotate(180deg) translate3d(0, 0, 0);
+  }
+
+  25% {
+    transform: rotate(183deg) translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: rotate(177deg) translate3d(0, 0, 0);
+  }
+
+  75% {
+    transform: rotate(181deg) translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: rotate(180deg) translate3d(0, 0, 0);
+  }
+}
+
+/* Checked Animation */
+@keyframes checked-icon-like {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+
+  50% {
+    transform: scale(1.2) rotate(-10deg);
+  }
+}
+
+@keyframes checked-icon-dislike {
+  0% {
+    transform: scale(0) rotate(180deg);
+    opacity: 0;
+  }
+
+  50% {
+    transform: scale(1.2) rotate(170deg);
+  }
+}
+
+/* Fireworks Animation */
+@keyframes fireworks-position {
+  0%,
+  19.9% {
+    margin-top: 10%;
+    margin-left: 40%;
+  }
+
+  20%,
+  39.9% {
+    margin-top: 40%;
+    margin-left: 30%;
+  }
+
+  40%,
+  59.9% {
+    margin-top: 20%;
+    margin-left: 70%;
+  }
+
+  60%,
+  79.9% {
+    margin-top: 30%;
+    margin-left: 20%;
+  }
+
+  80%,
+  99.9% {
+    margin-top: 30%;
+    margin-left: 80%;
+  }
+}
+
+@keyframes fireworks-gravity {
+  to {
+    transform: translateY(200px);
+    opacity: 0;
+  }
+}
+
+@keyframes fireworks-bang {
+  to {
+    box-shadow: 114px -107.3333333333px #8800ff, 212px -166.3333333333px #a600ff,
+    197px -6.3333333333px #ff006a, 179px -329.3333333333px #3300ff,
+    -167px -262.3333333333px #ff0062, 233px 65.6666666667px #ff008c,
+    81px 42.6666666667px #0051ff, -13px 54.6666666667px #00ff2b,
+    -60px -183.3333333333px #0900ff, 127px -259.3333333333px #ff00e6,
+    117px -122.3333333333px #00b7ff, 95px 20.6666666667px #ff8000,
+    115px 1.6666666667px #0004ff, -160px -328.3333333333px #00ff40,
+    69px -242.3333333333px #000dff, -208px -230.3333333333px #ff0400,
+    30px -15.3333333333px #e6ff00, 235px -15.3333333333px #fb00ff,
+    80px -232.3333333333px #d5ff00, 175px -173.3333333333px #00ff3c,
+    -187px -176.3333333333px #aaff00, 4px 26.6666666667px #ff6f00,
+    227px -106.3333333333px #ff0099, 119px 17.6666666667px #00ffd5,
+    -102px 4.6666666667px #ff0088, -16px -4.3333333333px #00fff7,
+    -201px -310.3333333333px #00ffdd, 64px -181.3333333333px #f700ff,
+    -234px -15.3333333333px #00fffb, -184px -263.3333333333px #aa00ff,
+    96px -303.3333333333px #0037ff, -139px 10.6666666667px #0026ff,
+    25px -205.3333333333px #00ff2b, -129px -322.3333333333px #40ff00,
+    -235px -187.3333333333px #26ff00, -136px -237.3333333333px #0091ff,
+    -82px -321.3333333333px #6a00ff, 7px -267.3333333333px #ff00c8,
+    -155px 30.6666666667px #0059ff, -85px -73.3333333333px #6a00ff,
+    60px -199.3333333333px #55ff00, -9px -289.3333333333px #00ffaa,
+    -208px -167.3333333333px #00ff80, -13px -299.3333333333px #ff0004,
+    179px -164.3333333333px #ff0044, -112px 12.6666666667px #0051ff,
+    -209px -125.3333333333px #ff00bb, 14px -101.3333333333px #00ff95,
+    -184px -292.3333333333px #ff0099, -26px -168.3333333333px #09ff00,
+    129px -67.3333333333px #0084ff, -17px -23.3333333333px #0059ff,
+    129px 34.6666666667px #7300ff, 35px -24.3333333333px #ffd900,
+    -12px -297.3333333333px #ff8400, 129px -156.3333333333px #0dff00,
+    157px -29.3333333333px #1a00ff, -221px 6.6666666667px #ff0062,
+    0px -311.3333333333px #ff006a, 155px 50.6666666667px #00ffaa,
+    -71px -318.3333333333px #0073ff;
+  }
+}
+
+/* like */
+
+/* book mark */
+.bookmark-checkbox {
+  display: inline-block;
+}
+
+.bookmark-checkbox__input {
+  display: none;
+}
+
+.bookmark-checkbox__label {
+  cursor: pointer;
+}
+
+.bookmark-checkbox__icon {
+  margin-left: 20px;
+  width: 2em;
+  height: 2em;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: stroke 0.3s, fill 0.3s;
+}
+
+.bookmark-checkbox__icon-back {
+  stroke: #333;
+  transition: transform 0.3s;
+}
+
+.bookmark-checkbox__icon-check {
+  stroke: #fff;
+  stroke-dasharray: 16;
+  stroke-dashoffset: 16;
+  transition: stroke-dashoffset 0.3s, transform 0.3s;
+  transform: translateX(2px);
+}
+
+.bookmark-checkbox__input:checked
++ .bookmark-checkbox__label
+.bookmark-checkbox__icon {
+  fill: #ff5a5f;
+}
+
+.bookmark-checkbox__input:checked
++ .bookmark-checkbox__label
+.bookmark-checkbox__icon-back {
+  stroke: #ff5a5f;
+  transform: scale(1.1);
+  animation: bookmark-pop 0.4s ease;
+}
+
+.bookmark-checkbox__input:checked
++ .bookmark-checkbox__label
+.bookmark-checkbox__icon-check {
+  stroke-dashoffset: 0;
+  transition-delay: 0.2s;
+}
+
+@keyframes bookmark-pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1.1);
+  }
+}
+
+/* book mark */
+
+element.style {
+  background: #fff;
+  border: 1px solid #19192c;
+}
+
+.bg-black.text-white.p-6.rounded-lg.w-full.max-w-md.font-mono {
+  max-width: 70rem;
+  margin: auto;
+}
+
+/* 댓글 */
+.mantine-9rx0rd {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.mantine-18l6s08 {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 200%;
+  border-top-left-radius: 200%;
+  border-top-right-radius: 200%;
+  border-bottom-right-radius: 200%;
+  border-bottom-left-radius: 200%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid #dee2e6;
+}
+
+.mantine-18l6s09 {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 200%;
+  border-top-left-radius: 200%;
+  border-top-right-radius: 200%;
+  border-bottom-right-radius: 200%;
+  border-bottom-left-radius: 200%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid #dee2e6;
+  justify-content: center;
+  align-items: center;
+}
+
+.mantine-9p81l6 {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  color: #495057;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  line-height: 1.5;
+  text-underline-position: under;
+}
+
+.mantine-9p81l6:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-9p81l6:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.mantine-1uguyhf {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.mantine-1q4x896 {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  color: #868e96;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  text-underline-position: under;
+}
+
+.mantine-1q4x896:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-1q4x896:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.mantine-1yjkc96 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.mantine-1ryt1ht {
+  white-space: nowrap;
+  height: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.mantine-19ok7fu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 0.625rem;
+  margin-right: 6px;
+}
+
+.mantine-19ok7fu svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mantine-k7c4r8 {
+  -webkit-tap-highlight-color: transparent;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  font-size: 1rem;
+  background-color: transparent;
+  text-align: left;
+  color: #000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  height: 2.25rem;
+  padding-left: calc(1.125rem / 1.5);
+  padding-right: 1.125rem;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  display: inline-block;
+  width: auto;
+  border-radius: 2rem;
+  font-weight: 600;
+  position: relative;
+  line-height: 1;
+  font-size: 0.875rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: pointer;
+  border: 0.0625rem solid #ced4da;
+  background-color: #fff;
+  color: #000;
+  color: #212529;
+  padding-left: 18px;
+}
+
+.mantine-k7c4r8:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-k7c4r8:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.mantine-k7c4r8:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-k7c4r8:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+@media (hover: hover) {
+  .mantine-k7c4r8:hover {
+    background-color: #f8f9fa;
+  }
+}
+
+@media (hover: none) {
+  .mantine-k7c4r8:active {
+    background-color: #f8f9fa;
+  }
+}
+
+.mantine-k7c4r8:active {
+  -webkit-transform: translateY(0.0625rem);
+  -moz-transform: translateY(0.0625rem);
+  -ms-transform: translateY(0.0625rem);
+  transform: translateY(0.0625rem);
+}
+
+.mantine-k7c4r8:disabled,
+.mantine-k7c4r8[data-disabled] {
+  border-color: transparent;
+  background-color: #e9ecef;
+  color: #adb5bd;
+  cursor: not-allowed;
+  background-image: none;
+  pointer-events: none;
+}
+
+.mantine-k7c4r8:disabled:active,
+.mantine-k7c4r8[data-disabled]:active {
+  -webkit-transform: none;
+  -moz-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.mantine-k7c4r8[data-loading] {
+  pointer-events: none;
+}
+
+.mantine-k7c4r8[data-loading]::before {
+  content: "";
+  position: absolute;
+  top: -0.0625rem;
+  right: -0.0625rem;
+  left: -0.0625rem;
+  bottom: -0.0625rem;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 2rem;
+  cursor: not-allowed;
+}
+
+.mantine-1qj7q0z {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: 2.25rem;
+  pointer-events: none;
+}
+
+.mantine-1ttseea {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  gap: 0;
+  width: 100%;
+  min-width: 0;
+}
+
+.mantine-2j9uwr {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 30px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.mantine-18l6s08 {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 2rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  width: 2.375rem;
+  min-width: 2.375rem;
+  height: 2.375rem;
+  border: 1px solid #dee2e6;
+}
+
+.mantine-18l6s08:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-18l6s08:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.mantine-1l47z8p {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  gap: 0;
+}
+
+.mantine-824czz {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.mantine-3qdwx9 {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  color: #495057;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  line-height: 1.5;
+  text-underline-position: under;
+}
+
+.mantine-3qdwx9:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-3qdwx9:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.mantine-1jlwn9k {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 100%;
+  letter-spacing: normal;
+}
+
+.mantine-11jjpd0 {
+  -webkit-tap-highlight-color: transparent;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  font-size: 0.6875rem;
+  height: 25px;
+  line-height: calc(1.25rem - 0.125rem);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding: 0 calc(1rem / 1.5);
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  text-transform: uppercase;
+  border-radius: 0.25rem;
+  font-weight: 700;
+  letter-spacing: 0.015625rem;
+  cursor: inherit;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  background: rgba(229, 249, 241, 1);
+  color: #00894f;
+  border: 0.0625rem solid transparent;
+  text-transform: none;
+  padding: 0 8px;
+}
+
+.mantine-11jjpd0:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+
+.mantine-11jjpd0:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.mantine-6va1do {
+  margin-top: 0.5rem;
+}
+
+.mantine-12kvhdu {
+  margin-top: 0.75rem;
+}
+
+.mantine-1qj7haw {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+.mantine-1qj7haw > * {
+  box-sizing: border-box;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+}
+
+.mantine-17p85na {
+  padding-left: 28px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.mantine-17p85na:not(.mantine-17p85na:first-of-type) .re-comment-arrow {
+  padding-top: 36px;
+}
+
+.mantine-17p85na:not(.mantine-17p85na:first-of-type) .re-comment {
+  padding-top: 24px;
+  border-top: 1px solid #e9ecef;
+}
+
+.mantine-155ln8z {
+  left: 0;
+  font-size: 0;
+  position: absolute;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.mantine-5n4x4z {
+  width: 100%;
+}
+
+.mantine-11k5015 {
+  border-radius: 16px;
+  border: 1px solid #e9ecef;
+  padding: 1.5rem;
+}
+
+h1 {
+  font-size: 2em;
+}
+
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+a {
+  background: 0 0;
+  text-decoration-skip: objects;
+}
+
+a:active,
+a:hover {
+  outline-width: 0;
+}
+
+b {
+  font-weight: bolder;
+}
+
+code {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+img {
+  border-style: none;
+  vertical-align: middle;
+}
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+button {
+  font-family: sans-serif;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+
+button {
+  overflow: visible;
+}
+
+button {
+  text-transform: none;
+}
+
+[type="reset"],
+[type="submit"],
+button {
+  -webkit-appearance: button;
+}
+
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner,
+button::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring,
+button:-moz-focusring {
+  outline: 0.0625rem dotted ButtonText;
+}
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type="search"] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+}
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  -moz-appearance: button;
+  -ms-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+
+::after,
+::before {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-print-color-scheme: light;
+  color-scheme: light;
+}
+q {
+  quotes: none;
+}
+
+q:after,
+q:before {
+  content: none;
+}
+
+.answer-name-text {
+  font-size: 20px;
+}
+
+/* 댓글 */
+
+.red-button-size {
+  height: 35px;
+}
+
+.question-answer {
+  font-size: 30px;
+  font-weight: 900;
+}
+
+#answer-title-text {
+  margin-top: 4rem;
+}
+
+#user-profile-image {
+  max-width: 200%;
+}
+</style>

--- a/frontend/src/components/qna/QnaCommentDetailComponent.vue
+++ b/frontend/src/components/qna/QnaCommentDetailComponent.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="answer-write-component">
+    <div class="ripple-component">
+      <div class="mantine-17p85na">
+        <div class="re-comment-arrow mantine-155ln8z">
+          <svg
+              aria-hidden="true"
+              focusable="false"
+              data-prefix="fas"
+              data-icon="arrow-turn-down-right"
+              class="svg-inline--fa fa-arrow-turn-down-right"
+              role="img"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+              style="font-size: 16px; color: #dee2e6"
+          >
+            <path
+                fill="currentColor"
+                d="M64 64c0-17.7-14.3-32-32-32S0 46.3 0 64V224c0 53 43 96 96 96H402.7l-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 256H96c-17.7 0-32-14.3-32-32V64z"
+            ></path>
+          </svg>
+        </div>
+        <div class="re-comment mantine-5n4x4z">
+          <div class="mantine-5n4x4z">
+            <div class="mantine-Stack-root mantine-1ttseea">
+              <div class="mantine-2j9uwr">
+                <div class="mantine-1uguyhf">
+                  <a
+                      class="mantine-Avatar-root mantine-18l6s08"
+                  ><img
+                      class="mantine-9rx0rd mantine-Avatar-image"
+                      src='{{ qnaComment.profileImage }}'
+                  /></a>
+                  <div class="mantine-Stack-root mantine-1l47z8p">
+                    <div class="mantine-824czz">
+                      <a
+                          class="mantine-Text-root mantine-3qdwx9"
+                      >{{ qnaComment.nickname }}</a
+                      >
+                      <div class="mantine-Badge-root mantine-11jjpd0">
+                              <span class="mantine-1jlwn9k mantine-Badge-inner"
+                              >{{ qnaComment.grade }}</span
+                              >
+                      </div>
+                    </div>
+                    <p class="mantine-Text-root mantine-1q4x896">
+                      {{ formatDateTime(qnaComment.createdAt) }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="mantine-6va1do">
+                <div class="markdown-body mantine-0">
+                  <p>{{ qnaComment.answerComment }}</p>
+                  <p>
+                    저 Child()라는 것이 자식클래스에 생성자를 넣고 싶으신 것 같은데,
+                    내부 코드까지 다 작성해주셔야 알 수 있습니다. 번거롭더라도 전체
+                    코드예시를 주시면 좋겠습니다.
+                  </p>
+                  <p>&nbsp;</p>
+                  <p>
+                    Child로 생성한 객체의 인스턴스 변수 x가 10으로 세팅되려면,
+                    말씀하신 대로 생성자를 통해서 하면 정상적으로 동작하긴 합니다.
+                  </p>
+                  <p>
+                    예를 들어 자식클래스(Child) 안 쪽에 아래와 같이 추가하면 Child의
+                    x값도 10이 됩니다.
+                  </p>
+                  <p>&nbsp;</p>
+                </div>
+              </div>
+              <div class="mantine-12kvhdu">
+                <div class="mantine-Group-root mantine-1qj7haw">
+                  <button
+                      class="mantine-UnstyledButton-root mantine-Button-root mantine-k7c4r8"
+                      type="button"
+                      data-button="true"
+                      aria-label="답글 작성하기"
+                  >
+                    <div class="mantine-1yjkc96 mantine-Button-inner">
+                            <span
+                                class="mantine-Button-icon mantine-Button-leftIcon mantine-19ok7fu"
+                            ><svg
+                                aria-hidden="true"
+                                focusable="false"
+                                data-prefix="far"
+                                data-icon="comment"
+                                class="svg-inline--fa fa-comment"
+                                role="img"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 512 512"
+                                style="font-size: 14px; color: inherit"
+                            >
+                                <path
+                                    fill="currentColor"
+                                    d="M123.6 391.3c12.9-9.4 29.6-11.8 44.6-6.4c26.5 9.6 56.2 15.1 87.8 15.1c124.7 0 208-80.5 208-160s-83.3-160-208-160S48 160.5 48 240c0 32 12.4 62.8 35.7 89.2c8.6 9.7 12.8 22.5 11.8 35.5c-1.4 18.1-5.7 34.7-11.3 49.4c17-7.9 31.1-16.7 39.4-22.7zM21.2 431.9c1.8-2.7 3.5-5.4 5.1-8.1c10-16.6 19.5-38.4 21.4-62.9C17.7 326.8 0 285.1 0 240C0 125.1 114.6 32 256 32s256 93.1 256 208s-114.6 208-256 208c-37.1 0-72.3-6.4-104.1-17.9c-11.9 8.7-31.3 20.6-54.3 30.6c-15.1 6.6-32.3 12.6-50.1 16.1c-.8 .2-1.6 .3-2.4 .5c-4.4 .8-8.7 1.5-13.2 1.9c-.2 0-.5 .1-.7 .1c-5.1 .5-10.2 .8-15.3 .8c-6.5 0-12.3-3.9-14.8-9.9c-2.5-6-1.1-12.8 3.4-17.4c4.1-4.2 7.8-8.7 11.3-13.5c1.7-2.3 3.3-4.6 4.8-6.9c.1-.2 .2-.3 .3-.5z"
+                                ></path></svg></span
+                            ><span class="mantine-1ryt1ht mantine-Button-label">답글</span>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {formatDateTime} from "@/utils/FormatDate";
+
+export default {
+  name: "QnaCommentDetailComponent",
+  data() {
+    return {};
+  },
+  props: ["qnaComment"],
+  methods: {
+    formatDateTime
+  },
+  mounted() {
+  },
+  components: {},
+}
+</script>
+
+<style>
+.answer-write-component {
+  margin-bottom: 40px;
+}
+
+</style>

--- a/frontend/src/components/qna/QnaDetailComponent.vue
+++ b/frontend/src/components/qna/QnaDetailComponent.vue
@@ -1,0 +1,1382 @@
+<template>
+  <div class="content">
+    <div class="question-component qna-background color">
+      <div class="rounded-box p-5 mb-10 md:p-8 bento-card" style="background: #efefef; border: 1px solid #19192c">
+        <div class="mb-10">
+          <div class="flex justify-between">
+            <div class="question-answer mb-5 build-section-card-title">
+              Q.
+              RestController 이렇게 쓰면 안되나요
+            </div>
+            <div
+                class="w-16 h-8 transition"
+            >
+              <button class="red-button-size ui inverted red button">edit</button>
+            </div>
+          </div>
+        </div>
+        <div class="" style="font-size: 13px">
+          <div>
+            <aside class="bg-black text-white p-6 rounded-lg w-full max-w-md font-mono">
+              <div class="flex justify-between items-center">
+                <div class="flex space-x-2 text-red-500">
+                  <div class="w-3 h-3 rounded-full bg-red-500"></div>
+                  <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
+                  <div class="w-3 h-3 rounded-full bg-green-500"></div>
+                </div>
+                <p class="text-sm">spring</p>
+              </div>
+              <div class="mt-4">
+                <p class="text-green-400">@RestController</p>
+                <p class="text-green-400">@RequestMapping("/test")</p>
+                <p class="text-white">&nbsp;public class TestJenController {</p>
+                <p class="text-green-400">&nbsp;&nbsp;@GetMapping()</p>
+                <p class="text-white">&nbsp;&nbsp;public String saveTest() {</p>
+                <p class="text-white">&nbsp;&nbsp;&nbsp;return "test";</p>
+                <p class="text-white">&nbsp;&nbsp;}</p>
+                <p class="text-white">}</p>
+              </div>
+            </aside>
+          </div>
+          <div class="mt-auto pt-10">
+            <div class="flex flex-col md:flex-row gap-5 justify-start">
+              <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+              ><span class="block px-4 py-2 cta-arrow-btn cta-arrow-verde"
+              ><span class="flex items-center justify-center background-shadow"
+              ><span class="relative inline-block">AI Answer</span
+              ><span class="inline-block h-2 ml-3 button-icon"
+              ><svg
+                  style="
+                            height: 100%;
+                            width: auto;
+                            max-height: 100%;
+                            max-width: 100%;
+                          "
+                  viewBox="0 0 78 72"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+              >
+                          <path
+                              d="M41.7575 4.13232L73.625 35.9998L41.7575 67.8673M4.375 35.9998H72.7325"
+                              stroke="currentColor"
+                              stroke-width="12"
+                              stroke-miterlimit="10"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                          ></path></svg></span></span
+              ><span style="display: block"
+              ><span class="inline-block h-2 ml-3 button-icon"
+              ></span></span></span></a
+              ><a
+                href="https://docs.bentoml.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+            ></a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="answer-write-component"></div>
+      <div class="answer-component qna-background color">
+<!--        <QnaAnswerDetailComponent-->
+<!--            v-for="qnaAnswer in qnaStore.qnaAnswers"-->
+<!--            :key="qnaAnswer.id"-->
+<!--            v-bind:qnaAnswer="qnaAnswer"-->
+<!--        />-->
+      </div>
+      <div class="ripple-component">
+        <div class="mantine-17p85na">
+          <div class="re-comment-arrow mantine-155ln8z">
+            <svg
+                aria-hidden="true"
+                focusable="false"
+                data-prefix="fas"
+                data-icon="arrow-turn-down-right"
+                class="svg-inline--fa fa-arrow-turn-down-right"
+                role="img"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+                style="font-size: 16px; color: #dee2e6"
+            >
+              <path
+                  fill="currentColor"
+                  d="M64 64c0-17.7-14.3-32-32-32S0 46.3 0 64V224c0 53 43 96 96 96H402.7l-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 256H96c-17.7 0-32-14.3-32-32V64z"
+              ></path>
+            </svg>
+          </div>
+          <div class="re-comment mantine-5n4x4z">
+            <div class="mantine-5n4x4z">
+              <div class="mantine-Stack-root mantine-1ttseea">
+                <div class="mantine-2j9uwr">
+                  <div class="mantine-1uguyhf">
+                    <a
+                        class="mantine-Avatar-root mantine-18l6s08"
+                        href="https://www.inflearn.com/users/14769/@weekendcode"
+                    ><img
+                        class="mantine-9rx0rd mantine-Avatar-image"
+                        src="https://cdn.inflearn.com/public/users/thumbnails/14769/aa751976-0548-441b-9084-d71ff6327348?w=76"
+                        alt="주말코딩님의 프로필 이미지"
+                    /></a>
+                    <div class="mantine-Stack-root mantine-1l47z8p">
+                      <div class="mantine-824czz">
+                        <a
+                            class="mantine-Text-root mantine-3qdwx9"
+                            href="https://www.inflearn.com/users/14769/@weekendcode"
+                        >MR KIM</a
+                        >
+                        <div class="mantine-Badge-root mantine-11jjpd0">
+                              <span class="mantine-1jlwn9k mantine-Badge-inner"
+                              >답변자</span
+                              >
+                        </div>
+                      </div>
+                      <p class="mantine-Text-root mantine-1q4x896">
+                        2024. 09. 04. 12:06
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="mantine-6va1do">
+                  <div class="markdown-body mantine-0">
+                    <p>
+                      저 Child()라는 것이 자식클래스에 생성자를 넣고 싶으신 것 같은데,
+                      내부 코드까지 다 작성해주셔야 알 수 있습니다. 번거롭더라도 전체
+                      코드예시를 주시면 좋겠습니다.
+                    </p>
+                    <p>&nbsp;</p>
+                    <p>
+                      Child로 생성한 객체의 인스턴스 변수 x가 10으로 세팅되려면,
+                      말씀하신 대로 생성자를 통해서 하면 정상적으로 동작하긴 합니다.
+                    </p>
+                    <p>
+                      예를 들어 자식클래스(Child) 안 쪽에 아래와 같이 추가하면 Child의
+                      x값도 10이 됩니다.
+                    </p>
+                    <p>&nbsp;</p>
+                  </div>
+                </div>
+                <div class="mantine-12kvhdu">
+                  <div class="mantine-Group-root mantine-1qj7haw">
+                    <button
+                        class="mantine-UnstyledButton-root mantine-Button-root mantine-k7c4r8"
+                        type="button"
+                        data-button="true"
+                        aria-label="답글 작성하기"
+                    >
+                      <div class="mantine-1yjkc96 mantine-Button-inner">
+                            <span
+                                class="mantine-Button-icon mantine-Button-leftIcon mantine-19ok7fu"
+                            ><svg
+                                aria-hidden="true"
+                                focusable="false"
+                                data-prefix="far"
+                                data-icon="comment"
+                                class="svg-inline--fa fa-comment"
+                                role="img"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 512 512"
+                                style="font-size: 14px; color: inherit"
+                            >
+                                <path
+                                    fill="currentColor"
+                                    d="M123.6 391.3c12.9-9.4 29.6-11.8 44.6-6.4c26.5 9.6 56.2 15.1 87.8 15.1c124.7 0 208-80.5 208-160s-83.3-160-208-160S48 160.5 48 240c0 32 12.4 62.8 35.7 89.2c8.6 9.7 12.8 22.5 11.8 35.5c-1.4 18.1-5.7 34.7-11.3 49.4c17-7.9 31.1-16.7 39.4-22.7zM21.2 431.9c1.8-2.7 3.5-5.4 5.1-8.1c10-16.6 19.5-38.4 21.4-62.9C17.7 326.8 0 285.1 0 240C0 125.1 114.6 32 256 32s256 93.1 256 208s-114.6 208-256 208c-37.1 0-72.3-6.4-104.1-17.9c-11.9 8.7-31.3 20.6-54.3 30.6c-15.1 6.6-32.3 12.6-50.1 16.1c-.8 .2-1.6 .3-2.4 .5c-4.4 .8-8.7 1.5-13.2 1.9c-.2 0-.5 .1-.7 .1c-5.1 .5-10.2 .8-15.3 .8c-6.5 0-12.3-3.9-14.8-9.9c-2.5-6-1.1-12.8 3.4-17.4c4.1-4.2 7.8-8.7 11.3-13.5c1.7-2.3 3.3-4.6 4.8-6.9c.1-.2 .2-.3 .3-.5z"
+                                ></path></svg></span
+                            ><span class="mantine-1ryt1ht mantine-Button-label">답글</span>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <footer></footer>
+  </div>
+</template>
+
+<script>
+// import QnaAnswerDetailComponent from "@/components/qna/QnaAnswerDetailComponent.vue";
+
+export default {
+  name: "QuestionDetailComponent",
+  data() {
+    return {
+    };
+  },
+  props: ["qnaDetail"],
+  methods: {},
+  components: {
+    // QnaAnswerDetailComponent
+  },
+};
+</script>
+
+<style>
+.rounded-box {
+  border-radius: 20px;
+}
+.circle {
+  margin-left: 25px;
+  margin-bottom: 10px;
+  width: 120px;
+  height: 120px;
+  overflow: hidden;
+  border-radius: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.circle img {
+  width: 200%;
+  height: auto;
+}
+
+img {
+  max-width: 200%;
+  height: auto;
+}
+/* 원형 이미지 */
+
+.title-text {
+  font-family: "auto";
+  margin-left: 50px;
+  font-size: 43px;
+  font-weight: 900;
+}
+
+.username-text {
+  margin-left: 20px;
+  margin-bottom: 10px;
+  font-size: 20px;
+  font-weight: 900;
+}
+
+.datetime-text {
+  margin-left: 10px;
+  margin-bottom: 10px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.label-custom {
+  margin-left: 20px;
+}
+
+.qna-background-color {
+  background-color: #efefef;
+}
+
+/* like */
+.like-dislike-container {
+  --dark-grey: #353535;
+  --middle-grey: #767676;
+  --border-radius-icon: 50px;
+  position: relative;
+  display: flex;
+  text-align: center;
+  flex-direction: row;
+  align-items: center;
+  cursor: default;
+  color: var(--dark-grey);
+  opacity: 0.9;
+  margin-left: auto;
+  padding: 0rem;
+  font-weight: 600;
+  background: var(--lightest-grey);
+  max-width: max-content;
+  border-radius: var(--border-radius-main);
+  box-shadow: var(--shadow);
+  transition: 0.2s ease all;
+}
+
+.like-dislike-container:hover {
+  box-shadow: var(--shadow-active);
+}
+
+.like-dislike-container .tool-box {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  top: 0;
+  right: 0;
+  border-radius: var(--border-radius-main);
+}
+
+.like-dislike-container .btn-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 0.8rem;
+  height: 0.8rem;
+  color: transparent;
+  font-size: 0;
+  cursor: pointer;
+  background-color: #ff000080;
+  border: none;
+  border-radius: var(--border-radius-main);
+  transition: 0.2s ease all;
+}
+
+.like-dislike-container .btn-close:hover {
+  width: 1rem;
+  height: 1rem;
+  font-size: 1rem;
+  color: #ffffff;
+  background-color: #ff0000cc;
+  box-shadow: var(--shadow-active);
+}
+
+.like-dislike-container .btn-close:active {
+  width: 0.9rem;
+  height: 0.9rem;
+  font-size: 0.9rem;
+  color: #ffffffde;
+  --shadow-btn-close: 0 3px 3px 0 #00000026;
+  box-shadow: var(--shadow-btn-close);
+}
+
+.like-dislike-container .text-content {
+  margin-bottom: 1rem;
+  font-size: 18px;
+  line-height: 1.6;
+  cursor: default;
+}
+
+.like-dislike-container .icons-box {
+  display: flex;
+}
+
+.like-dislike-container .icons {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0.6;
+  margin: 0 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid var(--middle-grey);
+  border-radius: var(--border-radius-icon);
+  transition: 0.2s ease all;
+}
+
+.like-dislike-container .icons:hover {
+  opacity: 0.9;
+  box-shadow: var(--shadow);
+}
+
+.like-dislike-container .icons:active {
+  opacity: 0.9;
+  box-shadow: var(--shadow-active);
+}
+
+.like-dislike-container .icons .btn-label {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 0.5rem;
+  cursor: pointer;
+  position: relative;
+}
+
+.like-dislike-container .like-text-content {
+  border-right: 0.1rem solid var(--dark-grey);
+  padding: 0 0.6rem 0 0.5rem;
+  pointer-events: none;
+}
+
+.like-dislike-container .dislike-text-content {
+  border-left: 0.1rem solid var(--dark-grey);
+  padding: 0 0.5rem 0 0.6rem;
+  pointer-events: none;
+}
+
+.like-dislike-container .icons .svgs {
+  width: 1.3rem;
+  fill: #000000;
+  box-sizing: content-box;
+  padding: 10px 10px;
+  transition: 0.2s ease all;
+}
+
+/* Hide the default checkbox */
+.like-dislike-container .icons .input-box {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+.like-dislike-container .icons #icon-like-regular {
+  display: block;
+}
+
+.like-dislike-container .icons #icon-like-solid {
+  display: none;
+}
+
+.like-dislike-container .icons:hover :is(#icon-like-solid, #icon-like-regular) {
+  animation: rotate-icon-like 0.7s ease-in-out both;
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-regular {
+  display: none;
+  animation: checked-icon-like 0.5s;
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-solid {
+  display: block;
+  animation: checked-icon-like 0.5s;
+}
+
+.like-dislike-container .icons #icon-dislike-regular {
+  display: block;
+  transform: rotate(180deg);
+}
+
+.like-dislike-container .icons #icon-dislike-solid {
+  display: none;
+  transform: rotate(180deg);
+}
+
+.like-dislike-container
+.icons:hover
+:is(#icon-dislike-solid, #icon-dislike-regular) {
+  animation: rotate-icon-dislike 0.7s ease-in-out both;
+}
+
+.like-dislike-container
+.icons
+#dislike-checkbox:checked
+~ #icon-dislike-regular {
+  display: none;
+  animation: checked-icon-dislike 0.5s;
+}
+
+.like-dislike-container .icons #dislike-checkbox:checked ~ #icon-dislike-solid {
+  display: block;
+  animation: checked-icon-dislike 0.5s;
+}
+
+.like-dislike-container .icons .fireworks {
+  transform: scale(0.4);
+}
+
+.like-dislike-container
+.icons
+#like-checkbox:checked
+~ .fireworks
+> .checked-like-fx {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  right: 40px;
+  border-radius: 50%;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s fireworks-bang ease-out forwards,
+  1s fireworks-gravity ease-in forwards, 5s fireworks-position linear forwards;
+  animation-duration: 1.25s, 1.25s, 6.25s;
+}
+
+.like-dislike-container
+.icons
+#dislike-checkbox:checked
+~ .fireworks
+> .checked-dislike-fx {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  left: 40px;
+  border-radius: 50%;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff,
+  0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s fireworks-bang ease-out forwards,
+  1s fireworks-gravity ease-in forwards, 5s fireworks-position linear forwards;
+  animation-duration: 1.25s, 1.25s, 6.25s;
+}
+
+/* Shake Animation */
+@keyframes rotate-icon-like {
+  0% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+
+  25% {
+    transform: rotate(3deg) translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: rotate(-3deg) translate3d(0, 0, 0);
+  }
+
+  75% {
+    transform: rotate(1deg) translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: rotate(0deg) translate3d(0, 0, 0);
+  }
+}
+
+@keyframes rotate-icon-dislike {
+  0% {
+    transform: rotate(180deg) translate3d(0, 0, 0);
+  }
+
+  25% {
+    transform: rotate(183deg) translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: rotate(177deg) translate3d(0, 0, 0);
+  }
+
+  75% {
+    transform: rotate(181deg) translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: rotate(180deg) translate3d(0, 0, 0);
+  }
+}
+
+/* Checked Animation */
+@keyframes checked-icon-like {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+
+  50% {
+    transform: scale(1.2) rotate(-10deg);
+  }
+}
+
+@keyframes checked-icon-dislike {
+  0% {
+    transform: scale(0) rotate(180deg);
+    opacity: 0;
+  }
+
+  50% {
+    transform: scale(1.2) rotate(170deg);
+  }
+}
+
+/* Fireworks Animation */
+@keyframes fireworks-position {
+  0%,
+  19.9% {
+    margin-top: 10%;
+    margin-left: 40%;
+  }
+
+  20%,
+  39.9% {
+    margin-top: 40%;
+    margin-left: 30%;
+  }
+
+  40%,
+  59.9% {
+    margin-top: 20%;
+    margin-left: 70%;
+  }
+
+  60%,
+  79.9% {
+    margin-top: 30%;
+    margin-left: 20%;
+  }
+
+  80%,
+  99.9% {
+    margin-top: 30%;
+    margin-left: 80%;
+  }
+}
+
+@keyframes fireworks-gravity {
+  to {
+    transform: translateY(200px);
+    opacity: 0;
+  }
+}
+
+@keyframes fireworks-bang {
+  to {
+    box-shadow: 114px -107.3333333333px #8800ff, 212px -166.3333333333px #a600ff,
+    197px -6.3333333333px #ff006a, 179px -329.3333333333px #3300ff,
+    -167px -262.3333333333px #ff0062, 233px 65.6666666667px #ff008c,
+    81px 42.6666666667px #0051ff, -13px 54.6666666667px #00ff2b,
+    -60px -183.3333333333px #0900ff, 127px -259.3333333333px #ff00e6,
+    117px -122.3333333333px #00b7ff, 95px 20.6666666667px #ff8000,
+    115px 1.6666666667px #0004ff, -160px -328.3333333333px #00ff40,
+    69px -242.3333333333px #000dff, -208px -230.3333333333px #ff0400,
+    30px -15.3333333333px #e6ff00, 235px -15.3333333333px #fb00ff,
+    80px -232.3333333333px #d5ff00, 175px -173.3333333333px #00ff3c,
+    -187px -176.3333333333px #aaff00, 4px 26.6666666667px #ff6f00,
+    227px -106.3333333333px #ff0099, 119px 17.6666666667px #00ffd5,
+    -102px 4.6666666667px #ff0088, -16px -4.3333333333px #00fff7,
+    -201px -310.3333333333px #00ffdd, 64px -181.3333333333px #f700ff,
+    -234px -15.3333333333px #00fffb, -184px -263.3333333333px #aa00ff,
+    96px -303.3333333333px #0037ff, -139px 10.6666666667px #0026ff,
+    25px -205.3333333333px #00ff2b, -129px -322.3333333333px #40ff00,
+    -235px -187.3333333333px #26ff00, -136px -237.3333333333px #0091ff,
+    -82px -321.3333333333px #6a00ff, 7px -267.3333333333px #ff00c8,
+    -155px 30.6666666667px #0059ff, -85px -73.3333333333px #6a00ff,
+    60px -199.3333333333px #55ff00, -9px -289.3333333333px #00ffaa,
+    -208px -167.3333333333px #00ff80, -13px -299.3333333333px #ff0004,
+    179px -164.3333333333px #ff0044, -112px 12.6666666667px #0051ff,
+    -209px -125.3333333333px #ff00bb, 14px -101.3333333333px #00ff95,
+    -184px -292.3333333333px #ff0099, -26px -168.3333333333px #09ff00,
+    129px -67.3333333333px #0084ff, -17px -23.3333333333px #0059ff,
+    129px 34.6666666667px #7300ff, 35px -24.3333333333px #ffd900,
+    -12px -297.3333333333px #ff8400, 129px -156.3333333333px #0dff00,
+    157px -29.3333333333px #1a00ff, -221px 6.6666666667px #ff0062,
+    0px -311.3333333333px #ff006a, 155px 50.6666666667px #00ffaa,
+    -71px -318.3333333333px #0073ff;
+  }
+}
+/* like */
+
+/* book mark */
+.bookmark-checkbox {
+  display: inline-block;
+}
+
+.bookmark-checkbox__input {
+  display: none;
+}
+
+.bookmark-checkbox__label {
+  cursor: pointer;
+}
+
+.bookmark-checkbox__icon {
+  margin-left: 20px;
+  width: 2em;
+  height: 2em;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: stroke 0.3s, fill 0.3s;
+}
+
+.bookmark-checkbox__icon-back {
+  stroke: #333;
+  transition: transform 0.3s;
+}
+
+.bookmark-checkbox__icon-check {
+  stroke: #fff;
+  stroke-dasharray: 16;
+  stroke-dashoffset: 16;
+  transition: stroke-dashoffset 0.3s, transform 0.3s;
+  transform: translateX(2px);
+}
+
+.bookmark-checkbox__input:checked
++ .bookmark-checkbox__label
+.bookmark-checkbox__icon {
+  fill: #ff5a5f;
+}
+
+.bookmark-checkbox__input:checked
++ .bookmark-checkbox__label
+.bookmark-checkbox__icon-back {
+  stroke: #ff5a5f;
+  transform: scale(1.1);
+  animation: bookmark-pop 0.4s ease;
+}
+
+.bookmark-checkbox__input:checked
++ .bookmark-checkbox__label
+.bookmark-checkbox__icon-check {
+  stroke-dashoffset: 0;
+  transition-delay: 0.2s;
+}
+
+@keyframes bookmark-pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1.1);
+  }
+}
+/* book mark */
+
+element.style {
+  background: #fff;
+  border: 1px solid #19192c;
+}
+
+.bg-black.text-white.p-6.rounded-lg.w-full.max-w-md.font-mono {
+  max-width: 70rem;
+  margin: auto;
+}
+
+/* 댓글 */
+.mantine-9rx0rd {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.mantine-18l6s08 {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 200%;
+  border-top-left-radius: 200%;
+  border-top-right-radius: 200%;
+  border-bottom-right-radius: 200%;
+  border-bottom-left-radius: 200%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid #dee2e6;
+}
+.mantine-18l6s09 {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 200%;
+  border-top-left-radius: 200%;
+  border-top-right-radius: 200%;
+  border-bottom-right-radius: 200%;
+  border-bottom-left-radius: 200%;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid #dee2e6;
+  justify-content: center;
+  align-items: center;
+}
+
+.mantine-9p81l6 {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  color: #495057;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  line-height: 1.5;
+  text-underline-position: under;
+}
+.mantine-9p81l6:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-9p81l6:focus:not(:focus-visible) {
+  outline: 0;
+}
+.mantine-1uguyhf {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.5rem;
+}
+.mantine-1q4x896 {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  color: #868e96;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  text-underline-position: under;
+}
+.mantine-1q4x896:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-1q4x896:focus:not(:focus-visible) {
+  outline: 0;
+}
+.mantine-1yjkc96 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+.mantine-1ryt1ht {
+  white-space: nowrap;
+  height: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+.mantine-19ok7fu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 0.625rem;
+  margin-right: 6px;
+}
+.mantine-19ok7fu svg {
+  width: 14px;
+  height: 14px;
+}
+.mantine-k7c4r8 {
+  -webkit-tap-highlight-color: transparent;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  font-size: 1rem;
+  background-color: transparent;
+  text-align: left;
+  color: #000;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-sizing: border-box;
+  height: 2.25rem;
+  padding-left: calc(1.125rem / 1.5);
+  padding-right: 1.125rem;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  display: inline-block;
+  width: auto;
+  border-radius: 2rem;
+  font-weight: 600;
+  position: relative;
+  line-height: 1;
+  font-size: 0.875rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: pointer;
+  border: 0.0625rem solid #ced4da;
+  background-color: #fff;
+  color: #000;
+  color: #212529;
+  padding-left: 18px;
+}
+.mantine-k7c4r8:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-k7c4r8:focus:not(:focus-visible) {
+  outline: 0;
+}
+.mantine-k7c4r8:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-k7c4r8:focus:not(:focus-visible) {
+  outline: 0;
+}
+@media (hover: hover) {
+  .mantine-k7c4r8:hover {
+    background-color: #f8f9fa;
+  }
+}
+@media (hover: none) {
+  .mantine-k7c4r8:active {
+    background-color: #f8f9fa;
+  }
+}
+.mantine-k7c4r8:active {
+  -webkit-transform: translateY(0.0625rem);
+  -moz-transform: translateY(0.0625rem);
+  -ms-transform: translateY(0.0625rem);
+  transform: translateY(0.0625rem);
+}
+.mantine-k7c4r8:disabled,
+.mantine-k7c4r8[data-disabled] {
+  border-color: transparent;
+  background-color: #e9ecef;
+  color: #adb5bd;
+  cursor: not-allowed;
+  background-image: none;
+  pointer-events: none;
+}
+.mantine-k7c4r8:disabled:active,
+.mantine-k7c4r8[data-disabled]:active {
+  -webkit-transform: none;
+  -moz-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+.mantine-k7c4r8[data-loading] {
+  pointer-events: none;
+}
+.mantine-k7c4r8[data-loading]::before {
+  content: "";
+  position: absolute;
+  top: -0.0625rem;
+  right: -0.0625rem;
+  left: -0.0625rem;
+  bottom: -0.0625rem;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 2rem;
+  cursor: not-allowed;
+}
+.mantine-1qj7q0z {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: 2.25rem;
+  pointer-events: none;
+}
+.mantine-1ttseea {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  gap: 0;
+  width: 100%;
+  min-width: 0;
+}
+.mantine-2j9uwr {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 30px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+.mantine-18l6s08 {
+  -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 2rem;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  width: 2.375rem;
+  min-width: 2.375rem;
+  height: 2.375rem;
+  border: 1px solid #dee2e6;
+}
+.mantine-18l6s08:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-18l6s08:focus:not(:focus-visible) {
+  outline: 0;
+}
+.mantine-1l47z8p {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  gap: 0;
+}
+.mantine-824czz {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+}
+.mantine-3qdwx9 {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  color: #495057;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  line-height: 1.5;
+  text-underline-position: under;
+}
+.mantine-3qdwx9:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-3qdwx9:focus:not(:focus-visible) {
+  outline: 0;
+}
+.mantine-1jlwn9k {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 100%;
+  letter-spacing: normal;
+}
+.mantine-11jjpd0 {
+  -webkit-tap-highlight-color: transparent;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+  "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+  "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+  sans-serif;
+  font-size: 0.6875rem;
+  height: 25px;
+  line-height: calc(1.25rem - 0.125rem);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding: 0 calc(1rem / 1.5);
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  text-transform: uppercase;
+  border-radius: 0.25rem;
+  font-weight: 700;
+  letter-spacing: 0.015625rem;
+  cursor: inherit;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  background: rgba(229, 249, 241, 1);
+  color: #00894f;
+  border: 0.0625rem solid transparent;
+  text-transform: none;
+  padding: 0 8px;
+}
+.mantine-11jjpd0:focus {
+  outline-offset: 0.125rem;
+  outline: 0.125rem solid #212529;
+}
+.mantine-11jjpd0:focus:not(:focus-visible) {
+  outline: 0;
+}
+.mantine-6va1do {
+  margin-top: 0.5rem;
+}
+.mantine-12kvhdu {
+  margin-top: 0.75rem;
+}
+.mantine-1qj7haw {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+.mantine-1qj7haw > * {
+  box-sizing: border-box;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+}
+.mantine-17p85na {
+  padding-left: 28px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.75rem;
+}
+.mantine-17p85na:not(.mantine-17p85na:first-of-type) .re-comment-arrow {
+  padding-top: 36px;
+}
+.mantine-17p85na:not(.mantine-17p85na:first-of-type) .re-comment {
+  padding-top: 24px;
+  border-top: 1px solid #e9ecef;
+}
+.mantine-155ln8z {
+  left: 0;
+  font-size: 0;
+  position: absolute;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+.mantine-5n4x4z {
+  width: 100%;
+}
+.mantine-11k5015 {
+  border-radius: 16px;
+  border: 1px solid #e9ecef;
+  padding: 1.5rem;
+}
+h1 {
+  font-size: 2em;
+}
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+a {
+  background: 0 0;
+  text-decoration-skip: objects;
+}
+a:active,
+a:hover {
+  outline-width: 0;
+}
+b {
+  font-weight: bolder;
+}
+code {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+img {
+  border-style: none;
+  vertical-align: middle;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+button {
+  font-family: sans-serif;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+button {
+  overflow: visible;
+}
+button {
+  text-transform: none;
+}
+[type="reset"],
+[type="submit"],
+button {
+  -webkit-appearance: button;
+}
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner,
+button::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring,
+button:-moz-focusring {
+  outline: 0.0625rem dotted ButtonText;
+}
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+[type="search"] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+}
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  -moz-appearance: button;
+  -ms-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+::after,
+::before {
+  box-sizing: border-box;
+}
+html {
+  -webkit-print-color-scheme: light;
+  color-scheme: light;
+}
+q {
+  quotes: none;
+}
+q:after,
+q:before {
+  content: none;
+}
+
+.answer-name-text {
+  font-size: 20px;
+}
+/* 댓글 */
+
+.red-button-size {
+  height: 35px;
+}
+
+.question-answer {
+  font-size: 30px;
+  font-weight: 900;
+}
+
+#answer-title-text {
+  margin-top: 4rem;
+}
+
+#user-profile-image {
+  max-width: 200%;
+}
+</style>

--- a/frontend/src/components/qna/QnaDetailComponent.vue
+++ b/frontend/src/components/qna/QnaDetailComponent.vue
@@ -6,7 +6,7 @@
           <div class="flex justify-between">
             <div class="question-answer mb-5 build-section-card-title">
               Q.
-              RestController 이렇게 쓰면 안되나요
+              {{ qnaDetail.title }}
             </div>
             <div
                 class="w-16 h-8 transition"
@@ -17,6 +17,7 @@
         </div>
         <div class="" style="font-size: 13px">
           <div>
+            <p>{{ qnaDetail.content }}</p>
             <aside class="bg-black text-white p-6 rounded-lg w-full max-w-md font-mono">
               <div class="flex justify-between items-center">
                 <div class="flex space-x-2 text-red-500">
@@ -24,8 +25,9 @@
                   <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
                   <div class="w-3 h-3 rounded-full bg-green-500"></div>
                 </div>
-                <p class="text-sm">spring</p>
+                <p class="text-sm">{{ qnaDetail.superCategoryName }}</p>
               </div>
+
               <div class="mt-4">
                 <p class="text-green-400">@RestController</p>
                 <p class="text-green-400">@RequestMapping("/test")</p>
@@ -78,128 +80,13 @@
           </div>
         </div>
       </div>
-      <div class="answer-write-component"></div>
-      <div class="answer-component qna-background color">
-<!--        <QnaAnswerDetailComponent-->
-<!--            v-for="qnaAnswer in qnaStore.qnaAnswers"-->
-<!--            :key="qnaAnswer.id"-->
-<!--            v-bind:qnaAnswer="qnaAnswer"-->
-<!--        />-->
-      </div>
-      <div class="ripple-component">
-        <div class="mantine-17p85na">
-          <div class="re-comment-arrow mantine-155ln8z">
-            <svg
-                aria-hidden="true"
-                focusable="false"
-                data-prefix="fas"
-                data-icon="arrow-turn-down-right"
-                class="svg-inline--fa fa-arrow-turn-down-right"
-                role="img"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 512 512"
-                style="font-size: 16px; color: #dee2e6"
-            >
-              <path
-                  fill="currentColor"
-                  d="M64 64c0-17.7-14.3-32-32-32S0 46.3 0 64V224c0 53 43 96 96 96H402.7l-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 256H96c-17.7 0-32-14.3-32-32V64z"
-              ></path>
-            </svg>
-          </div>
-          <div class="re-comment mantine-5n4x4z">
-            <div class="mantine-5n4x4z">
-              <div class="mantine-Stack-root mantine-1ttseea">
-                <div class="mantine-2j9uwr">
-                  <div class="mantine-1uguyhf">
-                    <a
-                        class="mantine-Avatar-root mantine-18l6s08"
-                        href="https://www.inflearn.com/users/14769/@weekendcode"
-                    ><img
-                        class="mantine-9rx0rd mantine-Avatar-image"
-                        src="https://cdn.inflearn.com/public/users/thumbnails/14769/aa751976-0548-441b-9084-d71ff6327348?w=76"
-                        alt="주말코딩님의 프로필 이미지"
-                    /></a>
-                    <div class="mantine-Stack-root mantine-1l47z8p">
-                      <div class="mantine-824czz">
-                        <a
-                            class="mantine-Text-root mantine-3qdwx9"
-                            href="https://www.inflearn.com/users/14769/@weekendcode"
-                        >MR KIM</a
-                        >
-                        <div class="mantine-Badge-root mantine-11jjpd0">
-                              <span class="mantine-1jlwn9k mantine-Badge-inner"
-                              >답변자</span
-                              >
-                        </div>
-                      </div>
-                      <p class="mantine-Text-root mantine-1q4x896">
-                        2024. 09. 04. 12:06
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div class="mantine-6va1do">
-                  <div class="markdown-body mantine-0">
-                    <p>
-                      저 Child()라는 것이 자식클래스에 생성자를 넣고 싶으신 것 같은데,
-                      내부 코드까지 다 작성해주셔야 알 수 있습니다. 번거롭더라도 전체
-                      코드예시를 주시면 좋겠습니다.
-                    </p>
-                    <p>&nbsp;</p>
-                    <p>
-                      Child로 생성한 객체의 인스턴스 변수 x가 10으로 세팅되려면,
-                      말씀하신 대로 생성자를 통해서 하면 정상적으로 동작하긴 합니다.
-                    </p>
-                    <p>
-                      예를 들어 자식클래스(Child) 안 쪽에 아래와 같이 추가하면 Child의
-                      x값도 10이 됩니다.
-                    </p>
-                    <p>&nbsp;</p>
-                  </div>
-                </div>
-                <div class="mantine-12kvhdu">
-                  <div class="mantine-Group-root mantine-1qj7haw">
-                    <button
-                        class="mantine-UnstyledButton-root mantine-Button-root mantine-k7c4r8"
-                        type="button"
-                        data-button="true"
-                        aria-label="답글 작성하기"
-                    >
-                      <div class="mantine-1yjkc96 mantine-Button-inner">
-                            <span
-                                class="mantine-Button-icon mantine-Button-leftIcon mantine-19ok7fu"
-                            ><svg
-                                aria-hidden="true"
-                                focusable="false"
-                                data-prefix="far"
-                                data-icon="comment"
-                                class="svg-inline--fa fa-comment"
-                                role="img"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 512 512"
-                                style="font-size: 14px; color: inherit"
-                            >
-                                <path
-                                    fill="currentColor"
-                                    d="M123.6 391.3c12.9-9.4 29.6-11.8 44.6-6.4c26.5 9.6 56.2 15.1 87.8 15.1c124.7 0 208-80.5 208-160s-83.3-160-208-160S48 160.5 48 240c0 32 12.4 62.8 35.7 89.2c8.6 9.7 12.8 22.5 11.8 35.5c-1.4 18.1-5.7 34.7-11.3 49.4c17-7.9 31.1-16.7 39.4-22.7zM21.2 431.9c1.8-2.7 3.5-5.4 5.1-8.1c10-16.6 19.5-38.4 21.4-62.9C17.7 326.8 0 285.1 0 240C0 125.1 114.6 32 256 32s256 93.1 256 208s-114.6 208-256 208c-37.1 0-72.3-6.4-104.1-17.9c-11.9 8.7-31.3 20.6-54.3 30.6c-15.1 6.6-32.3 12.6-50.1 16.1c-.8 .2-1.6 .3-2.4 .5c-4.4 .8-8.7 1.5-13.2 1.9c-.2 0-.5 .1-.7 .1c-5.1 .5-10.2 .8-15.3 .8c-6.5 0-12.3-3.9-14.8-9.9c-2.5-6-1.1-12.8 3.4-17.4c4.1-4.2 7.8-8.7 11.3-13.5c1.7-2.3 3.3-4.6 4.8-6.9c.1-.2 .2-.3 .3-.5z"
-                                ></path></svg></span
-                            ><span class="mantine-1ryt1ht mantine-Button-label">답글</span>
-                      </div>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
     <footer></footer>
   </div>
 </template>
 
 <script>
-// import QnaAnswerDetailComponent from "@/components/qna/QnaAnswerDetailComponent.vue";
+import {formatDateTime} from "@/utils/FormatDate";
 
 export default {
   name: "QuestionDetailComponent",
@@ -208,9 +95,10 @@ export default {
     };
   },
   props: ["qnaDetail"],
-  methods: {},
+  methods: {
+    formatDateTime
+  },
   components: {
-    // QnaAnswerDetailComponent
   },
 };
 </script>

--- a/frontend/src/components/qna/QnaDetailHeader.vue
+++ b/frontend/src/components/qna/QnaDetailHeader.vue
@@ -1,0 +1,564 @@
+<template>
+  <div class="qna-detail-top-title">
+    <div class="circle">
+      <img id="user-profile-image" src="@/assets/logo.png" alt="Profile Image"/>
+    </div>
+    <span class="title-text">RestController와 view에 관한 질문</span>
+  </div>
+  <span class="username-text">Chanhee kim</span>
+  <span class="datetime-text">2024-09-05 18:04</span>
+  <div class="label-custom">
+    <div class="ui tag labels">
+      <br/>
+      <a class="test ui label"> Spring </a>
+      <a class="ui label"> MVC pattern </a>
+    </div>
+  </div>
+  <div class="qna-detail-top-items">
+    <div class="like-dislike-container">
+      <div class="icons-box">
+        <div class="icons">
+          <label class="btn-label" for="like-checkbox">
+            <span class="like-text-content">123</span>
+            <input class="input-box" id="like-checkbox" type="checkbox"/>
+            <svg
+                class="svgs"
+                id="icon-like-solid"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+            >
+              <path
+                  d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"
+              ></path>
+            </svg>
+            <svg
+                class="svgs"
+                id="icon-like-regular"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+            >
+              <path
+                  d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"
+              ></path>
+            </svg>
+            <div class="fireworks">
+              <div class="checked-like-fx"></div>
+            </div>
+          </label>
+        </div>
+        <div class="icons">
+          <label class="btn-label" for="dislike-checkbox">
+            <input
+                class="input-box"
+                id="dislike-checkbox"
+                type="checkbox"
+            />
+            <div class="fireworks">
+              <div class="checked-dislike-fx"></div>
+            </div>
+            <svg
+                class="svgs"
+                id="icon-dislike-solid"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+            >
+              <path
+                  d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"
+              ></path>
+            </svg>
+            <svg
+                class="svgs"
+                id="icon-dislike-regular"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+            >
+              <path
+                  d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"
+              ></path>
+            </svg>
+            <span class="dislike-text-content">4</span>
+          </label>
+        </div>
+      </div>
+      <div class="bookmark-checkbox">
+        <input
+            type="checkbox"
+            id="bookmark-toggle"
+            class="bookmark-checkbox__input"
+        />
+        <label for="bookmark-toggle" class="bookmark-checkbox__label">
+          <svg class="bookmark-checkbox__icon" viewBox="0 0 24 24">
+            <path
+                class="bookmark-checkbox__icon-back"
+                d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"
+            ></path>
+            <path class="bookmark-checkbox__icon-check" d="M8 11l3 3 5-5"></path>
+          </svg>
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+</script>
+
+<style>
+.qna-detail-top-title {
+  display: flex;
+  align-items: center;
+}
+
+.qna-detail-top-items {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.circle {
+  margin-left: 25px;
+  margin-bottom: 10px;
+  width: 120px;
+  height: 120px;
+  overflow: hidden;
+  border-radius: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center
+}
+
+.circle img {
+  width: 200%;
+  height: auto
+}
+
+img {
+  max-width: 200%;
+  height: auto
+}
+
+.title-text {
+  font-family: auto;
+  margin-left: 50px;
+  font-size: 43px;
+  font-weight: 900
+}
+
+.username-text {
+  margin-left: 20px;
+  margin-bottom: 10px;
+  font-size: 20px;
+  font-weight: 900
+}
+
+.datetime-text {
+  margin-left: 10px;
+  margin-bottom: 10px;
+  font-size: 16px;
+  font-weight: 600
+}
+
+.label-custom {
+  margin-left: 20px
+}
+
+.like-dislike-container {
+  --dark-grey: #353535;
+  --middle-grey: #767676;
+  --border-radius-icon: 50px;
+  position: relative;
+  display: flex;
+  text-align: center;
+  flex-direction: row;
+  align-items: center;
+  cursor: default;
+  color: var(--dark-grey);
+  opacity: .9;
+  margin-left: auto;
+  padding: 0;
+  font-weight: 600;
+  background: var(--lightest-grey);
+  max-width: max-content;
+  border-radius: var(--border-radius-main);
+  box-shadow: var(--shadow);
+  transition: .2s ease all
+}
+
+.like-dislike-container:hover {
+  box-shadow: var(--shadow-active)
+}
+
+.like-dislike-container .text-content {
+  margin-bottom: 1rem;
+  font-size: 18px;
+  line-height: 1.6;
+  cursor: default
+}
+
+.like-dislike-container .icons-box {
+  display: flex
+}
+
+.like-dislike-container .icons {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: .6;
+  margin: 0 .5rem;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid var(--middle-grey);
+  border-radius: var(--border-radius-icon);
+  transition: .2s ease all
+}
+
+.like-dislike-container .icons:hover {
+  opacity: .9;
+  box-shadow: var(--shadow)
+}
+
+.like-dislike-container .icons:active {
+  opacity: .9;
+  box-shadow: var(--shadow-active)
+}
+
+.like-dislike-container .icons .btn-label {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 .5rem;
+  cursor: pointer;
+  position: relative
+}
+
+.like-dislike-container .like-text-content {
+  border-right: .1rem solid var(--dark-grey);
+  padding: 0 .6rem 0 .5rem;
+  pointer-events: none
+}
+
+.like-dislike-container .dislike-text-content {
+  border-left: .1rem solid var(--dark-grey);
+  padding: 0 .5rem 0 .6rem;
+  pointer-events: none
+}
+
+.like-dislike-container .icons .svgs {
+  width: 1.3rem;
+  fill: #000;
+  box-sizing: content-box;
+  padding: 10px 10px;
+  transition: .2s ease all
+}
+
+.like-dislike-container .icons .input-box {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0
+}
+
+.like-dislike-container .icons #icon-like-regular {
+  display: block
+}
+
+.like-dislike-container .icons #icon-like-solid {
+  display: none
+}
+
+.like-dislike-container .icons:hover :is(#icon-like-solid,#icon-like-regular) {
+  animation: rotate-icon-like .7s ease-in-out both
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-regular {
+  display: none;
+  animation: checked-icon-like .5s
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ #icon-like-solid {
+  display: block;
+  animation: checked-icon-like .5s
+}
+
+.like-dislike-container .icons #icon-dislike-regular {
+  display: block;
+  transform: rotate(180deg)
+}
+
+.like-dislike-container .icons #icon-dislike-solid {
+  display: none;
+  transform: rotate(180deg)
+}
+
+.like-dislike-container .icons:hover :is(#icon-dislike-solid,#icon-dislike-regular) {
+  animation: rotate-icon-dislike .7s ease-in-out both
+}
+
+.like-dislike-container .icons #dislike-checkbox:checked ~ #icon-dislike-regular {
+  display: none;
+  animation: checked-icon-dislike .5s
+}
+
+.like-dislike-container .icons #dislike-checkbox:checked ~ #icon-dislike-solid {
+  display: block;
+  animation: checked-icon-dislike .5s
+}
+
+.like-dislike-container .icons .fireworks {
+  transform: scale(.4)
+}
+
+.like-dislike-container .icons #like-checkbox:checked ~ .fireworks > .checked-like-fx {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  right: 40px;
+  border-radius: 50%;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s fireworks-bang ease-out forwards, 1s fireworks-gravity ease-in forwards, 5s fireworks-position linear forwards;
+  animation-duration: 1.25s, 1.25s, 6.25s
+}
+
+.like-dislike-container .icons #dislike-checkbox:checked ~ .fireworks > .checked-dislike-fx {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  left: 40px;
+  border-radius: 50%;
+  box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+  animation: 1s fireworks-bang ease-out forwards, 1s fireworks-gravity ease-in forwards, 5s fireworks-position linear forwards;
+  animation-duration: 1.25s, 1.25s, 6.25s
+}
+
+@keyframes rotate-icon-like {
+  0% {
+    transform: rotate(0) translate3d(0, 0, 0)
+  }
+  25% {
+    transform: rotate(3deg) translate3d(0, 0, 0)
+  }
+  50% {
+    transform: rotate(-3deg) translate3d(0, 0, 0)
+  }
+  75% {
+    transform: rotate(1deg) translate3d(0, 0, 0)
+  }
+  100% {
+    transform: rotate(0) translate3d(0, 0, 0)
+  }
+}
+
+@keyframes rotate-icon-dislike {
+  0% {
+    transform: rotate(180deg) translate3d(0, 0, 0)
+  }
+  25% {
+    transform: rotate(183deg) translate3d(0, 0, 0)
+  }
+  50% {
+    transform: rotate(177deg) translate3d(0, 0, 0)
+  }
+  75% {
+    transform: rotate(181deg) translate3d(0, 0, 0)
+  }
+  100% {
+    transform: rotate(180deg) translate3d(0, 0, 0)
+  }
+}
+
+@keyframes checked-icon-like {
+  0% {
+    transform: scale(0);
+    opacity: 0
+  }
+  50% {
+    transform: scale(1.2) rotate(-10deg)
+  }
+}
+
+@keyframes checked-icon-dislike {
+  0% {
+    transform: scale(0) rotate(180deg);
+    opacity: 0
+  }
+  50% {
+    transform: scale(1.2) rotate(170deg)
+  }
+}
+
+@keyframes fireworks-position {
+  0%, 19.9% {
+    margin-top: 10%;
+    margin-left: 40%
+  }
+  20%, 39.9% {
+    margin-top: 40%;
+    margin-left: 30%
+  }
+  40%, 59.9% {
+    margin-top: 20%;
+    margin-left: 70%
+  }
+  60%, 79.9% {
+    margin-top: 30%;
+    margin-left: 20%
+  }
+  80%, 99.9% {
+    margin-top: 30%;
+    margin-left: 80%
+  }
+}
+
+@keyframes fireworks-gravity {
+  to {
+    transform: translateY(200px);
+    opacity: 0
+  }
+}
+
+@keyframes fireworks-bang {
+  to {
+    box-shadow: 114px -107.3333333333px #80f, 212px -166.3333333333px #a600ff, 197px -6.3333333333px #ff006a, 179px -329.3333333333px #30f, -167px -262.3333333333px #ff0062, 233px 65.6666666667px #ff008c, 81px 42.6666666667px #0051ff, -13px 54.6666666667px #00ff2b, -60px -183.3333333333px #0900ff, 127px -259.3333333333px #ff00e6, 117px -122.3333333333px #00b7ff, 95px 20.6666666667px #ff8000, 115px 1.6666666667px #0004ff, -160px -328.3333333333px #00ff40, 69px -242.3333333333px #000dff, -208px -230.3333333333px #ff0400, 30px -15.3333333333px #e6ff00, 235px -15.3333333333px #fb00ff, 80px -232.3333333333px #d5ff00, 175px -173.3333333333px #00ff3c, -187px -176.3333333333px #af0, 4px 26.6666666667px #ff6f00, 227px -106.3333333333px #f09, 119px 17.6666666667px #00ffd5, -102px 4.6666666667px #f08, -16px -4.3333333333px #00fff7, -201px -310.3333333333px #0fd, 64px -181.3333333333px #f700ff, -234px -15.3333333333px #00fffb, -184px -263.3333333333px #a0f, 96px -303.3333333333px #0037ff, -139px 10.6666666667px #0026ff, 25px -205.3333333333px #00ff2b, -129px -322.3333333333px #40ff00, -235px -187.3333333333px #26ff00, -136px -237.3333333333px #0091ff, -82px -321.3333333333px #6a00ff, 7px -267.3333333333px #ff00c8, -155px 30.6666666667px #0059ff, -85px -73.3333333333px #6a00ff, 60px -199.3333333333px #5f0, -9px -289.3333333333px #0fa, -208px -167.3333333333px #00ff80, -13px -299.3333333333px #ff0004, 179px -164.3333333333px #f04, -112px 12.6666666667px #0051ff, -209px -125.3333333333px #f0b, 14px -101.3333333333px #00ff95, -184px -292.3333333333px #f09, -26px -168.3333333333px #09ff00, 129px -67.3333333333px #0084ff, -17px -23.3333333333px #0059ff, 129px 34.6666666667px #7300ff, 35px -24.3333333333px #ffd900, -12px -297.3333333333px #ff8400, 129px -156.3333333333px #0dff00, 157px -29.3333333333px #1a00ff, -221px 6.6666666667px #ff0062, 0 -311.3333333333px #ff006a, 155px 50.6666666667px #0fa, -71px -318.3333333333px #0073ff
+  }
+}
+
+.bookmark-checkbox {
+  display: inline-block
+}
+
+.bookmark-checkbox__input {
+  display: none
+}
+
+.bookmark-checkbox__label {
+  cursor: pointer
+}
+
+.bookmark-checkbox__icon {
+  margin-left: 20px;
+  width: 2em;
+  height: 2em;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: stroke .3s, fill .3s
+}
+
+.bookmark-checkbox__icon-back {
+  stroke: #333;
+  transition: transform .3s
+}
+
+.bookmark-checkbox__icon-check {
+  stroke: #fff;
+  stroke-dasharray: 16;
+  stroke-dashoffset: 16;
+  transition: stroke-dashoffset .3s, transform .3s;
+  transform: translateX(2px)
+}
+
+.bookmark-checkbox__input:checked + .bookmark-checkbox__label .bookmark-checkbox__icon {
+  fill: #ff5a5f
+}
+
+.bookmark-checkbox__input:checked + .bookmark-checkbox__label .bookmark-checkbox__icon-back {
+  stroke: #ff5a5f;
+  transform: scale(1.1);
+  animation: bookmark-pop .4s ease
+}
+
+.bookmark-checkbox__input:checked + .bookmark-checkbox__label .bookmark-checkbox__icon-check {
+  stroke-dashoffset: 0;
+  transition-delay: .2s
+}
+
+@keyframes bookmark-pop {
+  0% {
+    transform: scale(1)
+  }
+  50% {
+    transform: scale(1.2)
+  }
+  100% {
+    transform: scale(1.1)
+  }
+}
+h1 {
+  font-size: 2em
+}
+
+a {
+  background: 0 0;
+  text-decoration-skip: objects
+}
+
+a:active, a:hover {
+  outline-width: 0
+}
+
+img {
+  border-style: none;
+  vertical-align: middle
+}
+
+svg:not(:root) {
+  overflow: hidden
+}
+
+[type=reset], [type=submit] {
+  -webkit-appearance: button
+}
+
+[type=button]::-moz-focus-inner, [type=reset]::-moz-focus-inner, [type=submit]::-moz-focus-inner {
+  border-style: none;
+  padding: 0
+}
+
+[type=button]:-moz-focusring, [type=reset]:-moz-focusring, [type=submit]:-moz-focusring {
+  outline: .0625rem dotted ButtonText
+}
+
+[type=checkbox], [type=radio] {
+  box-sizing: border-box;
+  padding: 0
+}
+
+[type=number]::-webkit-inner-spin-button, [type=number]::-webkit-outer-spin-button {
+  height: auto
+}
+
+[type=search] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none
+}
+
+[type=search]::-webkit-search-cancel-button, [type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  -moz-appearance: button;
+  -ms-appearance: button;
+  appearance: button;
+  font: inherit
+}
+
+::after, ::before {
+  box-sizing: border-box
+}
+
+#user-profile-image {
+  max-width: 200%
+}
+</style>

--- a/frontend/src/components/qna/QnaDetailHeaderComponent.vue
+++ b/frontend/src/components/qna/QnaDetailHeaderComponent.vue
@@ -3,15 +3,15 @@
     <div class="circle">
       <img id="user-profile-image" src="@/assets/logo.png" alt="Profile Image"/>
     </div>
-    <span class="title-text">RestController와 view에 관한 질문</span>
+    <span class="title-text">{{ qnaDetail.title }}</span>
   </div>
-  <span class="username-text">Chanhee kim</span>
-  <span class="datetime-text">2024-09-05 18:04</span>
+  <span class="username-text">{{ qnaDetail.nickname }}</span>
+  <span class="datetime-text">{{ formatDateTime(qnaDetail.createdAt) }}</span>
   <div class="label-custom">
     <div class="ui tag labels">
       <br/>
-      <a class="test ui label"> Spring </a>
-      <a class="ui label"> MVC pattern </a>
+      <a class="test ui label"> {{ qnaDetail.superCategoryName }} </a>
+      <a class="ui label">{{ qnaDetail.subCategoryName }}</a>
     </div>
   </div>
   <div class="qna-detail-top-items">
@@ -19,7 +19,7 @@
       <div class="icons-box">
         <div class="icons">
           <label class="btn-label" for="like-checkbox">
-            <span class="like-text-content">123</span>
+            <span class="like-text-content">{{ qnaDetail.likeCnt }}</span>
             <input class="input-box" id="like-checkbox" type="checkbox"/>
             <svg
                 class="svgs"
@@ -76,7 +76,7 @@
                   d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"
               ></path>
             </svg>
-            <span class="dislike-text-content">4</span>
+            <span class="dislike-text-content">{{ qnaDetail.hateCnt }}</span>
           </label>
         </div>
       </div>
@@ -101,7 +101,21 @@
 </template>
 
 <script>
+import {formatDateTime} from "@/utils/FormatDate";
 
+export default {
+  name: "QnaDetailHeaderComponent",
+  data() {
+    return {
+    };
+  },
+  props: ["qnaDetail"],
+  methods: {
+    formatDateTime
+  },
+  components: {
+  },
+};
 </script>
 
 <style>
@@ -114,7 +128,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 25px;
 }
 
 .circle {

--- a/frontend/src/components/qna/QnaListCardComponent.vue
+++ b/frontend/src/components/qna/QnaListCardComponent.vue
@@ -77,16 +77,15 @@
         </div>
       </div>
       <div class="qna-category-highlow">
-        <span>{{ qnaCard.superCategory }}</span>
+        <span>{{ qnaCard.superCategoryName }}</span>
         /
-        <span>{{ qnaCard.subCategory }}</span>
+        <span>{{ qnaCard.subCategoryName }}</span>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-
 import {formatDateTime} from "@/utils/FormatDate";
 
 export default {

--- a/frontend/src/components/qna/QnaListCardComponent.vue
+++ b/frontend/src/components/qna/QnaListCardComponent.vue
@@ -20,7 +20,7 @@
             </div>
           </div>
           <p class="mantine-Text-root mantine-1q4x896">
-            {{ qnaCard.createdAt }}
+            {{ formatDateTime(qnaCard.createdAt) }}
           </p>
         </div>
       </div>
@@ -86,14 +86,20 @@
 </template>
 
 <script>
+
+import {formatDateTime} from "@/utils/FormatDate";
+
 export default {
   name: "QnaCardComponent",
   data() {
     return {};
   },
   props: ["qnaCard"],
-  methods: {},
-  components: {},
+  methods: {
+    formatDateTime
+  },
+  components: {
+  },
 };
 </script>
 
@@ -106,8 +112,8 @@ export default {
   z-index: 5;
   box-shadow: 4px 4px 20px rgba(0, 0, 0, 0.3);
   border-radius: 10px;
-  width: 400px;
-  height: 220px;
+  width: 350px;
+  height: 200px;
   display: flex;
   flex-direction: column;
   transition: 200ms ease-in-out;

--- a/frontend/src/pages/QnaDetailPage.vue
+++ b/frontend/src/pages/QnaDetailPage.vue
@@ -1,0 +1,51 @@
+
+ <template>
+    <div class="inner">
+      <QnaDetailHeader/>
+      <QnaDetailComponent />
+    </div>
+
+</template>
+
+<script>
+import {mapStores} from "pinia";
+import {useQnaStore} from "@/store/useQnaStore";
+import { useRoute } from 'vue-router';
+import QnaDetailComponent from "@/components/qna/QnaDetailComponent.vue";
+import QnaDetailHeader from "@/components/qna/QnaDetailHeader.vue";
+
+export default {
+  name: "QnaDetailPage",
+
+  data() {
+    return {
+      id: 1
+    };
+  },
+  computed: {
+    ...mapStores(useQnaStore),
+
+  },
+  mounted() {
+    const route = useRoute();
+    console.log(route);
+    const qnaDetailId = this.$route.params.id;
+    this.qnaStore.getQnaDetail(qnaDetailId);
+  },
+  methods: {},
+  components: {
+    QnaDetailComponent,
+    QnaDetailHeader,
+  },
+};
+</script>
+
+<style>
+.inner {
+  width: 1200px;
+  height: max-content;
+  margin: auto;
+  padding: 10px;
+  background-color: #fff;
+}
+</style>

--- a/frontend/src/pages/QnaDetailPage.vue
+++ b/frontend/src/pages/QnaDetailPage.vue
@@ -1,39 +1,53 @@
-
- <template>
-    <div class="inner">
-      <QnaDetailHeader/>
-      <QnaDetailComponent />
-    </div>
+<template>
+  <div class="inner">
+    <QnaDetailHeader v-bind:qnaDetail=qnaStore.qnaDetail />
+    <QnaDetailComponent v-bind:qnaDetail=qnaStore.qnaDetail />
+    <div v-if="isLoading"></div>
+    <QnaAnswerDetailComponent v-else
+        v-for="qnaAnswer in qnaStore.qnaAnswers"
+        :key="qnaAnswer.id"
+        :qnaAnswer="qnaAnswer"
+    />
+  </div>
 
 </template>
 
 <script>
 import {mapStores} from "pinia";
 import {useQnaStore} from "@/store/useQnaStore";
-import { useRoute } from 'vue-router';
+import {useRoute} from 'vue-router';
 import QnaDetailComponent from "@/components/qna/QnaDetailComponent.vue";
-import QnaDetailHeader from "@/components/qna/QnaDetailHeader.vue";
+import QnaDetailHeader from "@/components/qna/QnaDetailHeaderComponent.vue";
+import QnaAnswerDetailComponent from "@/components/qna/QnaAnswerDetailComponent.vue";
 
 export default {
   name: "QnaDetailPage",
 
   data() {
     return {
-      id: 1
+      id: 1,
+      isLoading: true
     };
+  },
+  methods: {
+    async getQnaDetail(){
+      const route = useRoute();
+      const qnaDetailId = route.params.id;
+      await this.qnaStore.getQnaDetail(qnaDetailId);
+      this.isLoading=false
+    }
   },
   computed: {
     ...mapStores(useQnaStore),
 
   },
   mounted() {
-    const route = useRoute();
-    console.log(route);
-    const qnaDetailId = this.$route.params.id;
-    this.qnaStore.getQnaDetail(qnaDetailId);
+    this.getQnaDetail()
+
+
   },
-  methods: {},
   components: {
+    QnaAnswerDetailComponent,
     QnaDetailComponent,
     QnaDetailHeader,
   },
@@ -42,10 +56,11 @@ export default {
 
 <style>
 .inner {
-  width: 1200px;
-  height: max-content;
-  margin: auto;
-  padding: 10px;
-  background-color: #fff;
+  width: auto;
+  display: grid;
+  align-content: center;
+  align-items: center;
+  background-color: #ffffff;
+  margin: 50px 500px;
 }
 </style>

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="wrap">
+    <div class="qna-top">
+      <p id="main-title">QnA</p>
+      <p id="sub-title">당신의 에러를 해결해보세요</p>
+    </div>
     <div class="qna-inner">
-      <SortTypeComponent v-bind:sortType="sortType"/>
+      <SortTypeComponent @checkLatest="handleCheckLatest"
+                         @checkLike="handleCheckLike"/>
       <div class="qna-list-flex">
         <QnaCardComponent
             v-for="qnaCard in qnaStore.qnaCards"
@@ -22,16 +27,30 @@ import SortTypeComponent from "@/components/Common/SortTypeComponent.vue";
 export default {
   name: "QnaListPage",
   data() {
-    return {};
+    return {
+      selectedSort: null,
+      selectedPage: 0
+    };
   },
   computed: {
     ...mapStores(useQnaStore),
   },
   mounted() {
-    this.qnaStore.getQnaList();
-    console.log(this.qnaStore.qnaCards);
+    this.selectedSort = "latest";
   },
-  methods: {},
+  watch: {
+    selectedSort() {
+      this.qnaStore.getQnaList(this.selectedSort, this.selectedPage);
+    },
+  },
+  methods: {
+    handleCheckLatest() {
+      this.selectedSort="latest"
+    },
+    handleCheckLike() {
+      this.selectedSort="like"
+    },
+  },
   components: {
     QnaCardComponent,
     SortTypeComponent,
@@ -41,6 +60,24 @@ export default {
 
 
 <style>
+.qna-top {
+  height: 320px;
+  display: grid;
+  align-content: center;
+  align-items: center;
+  background-color: #e1e8e8;
+}
+
+#main-title {
+  text-align: center;
+  font-size: 40px;
+}
+
+#sub-title {
+  text-align: center;
+  font-size: 25px;
+}
+
 .qna-list-flex {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
@@ -48,6 +85,7 @@ export default {
   gap: 26px 36px;
   justify-items: center;
 }
+
 .qna-inner {
   width: auto;
   height: max-content;
@@ -55,5 +93,6 @@ export default {
   padding: 10px;
   background-color: #fff;
 }
+
 
 </style>

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -16,6 +16,9 @@
       </div>
     </div>
   </div>
+  <div class="qna-bottom">
+    <PaginationComponent @updatePage="handlePageUpdate"/>
+  </div>
 </template>
 
 <script>
@@ -23,6 +26,7 @@ import {mapStores} from "pinia";
 import {useQnaStore} from "@/store/useQnaStore";
 import QnaCardComponent from "@/components/qna/QnaListCardComponent.vue";
 import SortTypeComponent from "@/components/Common/SortTypeComponent.vue";
+import PaginationComponent from "@/components/Common/PaginationComponent.vue";
 
 export default {
   name: "QnaListPage",
@@ -37,23 +41,31 @@ export default {
   },
   mounted() {
     this.selectedSort = "latest";
+    this.selectedPage = 1;
   },
   watch: {
     selectedSort() {
-      this.qnaStore.getQnaList(this.selectedSort, this.selectedPage);
+      this.qnaStore.getQnaList(this.selectedSort, this.selectedPage-1);
+    },
+    selectedPage() {
+      this.qnaStore.getQnaList(this.selectedSort, this.selectedPage-1);
     },
   },
   methods: {
     handleCheckLatest() {
-      this.selectedSort="latest"
+      this.selectedSort = "latest"
     },
     handleCheckLike() {
-      this.selectedSort="like"
+      this.selectedSort = "like"
+    },
+    handlePageUpdate(newPage) {
+      this.selectedPage = newPage
     },
   },
   components: {
     QnaCardComponent,
     SortTypeComponent,
+    PaginationComponent,
   },
 };
 </script>
@@ -66,6 +78,13 @@ export default {
   align-content: center;
   align-items: center;
   background-color: #e1e8e8;
+}
+.qna-bottom {
+  height: 70px;
+  display: grid;
+  background-color: #ffffff;
+  justify-content: center;
+  align-content: space-around;
 }
 
 #main-title {

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="wrap">
+  <div class="custom-container">
     <div class="qna-top">
       <p id="main-title">QnA</p>
       <p id="sub-title">당신의 에러를 해결해보세요</p>

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -1,16 +1,22 @@
 <template>
-  <SortTypeComponent/>
-  <QnaCardComponent
-    v-for="qnaCard in qnaStore.qnaCards"
-    :key="qnaCard.id"
-    v-bind:qnaCard="qnaCard"
-  />
+  <div class="wrap">
+    <div class="qna-inner">
+      <SortTypeComponent v-bind:sortType="sortType"/>
+      <div class="qna-list-flex">
+        <QnaCardComponent
+            v-for="qnaCard in qnaStore.qnaCards"
+            :key="qnaCard.id"
+            v-bind:qnaCard="qnaCard"
+        />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
-import { mapStores } from "pinia";
-import { useQnaStore } from "@/store/useQnaStore";
-import QnaCardComponent from "@/components/qna/QnaCardComponent.vue";
+import {mapStores} from "pinia";
+import {useQnaStore} from "@/store/useQnaStore";
+import QnaCardComponent from "@/components/qna/QnaListCardComponent.vue";
 import SortTypeComponent from "@/components/Common/SortTypeComponent.vue";
 
 export default {
@@ -33,4 +39,21 @@ export default {
 };
 </script>
 
-<style></style>
+
+<style>
+.qna-list-flex {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  grid-template-rows: repeat(2, auto);
+  gap: 26px 36px;
+  justify-items: center;
+}
+.qna-inner {
+  width: auto;
+  height: max-content;
+  margin: 20px 100px;
+  padding: 10px;
+  background-color: #fff;
+}
+
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,7 +10,7 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: "/login", component: LoginPage, meta: { showHeader: false }},
-    { path: "/qna-list", component: QnaListPage },
+    { path: "/qna/list", component: QnaListPage },
     { path: "/qna/register", component: QnaRegisterComponent },
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPgae },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,8 @@ import WikiRegisterPage from "@/pages/wiki/WikiRegisterPage.vue";
 import ChatPgae from "@/pages/ChatPgae.vue";
 import QnaRegisterComponent from "@/components/qna/QnaRegisterComponent.vue";
 import OAuthLoginPage from "@/pages/OAuthLoginPage.vue";
+import QnaDetailPage from "@/pages/QnaDetailPage.vue";
+
 
 const router = createRouter({
   history: createWebHistory(),
@@ -12,6 +14,7 @@ const router = createRouter({
     { path: "/login", component: LoginPage, meta: { showHeader: false }},
     { path: "/qna/list", component: QnaListPage },
     { path: "/qna/register", component: QnaRegisterComponent },
+    { path: '/qna/detail/:id', component: QnaDetailPage },
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPgae },
     { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } }

--- a/frontend/src/store/useQnaStore.js
+++ b/frontend/src/store/useQnaStore.js
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { useRoute } from 'vue-router';
 import axios from "axios";
 
 axios.interceptors.response.use(
@@ -17,8 +18,12 @@ axios.interceptors.response.use(
 export const useQnaStore = defineStore("qna", {
   state: () => ({
     qnaCards: [],
-    qnaDetail: []
+    qnaDetail: [],
+    qnaAnswers: []
   }),
+
+
+
   actions: {
     async registerQna(myTitle, myText) {
       const data = {
@@ -55,6 +60,17 @@ export const useQnaStore = defineStore("qna", {
       } catch (error) {
         console.error("Error fetching Q&A list:", error);
       }
+    },
+    async getQnaDetail() {
+      const route = useRoute();
+      console.log(route);
+      console.log(route.params.id)
+      let res = await axios.get(
+          "/api/qna/detail?qnaBoardId="+ route.params.id, { withCredentials: true }
+      );
+      console.log(this.res);
+      this.qnaDetail = res.data.result;
+      console.log(this.getQnaDetail);
     },
   },
 });

--- a/frontend/src/store/useQnaStore.js
+++ b/frontend/src/store/useQnaStore.js
@@ -63,14 +63,11 @@ export const useQnaStore = defineStore("qna", {
     },
     async getQnaDetail() {
       const route = useRoute();
-      console.log(route);
-      console.log(route.params.id)
       let res = await axios.get(
           "/api/qna/detail?qnaBoardId="+ route.params.id, { withCredentials: true }
       );
-      console.log(this.res);
       this.qnaDetail = res.data.result;
-      console.log(this.getQnaDetail);
+      this.qnaAnswers = res.data.result.answers;
     },
   },
 });

--- a/frontend/src/store/useQnaStore.js
+++ b/frontend/src/store/useQnaStore.js
@@ -38,11 +38,11 @@ export const useQnaStore = defineStore("qna", {
       }
     },
 
-    async getQnaList() {
+    async getQnaList(sort, page) {
       const params = {
-        sort: "latest",
-        page: 0,
-        size: 10
+        sort: sort,
+        page: page,
+        size: 15
       };
 
       try {

--- a/frontend/src/store/useQnaStore.js
+++ b/frontend/src/store/useQnaStore.js
@@ -17,41 +17,44 @@ axios.interceptors.response.use(
 export const useQnaStore = defineStore("qna", {
   state: () => ({
     qnaCards: [],
+    qnaDetail: []
   }),
   actions: {
-    async getQnaList() {
-      let res = await axios.get(
-        "http://localhost:8080/qna/list"
-      );
-      if (typeof res.data === "string") {
-        this.qnaCards = JSON.parse(res.data).result;
-      } else {
-        this.qnaCards = res.data.result;
-      }
-
-      if (res.status === 200) {
-        console.log(this.qnaCards);
-        this.qnaCards = res.data.result;
-      }
-    },
     async registerQna(myTitle, myText) {
       const data = {
         title: myTitle,
         content: myText,
-        categoryId: 1
+        categoryId: 5
       };
 
       try {
-        let res = await axios.post("http://localhost:8080/qna", data);
-
-        if (res.status === 200) {
-          console.log("Q&A 등록 성공:", res.data);
-        }
+        await axios.post("http://localhost:8080/qna", data, {
+          headers: {
+            'Content-Type': 'application/json'
+          }, withCredentials: true
+        });
       } catch (error) {
-        console.error("Q&A 등록 실패:", error);
+        console.log("err")
       }
-    }
+    },
 
+    async getQnaList() {
+      const params = {
+        sort: "latest",
+        page: 0,
+        size: 10
+      };
+
+      try {
+        const res = await axios.get("http://localhost:8080/qna/list", {
+          params: params,
+          withCredentials: true
+        });
+        this.qnaCards = res.data.result;
+        console.log(this.qnaCards);
+      } catch (error) {
+        console.error("Error fetching Q&A list:", error);
+      }
+    },
   },
-
 });

--- a/frontend/src/utils/FormatDate.js
+++ b/frontend/src/utils/FormatDate.js
@@ -1,11 +1,11 @@
-// const formatDateTime = (dateTime) => {
-//   const date = new Date(dateTime);
+export const formatDateTime = (dateTime) => {
+  const date = new Date(dateTime);
 
-//   const year = date.getFullYear();
-//   const month = String(date.getMonth() + 1).padStart(2, "0"); // 월은 0부터 시작하므로 +1
-//   const day = String(date.getDate()).padStart(2, "0");
-//   const hours = String(date.getHours()).padStart(2, "0");
-//   const minutes = String(date.getMinutes()).padStart(2, "0");
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0"); // 월은 0부터 시작하므로 +1
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
 
-//   return `${year}-${month}-${day} ${hours}:${minutes}`;
-// };
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+};


### PR DESCRIPTION
## 연관 이슈
close #37 


## 작업 내용
- v-for를 이용해 질문에서 답변 리스트를, 답변에서 댓글 리스트를 가져올 수 있도록 로직 구현
- props를 이용하여 상위 컴포넌트에서 데이터를 받아, vue 파일로 출력 될 수 있도록 처리
- 백엔드의 상세조회 부분과 store를 이용하여 연동

참고 사항
- 현재 좋아요 표시 형태에 문제가 있으나, 후에 질문 및 답변 좋아요/싫어요 로직을 구현하는 과정에서 binding을 통해 해결 할 수 있을 것으로 예상,
- editer의 viewer를 사용해서 기존에 p태그 안에 넣어 놓은 각 내용(작성된 글)을 출력하는 로직 필요  


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)

