### PR TITLE
[Feat] 포인트 내역 조회 API 구현 (#64)

### DIFF
--- a/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) ->
                 auth
                         .requestMatchers("/**").permitAll()
+                        .requestMatchers("/point").authenticated()
                         .anyRequest().authenticated()
         );
         http.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/org/example/backend/Point/Controller/PointController.java
+++ b/backend/src/main/java/org/example/backend/Point/Controller/PointController.java
@@ -7,16 +7,18 @@ import org.example.backend.Point.Service.PointService;
 import org.example.backend.Security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/point")
 public class PointController {
     private final PointService pointService;
 
-    @GetMapping("/point")
+    @GetMapping
     public BaseResponse<List<GetPointHistoryRes>> getPointHistory(@AuthenticationPrincipal CustomUserDetails customUserDetails, Integer page, Integer size){
         return new BaseResponse<>(pointService.getPointHistory(customUserDetails.getUserId(), page, size));
     }

--- a/backend/src/main/java/org/example/backend/Point/Controller/PointController.java
+++ b/backend/src/main/java/org/example/backend/Point/Controller/PointController.java
@@ -1,0 +1,25 @@
+package org.example.backend.Point.Controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.Point.Model.Res.GetPointHistoryRes;
+import org.example.backend.Point.Service.PointService;
+import org.example.backend.Security.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class PointController {
+    private final PointService pointService;
+
+    @GetMapping("/point")
+    public BaseResponse<List<GetPointHistoryRes>> getPointHistory(@AuthenticationPrincipal CustomUserDetails customUserDetails, Integer page, Integer size){
+        return new BaseResponse<>(pointService.getPointHistory(customUserDetails.getUserId(), page, size));
+    }
+
+
+}

--- a/backend/src/main/java/org/example/backend/Point/Model/Entity/PointDetail.java
+++ b/backend/src/main/java/org/example/backend/Point/Model/Entity/PointDetail.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.User.Model.Entity.User;
+import org.springframework.data.annotation.CreatedDate;
+
 import java.time.LocalDateTime;
 
 @Entity
@@ -24,7 +26,7 @@ public class PointDetail {
     @Column(nullable = false)
     private Integer point;
     @Column(nullable = false)
-    @Builder.Default
+    @CreatedDate
     private LocalDateTime createdAt = LocalDateTime.now();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/example/backend/Point/Model/Res/GetPointHistoryRes.java
+++ b/backend/src/main/java/org/example/backend/Point/Model/Res/GetPointHistoryRes.java
@@ -1,0 +1,16 @@
+package org.example.backend.Point.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class GetPointHistoryRes {
+    private Integer point;
+    private Boolean state; // true이면 적립, false 이면 차감
+    private String description; // 적립 이유
+    private LocalDateTime createdAt;
+
+}

--- a/backend/src/main/java/org/example/backend/Point/Repository/PointRepository.java
+++ b/backend/src/main/java/org/example/backend/Point/Repository/PointRepository.java
@@ -1,0 +1,10 @@
+package org.example.backend.Point.Repository;
+
+import org.example.backend.Point.Model.Entity.PointDetail;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointRepository extends JpaRepository<PointDetail, Long> {
+    Page<PointDetail> findAllByUserId(Long userId, Pageable pageable);
+}

--- a/backend/src/main/java/org/example/backend/Point/Service/PointService.java
+++ b/backend/src/main/java/org/example/backend/Point/Service/PointService.java
@@ -1,0 +1,35 @@
+package org.example.backend.Point.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Point.Model.Entity.PointDetail;
+import org.example.backend.Point.Model.Res.GetPointHistoryRes;
+import org.example.backend.Point.Repository.PointRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+    private final PointRepository pointRepository;
+
+    public List<GetPointHistoryRes> getPointHistory(Long userId, Integer page, Integer size){
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<PointDetail> pointDetailPage = pointRepository.findAllByUserId(userId, pageable);
+        List<GetPointHistoryRes> getPointHistoryResList = new ArrayList<>();
+        for ( PointDetail pointDetail : pointDetailPage ) {
+            getPointHistoryResList.add(GetPointHistoryRes.builder()
+                    .point(pointDetail.getPoint())
+                    .state(pointDetail.isState())
+                    .description(pointDetail.getDescription())
+                    .createdAt(pointDetail.getCreatedAt())
+                    .build());
+        }
+        return getPointHistoryResList;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #64 


## 작업 내용
**로그인한 사용자의 포인트 내역 조회**
  - 로그인한 사용자의 id로 PointDetail 테이블을 조회
  - 페이징 처리하여 반환
  - point, state(적립true/차감false), description, createdAt

```
{
    "code": 1000,
    "isSuccess": true,
    "message": "요청이 성공하였습니다.",
    "result": [
        {
            "point": 10,
            "state": true,
            "description": "질문글 작성",
            "createdAt": "2024-09-13T15:35:41"
        },
        {
            "point": 10,
            "state": true,
            "description": "질문글 작성",
            "createdAt": "2024-09-13T15:35:41"
        },
        {
            "point": 10,
            "state": true,
            "description": "질문글 작성",
            "createdAt": "2024-09-11T15:35:41"
        }
    ]
}
```

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
로그인한 사용자가 아닐 경우에 대한 처리는 spring security에서 설정함