### PR TITLE
[Feat] 포인트 내역 페이지 구현 (#62)

### DIFF
--- a/frontend/src/components/Common/PaginationComponent.vue
+++ b/frontend/src/components/Common/PaginationComponent.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="ui pagination menu">
+  <div v-show="isLoading" class="ui pagination menu">
+    <a class="item" @click="setPrevPage">&lt;&lt;</a>
     <a
         v-for="number in pageNumbers"
         :key="number"
@@ -8,24 +9,65 @@
     >
       {{ number }}
     </a>
+    <a class="item" @click="setNextPage">&gt;&gt;</a>
   </div>
 </template>
 
 <script>
 export default {
   name: "PaginationComponent",
+  props: ["totalPage"],
   data() {
     return {
       currentPage: 1,
-      pageNumbers: [1, 2, 3, 4, 5],
+      pageNumbers: [],
+      isLoading: false,
     };
   },
   methods: {
     setActivePage(number) {
       this.currentPage = number
-      this.$emit('updatePage',this.currentPage);
+      this.$emit('updatePage', this.currentPage);
+    },
+    setPrevPage() {
+      if (this.currentPage === 1) {
+        return;
+      }
+      this.currentPage--;
+      if (this.currentPage % 5 === 0) {
+        this.pageNumbers = [];
+        for (let page = this.currentPage - 4; page < this.currentPage + 1; page++) {
+          this.pageNumbers.push(page);
+        }
+      }
+      this.$emit('updatePage', this.currentPage);
+    },
+    setNextPage() {
+      if (this.currentPage === this.totalPage) {
+        return;
+      }
+      this.currentPage++;
+      if (this.currentPage % 5 === 1) {
+        this.pageNumbers = [];
+        for (let page = this.currentPage; page < this.currentPage + 5 ; page++) {
+          if (page > this.totalPage) {
+            break;
+          }
+          this.pageNumbers.push(page);
+        }
+      }
+      this.$emit('updatePage', this.currentPage);
     },
   },
+  created() {
+    for (let page = 1; page < this.totalPage + 1; page++) {
+      if (page > 5){
+        break;
+      }
+      this.pageNumbers.push(page);
+    }
+    this.isLoading = true;
+  }
 };
 </script>
 
@@ -41,6 +83,7 @@ export default {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
+
 .ui.menu {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/frontend/src/components/Point/PointHistoryComponent.vue
+++ b/frontend/src/components/Point/PointHistoryComponent.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="point-item">
+    <div class="description">
+      <p>{{ pointHistory.description }}</p>
+      <span>{{ pointHistory.createdAt.split("T")[0] }}</span>
+    </div>
+    <div class="points-value" :class="pointHistory.state ? 'positive' : 'negative'">{{ pointHistory.state ? "":"-" }}{{pointHistory.point}}P</div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PointHistoryComponent",
+  props: ["pointHistory"]
+}
+</script>
+
+
+<style scoped>
+.point-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.point-item:last-child {
+  border-bottom: none;
+}
+
+.description p {
+  margin-bottom: 5px;
+  font-size: 16px;
+  color: #333;
+}
+
+.description span {
+  font-size: 14px;
+  color: #999;
+}
+
+.points-value {
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.points-value.positive {
+  color: #1e88e5;
+}
+
+.points-value.negative {
+  color: #e53935;
+}
+</style>

--- a/frontend/src/components/Point/PointInfoComponent.vue
+++ b/frontend/src/components/Point/PointInfoComponent.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="container" >
+    <div class="point">
+      <a href="#" class="ranking">랭킹</a>
+      <span class="divider">|</span>
+      <a href="#" class="points">포인트 내역</a>
+    </div>
+
+    <div class="point-container">
+      <div class="my-ranking">
+        <h2>내 랭킹</h2>
+        <div class="ranking-info">
+          <p>순위: <strong>{{ pointStore.myPointRank.rank }}</strong></p>
+          <p>포인트: <strong>{{ pointStore.myPointRank.point }}P</strong></p>
+        </div>
+      </div>
+      <PointHistoryComponent v-for="(pointHistory, idx) in pointStore.pointHistoryList" :key="idx"
+                             :pointHistory="pointHistory"/>
+    </div>
+  </div>
+
+
+</template>
+
+<script>
+import PointHistoryComponent from "@/components/Point/PointHistoryComponent.vue";
+import {mapStores} from "pinia";
+import {usePointStore} from "@/store/usePointStore";
+
+export default {
+  name: "MyPointInfoComponent",
+  components: {PointHistoryComponent},
+  computed: {
+    ...mapStores(usePointStore),
+  }
+}
+</script>
+
+<style scoped>
+.container {
+  width: 80%;
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: #fff;
+  padding: 20px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+}
+
+.point {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  margin-bottom: 0;
+  font-size: 25px;
+  font-weight: bold;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 30px;
+}
+
+.point a {
+  text-decoration: none;
+  color: #666;
+  padding: 0 10px;
+}
+
+.point a:hover {
+  color: #1e88e5;
+}
+
+.point .ranking {
+  color: #aaa;
+}
+
+.point .points {
+  color: #333;
+}
+
+.divider {
+  font-size: 18px;
+  color: #ccc;
+  margin: 0 10px;
+}
+
+.point-container {
+  margin-top: 10px;
+  padding-top: 20px;
+  border-radius: 8px;
+  padding: 15px;
+}
+
+.my-ranking {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.my-ranking h2 {
+  font-size: 24px;
+  margin-bottom: 10px;
+  font-weight: 600 !important;
+}
+
+.my-ranking .ranking-info {
+  font-size: 18px;
+  color: #333;
+}
+
+.my-ranking .ranking-info p {
+  margin: 5px 0;
+}
+
+</style>

--- a/frontend/src/components/qna/QnaListCardComponent.vue
+++ b/frontend/src/components/qna/QnaListCardComponent.vue
@@ -103,7 +103,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 /* QnA card */
 .card {
   position: relative;

--- a/frontend/src/pages/PointPage.vue
+++ b/frontend/src/pages/PointPage.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="custom-container" style="text-align:center;">
+    <router-view v-show="isLoading"/>
+    <div v-if="!isLoading"></div>
+    <pagination-component v-else style="margin-top: 20px;" @updatePage="updatePage" :totalPage="pointStore.pointHistoryList[0].totalPage"/>
+  </div>
+
+</template>
+
+<script>
+
+import PaginationComponent from "@/components/Common/PaginationComponent.vue";
+import {mapStores} from "pinia";
+import {usePointStore} from "@/store/usePointStore";
+
+export default {
+  name: "PointPage" ,
+  components: {PaginationComponent},
+  computed: {
+    ...mapStores(usePointStore),
+  },
+  data(){
+    return {
+      isLoading: false,
+      page: 0,
+    }
+  },
+  methods: {
+    async getMyRank(){
+      await this.pointStore.getMyPointRanking();
+    },
+    updatePage(page){
+      this.page = page-1
+      this.getPointHistory();
+    },
+    async getPointHistory() {
+      await this.pointStore.getPointHistory(this.page);
+      this.isLoading = true;
+    },
+
+  },
+  mounted() {
+    this.getMyRank();
+    this.getPointHistory(this.page);
+
+  },
+}
+</script>
+
+<style scoped>
+
+</style>
+

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,8 @@ import WikiRegisterPage from "@/pages/WikiRegisterPage.vue";
 import ChatPage from "@/pages/ChatPage.vue";
 import QnaRegisterComponent from "@/components/qna/QnaRegisterComponent.vue";
 import OAuthLoginPage from "@/pages/OAuthLoginPage.vue";
+import PointPage from "@/pages/PointPage.vue";
+import PointInfoComponent from "@/components/Point/PointInfoComponent.vue";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -14,7 +16,10 @@ const router = createRouter({
     { path: "/qna/register", component: QnaRegisterComponent },
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPage },
-    { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } }
+    { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } },
+    { path: "/point", component: PointPage, children: [
+        { path: "info", component: PointInfoComponent },
+      ]},
   ]
 });
 

--- a/frontend/src/store/usePointStore.js
+++ b/frontend/src/store/usePointStore.js
@@ -1,0 +1,37 @@
+import {defineStore} from "pinia";
+import axios from "axios";
+
+const backend = "/api";
+
+export const usePointStore = defineStore("point", {
+    state: () => ({
+        pointHistoryList: [
+            {
+                point: 1000,
+                state: false,
+                description: "이유",
+                createdAt: "YYYY-MM-DDTHH:MM:SS",
+                totalPage: 0,
+            }
+        ],
+        myPointRank: {
+            point: 0,
+            rank: 1,
+        }
+
+    }),
+    actions: {
+        async getPointHistory(page) {
+            const size = 10;
+            const res = await axios.get(`${backend}/point?page=${page}&size=${size}`, {withCredentials: true})
+            console.log(res.data.result);
+            this.pointHistoryList = res.data.result;
+        },
+        async getMyPointRanking() {
+            const res = await axios.get(`${backend}/point/myrank`, {withCredentials: true})
+            this.myPointRank = res.data.result;
+
+        }
+
+    }
+})


### PR DESCRIPTION
## 연관 이슈
close #62 


## 작업 내용
✅ 포인트 내역 컴포넌트 구현
  - 포인트
  - 적립/차감 여부
  - 날짜
  - 이유
  
✅ 자신의 총 포인트와 랭킹을 표시
✅ 포인트 조회 페이지 구현
  - 페이징 처리


## 스크린샷 (선택)
![포인트 내역 페이지](https://github.com/user-attachments/assets/c3f4f56d-e63d-403b-b06e-9e17cace1b4f)

## 리뷰 요구사항 혹은 기타 (선택)
PaginationComponent 수정함
페이지는 최대 5개 까지 표시되고, totalPage를 상위 컴포넌트 혹은 페이지에서 받아서 5개보다 페이지가 많으면 <<,   >> 으로 처리