### PR TITLE
[Feat] Spring Security 설정으로 로그인 ì설정으로 인가받지 못한 사용자 처리 (#185)

### DIFF
--- a/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/Config/SecurityConfig.java
@@ -3,11 +3,13 @@ package org.example.backend.Config;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Config.Filter.JwtFilter;
 import org.example.backend.Config.Filter.LoginFilter;
+import org.example.backend.Exception.CustomAuthenticationEntryPoint;
 import org.example.backend.Exception.CustomAuthenticationFailureHandler;
 import org.example.backend.Security.OAuth2LoginSuccessHandler;
 import org.example.backend.Util.JwtUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,7 +28,7 @@ import org.springframework.web.filter.CorsFilter;
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
         http.csrf(csrf -> csrf.disable());
@@ -50,9 +52,13 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((auth) ->
                 auth
-                        .requestMatchers("/**").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/chat/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/qna").authenticated()
+                        .anyRequest().permitAll()
         );
+
+        http.exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(customAuthenticationEntryPoint)); // 인가되지 않은 사용자가 요청을 보냈을 때 처리하는 handler
+
         http.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
         http.addFilterAt(new LoginFilter(jwtUtil, authenticationManager), UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/org/example/backend/Exception/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/org/example/backend/Exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package org.example.backend.Exception;
+
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final Gson gson = new Gson();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json; charset=UTF-8");
+        PrintWriter out = response.getWriter();
+        String jsonResponse = gson.toJson(new BaseResponse<>(BaseResponseStatus.USER_NOT_LOGIN));
+        out.print(jsonResponse);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #185 

## 작업 내용
스프링 시큐리티 설정으로 인가받지 않은 사용자가 인가가 필요한 API 호출시 예외 처리 설정

``` java
@Component
public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
    private final Gson gson = new Gson();

    @Override
    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
        response.setCharacterEncoding("UTF-8");
        response.setContentType("application/json; charset=UTF-8");
        PrintWriter out = response.getWriter();
        String jsonResponse = gson.toJson(new BaseResponse<>(BaseResponseStatus.USER_NOT_LOGIN));
        out.print(jsonResponse);
    }
}

```
## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b44ae721-4173-4996-9459-80072bbfffb4)


## 리뷰 요구사항 혹은 기타 (선택)
