### PR TITLE
[Feat] 위키 상세조회 API (#27)

### DIFF
--- a/backend/src/main/java/org/example/backend/BackendApplication.java
+++ b/backend/src/main/java/org/example/backend/BackendApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 @EnableJpaAuditing
 public class BackendApplication {

--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -28,9 +28,9 @@ public enum BaseResponseStatus {
     // 위키 기능 - 5000
     WIKI_REGIST_FAIL(false, 5001,"위키 등록을 실패했습니다."),
     WIKI_TITLE_REGIST_FAIL(false, 5002,"제목을 입력해주세요."),
-    WIKI_CATEGORY_REGIST_FAIL(false, 5002,"카테고리를 입력해주세요."),
     WIKI_CONTENT_REGIST_FAIL(false, 5003,"내용을 입력해주세요."),
     WIKI_CONTENT_DUPLICATION_FAIL(false, 5004,"중복되는 위키입니다."),
+    WIKI_NOT_FOUND_DETAIL(false,5005,"위키 조회를 실패했습니다."),
     // 에러 아카이브 기능 - 6000
 
     // 에러 QnA 기능 - 7000

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -75,9 +75,9 @@ public class WikiController {
     @GetMapping("/detail")
     public BaseResponse<GetWikiDetailRes> detail(GetWikiDetailReq getWikiDetailReq,
                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        System.out.println(customUserDetails);
-//        if(customUserDetails ==null){
-//        }
-        return new BaseResponse<>(wikiService.detail(getWikiDetailReq,customUserDetails));
+
+        Long userId = (customUserDetails != null) ? customUserDetails.getUserId() : null;
+
+        return new BaseResponse<>(wikiService.detail(getWikiDetailReq,userId));
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -6,8 +6,10 @@ import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
+import org.example.backend.Wiki.Model.Req.GetWikiDetailReq;
 import org.example.backend.Wiki.Model.Req.GetWikiListReq;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
+import org.example.backend.Wiki.Model.Res.GetWikiDetailRes;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
 import org.example.backend.Wiki.Service.WikiService;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
 
 
 @RestController
@@ -66,5 +69,15 @@ public class WikiController {
         }
         List<WikiListRes> wikiList = wikiService.wikiList(getWikiListReq);
         return new BaseResponse<>(wikiList);
+    }
+
+    // 위키 상세 조회
+    @GetMapping("/detail")
+    public BaseResponse<GetWikiDetailRes> detail(GetWikiDetailReq getWikiDetailReq,
+                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        System.out.println(customUserDetails);
+//        if(customUserDetails ==null){
+//        }
+        return new BaseResponse<>(wikiService.detail(getWikiDetailReq,customUserDetails));
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
@@ -2,9 +2,11 @@ package org.example.backend.Wiki.Model.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.example.backend.Qna.model.Entity.QnaScrap;
 import org.example.backend.User.Model.Entity.User;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Builder
@@ -36,4 +38,7 @@ public class WikiContent {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "wikiContent", fetch = FetchType.LAZY)
+    private List<WikiScrap> wikiScrapList;
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiDetailReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiDetailReq.java
@@ -1,0 +1,11 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetWikiDetailReq {
+
+    private Long id;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiDetailRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiDetailRes.java
@@ -1,0 +1,17 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetWikiDetailRes {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String category;
+    private Integer version;
+    private Boolean checkScrap;
+
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface WikiContentRepository extends JpaRepository<WikiContent, Long> {
-    //Optional<WikiContent> findByUserId(Long id);
-    Optional<WikiContent> findByWikiId(Long id);
+
+    Optional<WikiContent> findByWikiIdAndVersion(Long wikiId, Integer version);
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
@@ -1,11 +1,11 @@
 package org.example.backend.Wiki.Repository;
 
-import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface WikiContentRepository extends JpaRepository<WikiContent, Long> {
-    Optional<Wiki> findByUserId(Long id);
+    //Optional<WikiContent> findByUserId(Long id);
+    Optional<WikiContent> findByWikiId(Long id);
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
@@ -1,7 +1,11 @@
 package org.example.backend.Wiki.Repository;
 
+import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface WikiContentRepository extends JpaRepository<WikiContent, Long> {
+    Optional<Wiki> findByUserId(Long id);
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiScrapRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiScrapRepository.java
@@ -1,0 +1,10 @@
+package org.example.backend.Wiki.Repository;
+
+import org.example.backend.Wiki.Model.Entity.WikiScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WikiScrapRepository extends JpaRepository<WikiScrap, Long> {
+    Optional<WikiScrap> findByUserIdAndWikiContentId(Long userId, Long wikiContentId);
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -99,30 +99,30 @@ public class WikiService {
     }
 
     // 위키 상세 조회
-    public GetWikiDetailRes detail(GetWikiDetailReq getWikiDetailReq, CustomUserDetails customUserDetails) {
+    public GetWikiDetailRes detail(GetWikiDetailReq getWikiDetailReq, Long userId) {
 
         Wiki wiki = wikiRepository.findById(getWikiDetailReq.getId()).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
-        WikiContent wikiContent = wikiContentRepository.findById(wiki.getId()).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
+        LatestWiki latestWikiId = wiki.getLatestWiki();
 
         GetWikiDetailRes wikiDetailRes = GetWikiDetailRes.builder()
                 .id(wiki.getId())
                 .title(wiki.getTitle())
                 .content(wiki.getLatestWiki().getContent())
                 .category(wiki.getCategory().getCategoryName())
-                .version(wikiContent.getVersion())
-                .checkScrap(ischeckScrap(wikiContent, customUserDetails))
+                .version(latestWikiId.getVersion())
+                .checkScrap(ischeckScrap(latestWikiId, userId))
                 .build();
         return wikiDetailRes;
 
     }
 
-    // 스크랩 여부 조회 메서드 //해당 컨텐츠의 스크랩 레포를 봐야함
-    private Boolean ischeckScrap(WikiContent wikiContent, CustomUserDetails customUserDetails) {
+    // 스크랩 여부 조회 메서드
+    private Boolean ischeckScrap(LatestWiki latestWiki, Long userId) {
 
-        if (customUserDetails == null) {
+        if (userId == null) {
             return false;
         }
-        return wikiScrapRepository.findByUserIdAndWikiContentId(customUserDetails.getUserId(), wikiContent.getId()).isPresent();
+        return wikiScrapRepository.findByUserIdAndWikiContentId(userId, latestWiki.getId()).isPresent();
 
     }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -12,13 +12,16 @@ import org.example.backend.User.Repository.UserRepository;
 import org.example.backend.Wiki.Model.Entity.LatestWiki;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
+import org.example.backend.Wiki.Model.Req.GetWikiDetailReq;
 import org.example.backend.Wiki.Model.Req.GetWikiListReq;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
+import org.example.backend.Wiki.Model.Res.GetWikiDetailRes;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
 import org.example.backend.Wiki.Repository.LatestWikiRepository;
 import org.example.backend.Wiki.Repository.WikiContentRepository;
 import org.example.backend.Wiki.Repository.WikiRepository;
+import org.example.backend.Wiki.Repository.WikiScrapRepository;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
@@ -34,6 +37,7 @@ public class WikiService {
     private final WikiContentRepository wikiContentRepository;
     private final LatestWikiRepository latestWikiRepository;
     private final UserRepository userRepository;
+    private final WikiScrapRepository wikiScrapRepository;
 
     public WikiRegisterRes register(WikiRegisterReq wikiRegisterReq, String thumbnail, CustomUserDetails customUserDetails
     ) {
@@ -93,4 +97,36 @@ public class WikiService {
                                 .build())
                 .collect(Collectors.toList());
     }
+
+    // 위키 상세 조회
+    public GetWikiDetailRes detail(GetWikiDetailReq getWikiDetailReq, CustomUserDetails customUserDetails) {
+
+        Wiki wiki = wikiRepository.findById(getWikiDetailReq.getId()).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
+        WikiContent wikiContent = wikiContentRepository.findById(wiki.getId()).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
+
+        GetWikiDetailRes wikiDetailRes = GetWikiDetailRes.builder()
+                .id(wiki.getId())
+                .title(wiki.getTitle())
+                .content(wiki.getLatestWiki().getContent())
+                .category(wiki.getCategory().getCategoryName())
+                .version(wikiContent.getVersion())
+                .checkScrap(ischeckScrap(wikiContent, customUserDetails))
+                .build();
+        return wikiDetailRes;
+
+    }
+
+    // 스크랩 여부 조회 메서드 //해당 컨텐츠의 스크랩 레포를 봐야함
+    private Boolean ischeckScrap(WikiContent wikiContent, CustomUserDetails customUserDetails) {
+
+        if (customUserDetails == null) {
+            return false;
+        }
+        return wikiScrapRepository.findByUserIdAndWikiContentId(customUserDetails.getUserId(), wikiContent.getId()).isPresent();
+
+    }
 }
+
+
+
+


### PR DESCRIPTION
## 연관 이슈
close #27


## 작업 내용
📌위키 상세 조회
- 위키(최신버전) 상세조회 기능 구현
- 로그인 한 유저일 시, 스크랩 여부 확인하고 T/F 반환
- 미로그인 유저일 시, 스크랩 여부 fale로 반환
- 제목, 내용, 카테고리, 버전, 스크랩 여부 반환

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/295a19ed-b8e2-4022-88d9-befa849c4ea1)

## 리뷰 요구사항 혹은 기타 (선택)
