### PR TITLE
[Fix] 마이페이지 버튼 드롭다운으로 수정

### DIFF
--- a/frontend/src/components/Header/HeaderComponent.vue
+++ b/frontend/src/components/Header/HeaderComponent.vue
@@ -1,15 +1,17 @@
 <template>
     <header>
         <div class="logo">
-            <h1>Enadu</h1>
+            <router-link :to="{ path: '/' }"><h1>Enadu</h1></router-link>
         </div>
         <nav class="navigation">
             <ul>
-                <li><a href="#"><i class="fas fa-code"></i> 아카이브</a></li>
+                <li><router-link :to="{ path: '/' }"><i class="fas fa-code"></i> 아카이브</router-link></li>
                 <li class="divider">|</li>
-                <li><a href="#"><i class="fas fa-book"></i> 위키</a></li>
+                <li><router-link :to="{ path: '/' }"><i class="fas fa-book"></i> 위키</router-link></li>
                 <li class="divider">|</li>
-                <li><a href="#"><i class="fas fa-question-circle"></i> QnA</a></li>
+                <li>
+                    <router-link :to="{ path: '/qna/list' }"><i class="fas fa-question-circle"></i> QnA</router-link>
+                </li>
             </ul>
         </nav>
         <div class="search-bar">
@@ -17,48 +19,60 @@
             <button @click="showAlert"><i class="fas fa-search"></i></button>
         </div>
         <div class="auth-navigation">
-          <div v-if="!isLoggedIn">
-            <ul>
-                <li><router-link :to="{ path: '/login', query: { mode: 'login' } }">로그인</router-link></li>
-                <li class="divider">|</li>
-                <li><router-link :to="{ path: '/login', query: { mode: 'signup' } }">회원가입</router-link></li>
-            </ul>
-          </div>
-          <div v-else>
-            <ul>
-                <li><a href="#" @click.prevent="logout">로그아웃</a></li>
-                <li class="divider">|</li>
-                <li><a href="#">포인트</a></li>
-                <li class="divider">|</li>
-                <li><a href="#">마이페이지</a></li>
-            </ul>
-          </div>
+            <div v-if="!isLoggedIn">
+                <ul>
+                    <li>
+                        <router-link :to="{ path: '/login', query: { mode: 'login' } }">로그인</router-link>
+                    </li>
+                    <li class="divider">|</li>
+                    <li>
+                        <router-link :to="{ path: '/login', query: { mode: 'signup' } }">회원가입</router-link>
+                    </li>
+                </ul>
+            </div>
+            <div v-else>
+                <ul>
+                    <li><a href="#" @click.prevent="logout">로그아웃</a></li>
+                    <li class="divider">|</li>
+                    <li class="dropdown">
+                        <router-link :to="{ path: '/' }"><i class="fas fa-caret-down"></i> 마이페이지</router-link>
+                        <ul class="dropdown-menu">
+                            <li><router-link :to="{ path: '/' }"><i class="fas fa-user"></i> 회원 정보</router-link></li>
+                            <li><router-link :to="{ path: '/' }"><i class="fas fa-file-alt"></i> 작성 내역</router-link></li>
+                            <li><router-link :to="{ path: '/' }"><i class="fas fa-bookmark"></i> 스크랩 내역</router-link></li>
+                            <li><router-link :to="{ path: '/' }"><i class="fas fa-coins"></i> 포인트 및 랭킹</router-link></li>
+                            <li><router-link :to="{ path: '/chat' }"><i class="fas fa-comments"></i> 채팅</router-link></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
         </div>
     </header>
 </template>
 
 <script>
-  import { mapStores } from "pinia";
-  import { useUserStore } from "@/store/useUserStore";
-  export default {
+import {mapStores} from "pinia";
+import {useUserStore} from "@/store/useUserStore";
+
+export default {
     name: "HeaderComponent",
     computed: {
-      ...mapStores(useUserStore),
-      isLoggedIn() {
-        return this.userStore.isLoggedIn;
-      },
+        ...mapStores(useUserStore),
+        isLoggedIn() {
+            return this.userStore.isLoggedIn;
+        },
     },
     methods: {
-      showAlert() {
-        alert("통합 검색은 추후 추가 예정입니다.")
-      },
-      logout() {
-        if (window.confirm("로그아웃 하시겠습니까?")) {
-          this.userStore.logout();
+        showAlert() {
+            alert("통합 검색은 추후 추가 예정입니다.")
+        },
+        logout() {
+            if (window.confirm("로그아웃 하시겠습니까?")) {
+                this.userStore.logout();
+            }
         }
-      }
     }
-  }
+}
 </script>
 
 <style scoped lang="scss">
@@ -70,55 +84,93 @@ header {
     padding: 15px 30px;
     border-bottom: 2px solid #ddd;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  }
-  
-  .logo {
+}
+
+i {
+    padding-right: 10px;
+    font-size: 18px;
+}
+
+.logo {
     margin-right: 50px;
-  }
-  
-  .logo h1 {
+}
+
+.logo h1 {
     font-size: 28px;
     font-weight: bold;
     color: #333;
-    font-family: 'Arial', sans-serif;
-  }
-  
-  .navigation {
-    flex-grow: 1; 
-  }
-  
-  .navigation ul, .auth-navigation ul {
+}
+
+.navigation {
+    flex-grow: 1;
+}
+
+.navigation ul, .auth-navigation ul {
     list-style: none;
     display: flex;
     gap: 10px;
     align-items: center;
-  }
-  
-  .navigation ul li, .auth-navigation ul li {
+}
+
+.navigation ul li, .auth-navigation ul li {
     display: flex;
     align-items: center;
-  }
-  
-  .navigation ul li.divider, .auth-navigation ul li.divider {
+}
+
+.navigation ul li.divider, .auth-navigation ul li.divider {
     font-size: 20px;
     color: #ccc;
-  }
-  
-  .navigation ul li a, .auth-navigation ul li a {
+}
+
+.navigation ul li a, .auth-navigation ul li a {
     text-decoration: none;
     color: #333;
-    font-size: 16px;
+    font-size: 15px;
     display: flex;
     align-items: center;
     gap: 5px;
     padding: 5px;
-  }
-  
-  .navigation ul li a:hover, .auth-navigation ul li a:hover {
+}
+
+.navigation ul li a:hover, .auth-navigation ul li a:hover {
     color: var(--main-color);
-  }
-  
-  .search-bar {
+}
+
+.auth-navigation ul li.dropdown {
+    position: relative;
+}
+
+.auth-navigation ul li.dropdown .dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: -10%;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    z-index: 1000;
+    list-style: none;
+    width: 170px;
+}
+
+.auth-navigation ul li.dropdown .dropdown-menu li {
+    padding: 10px 15px;
+}
+
+.auth-navigation ul li.dropdown .dropdown-menu li a {
+    color: #333;
+    text-decoration: none;
+    display: block;
+}
+
+.auth-navigation ul li.dropdown .dropdown-menu li a:hover {
+    color: var(--main-color);
+}
+
+.auth-navigation ul li.dropdown:hover .dropdown-menu {
+    display: block;
+}
+
+.search-bar {
     display: flex;
     align-items: center;
     background-color: #fafcfc;
@@ -128,9 +180,9 @@ header {
     margin-left: auto;
     margin-right: 30px;
     border: 1px solid var(--main-color);
-  }
-  
-  .search-bar input {
+}
+
+.search-bar input {
     border: none;
     outline: none;
     background: none;
@@ -138,9 +190,9 @@ header {
     width: 300px;
     font-size: 16px;
     height: 32.5px !important;
-  }
-  
-  .search-bar button {
+}
+
+.search-bar button {
     background-color: #fafcfc;
     border: none;
     border-radius: 7px;
@@ -151,26 +203,26 @@ header {
     align-items: center;
     cursor: pointer;
     color: white;
-  }
-  
-  .search-bar i{
+}
+
+.search-bar i {
     color: var(--main-color);
-  }
-  
-  @media (max-width: 768px) {
+}
+
+@media (max-width: 768px) {
     header {
-      flex-direction: column;
-      align-items: flex-start;
+        flex-direction: column;
+        align-items: flex-start;
     }
-  
+
     .navigation ul, .auth-navigation ul {
-      flex-direction: column;
-      gap: 10px;
+        flex-direction: column;
+        gap: 10px;
     }
-  
+
     .search-bar {
-      width: 100%;
-      margin-top: 10px;
+        width: 100%;
+        margin-top: 10px;
     }
-  }
+}
 </style>

--- a/frontend/src/components/Header/HeaderComponent.vue
+++ b/frontend/src/components/Header/HeaderComponent.vue
@@ -69,6 +69,7 @@ export default {
         logout() {
             if (window.confirm("로그아웃 하시겠습니까?")) {
                 this.userStore.logout();
+                alert("로그아웃 되었습니다.")
             }
         }
     }

--- a/frontend/src/components/qna/QnaListCardComponent.vue
+++ b/frontend/src/components/qna/QnaListCardComponent.vue
@@ -4,19 +4,19 @@
       <div class="mantine-1uguyhf">
         <a class="mantine-Avatar-root mantine-18l6s08">
           <img
-            class="mantine-9rx0rd mantine-Avatar-image"
-            :src="qnaCard.profileImage"
+              class="mantine-9rx0rd mantine-Avatar-image"
+              :src="qnaCard.profileImage"
           />
         </a>
         <div class="mantine-Stack-root mantine-1l47z8p">
           <div class="mantine-824czz">
             <a class="mantine-Text-root mantine-3qdwx9">{{
-              qnaCard.nickname
-            }}</a>
+                qnaCard.nickname
+              }}</a>
             <div class="mantine-Badge-root mantine-11jjpd0">
               <span class="mantine-1jlwn9k mantine-Badge-inner">{{
-                qnaCard.grade
-              }}</span>
+                  qnaCard.grade
+                }}</span>
             </div>
           </div>
           <p class="mantine-Text-root mantine-1q4x896">
@@ -32,54 +32,39 @@
       <div class="test">
         <div>
           <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
           >
             <g stroke-width="0" id="SVGRepo_bgCarrier"></g>
             <g
-              stroke-linejoin="round"
-              stroke-linecap="round"
-              id="SVGRepo_tracerCarrier"
-            ></g>
-            <g id="SVGRepo_iconCarrier">
-              <path
                 stroke-linejoin="round"
                 stroke-linecap="round"
-                stroke-width="1.5"
-                d="M16 10H16.01M12 10H12.01M8 10H8.01M3 10C3 4.64706 5.11765 3 12 3C18.8824 3 21 4.64706 21 10C21 15.3529 18.8824 17 12 17C11.6592 17 11.3301 16.996 11.0124 16.9876L7 21V16.4939C4.0328 15.6692 3 13.7383 3 10Z"
-              ></path>
-            </g></svg
-          >{{ qnaCard.answerCnt }}
-        </div>
-        <div>
-          <svg
-            fill="#000000"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-            xmlns="http://www.w3.org/2000/svg"
-            version="1.1"
-            viewBox="-2.5 0 32 32"
-          >
-            <g stroke-width="0" id="SVGRepo_bgCarrier"></g>
-            <g
-              stroke-linejoin="round"
-              stroke-linecap="round"
-              id="SVGRepo_tracerCarrier"
+                id="SVGRepo_tracerCarrier"
             ></g>
             <g id="SVGRepo_iconCarrier">
-              <g id="icomoon-ignore"></g>
               <path
-                fill="#000000"
-                d="M0 10.284l0.505 0.36c0.089 0.064 0.92 0.621 2.604 0.621 0.27 0 0.55-0.015 0.836-0.044 3.752 4.346 6.411 7.472 7.060 8.299-1.227 2.735-1.42 5.808-0.537 8.686l0.256 0.834 7.63-7.631 8.309 8.309 0.742-0.742-8.309-8.309 7.631-7.631-0.834-0.255c-2.829-0.868-5.986-0.672-8.686 0.537-0.825-0.648-3.942-3.3-8.28-7.044 0.11-0.669 0.23-2.183-0.575-3.441l-0.352-0.549-8.001 8.001zM1.729 10.039l6.032-6.033c0.385 1.122 0.090 2.319 0.086 2.334l-0.080 0.314 0.245 0.214c7.409 6.398 8.631 7.39 8.992 7.546l-0.002 0.006 0.195 0.058 0.185-0.087c2.257-1.079 4.903-1.378 7.343-0.836l-13.482 13.481c-0.55-2.47-0.262-5.045 0.837-7.342l0.104-0.218-0.098-0.221-0.031 0.013c-0.322-0.632-1.831-2.38-7.498-8.944l-0.185-0.215-0.282 0.038c-0.338 0.045-0.668 0.069-0.981 0.069-0.595 0-1.053-0.083-1.38-0.176z"
+                  stroke-linejoin="round"
+                  stroke-linecap="round"
+                  stroke-width="1.5"
+                  d="M16 10H16.01M12 10H12.01M8 10H8.01M3 10C3 4.64706 5.11765 3 12 3C18.8824 3 21 4.64706 21 10C21 15.3529 18.8824 17 12 17C11.6592 17 11.3301 16.996 11.0124 16.9876L7 21V16.4939C4.0328 15.6692 3 13.7383 3 10Z"
               ></path>
-            </g></svg
-          >{{ qnaCard.likeCnt }}
+            </g>
+          </svg
+          >
+          {{ qnaCard.answerCnt }}
+        </div>
+        <div>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 9V5a3 3 0 00-6 0v4H3.75a2.25 2.25 0 00-2.25 2.25v7.5A2.25 2.25 0 003.75 21h12.5a2.25 2.25 0 002.25-2.25v-7.5A2.25 2.25 0 0016.25 9H14zM9 9v12" />
+          </svg>
+          {{ qnaCard.likeCnt }}
         </div>
       </div>
       <div class="qna-category-highlow">
-        <span>{{ qnaCard.superCategory }}</span>
-        /
-        <span>{{ qnaCard.subCategory }}</span>
+        <span>{{ qnaCard.superCategoryName }}</span>
+        <span v-show="qnaCard.superCategoryName"> / </span>
+        <span>{{ qnaCard.subCategoryName }}</span>
       </div>
     </div>
   </div>
@@ -110,29 +95,49 @@ export default {
   background-color: #ffffff;
   padding: 1em;
   z-index: 5;
-  box-shadow: 4px 4px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
   border-radius: 10px;
-  width: 350px;
-  height: 200px;
+  width: 100%;
+  min-height: 150px;
   display: flex;
   flex-direction: column;
   transition: 200ms ease-in-out;
   justify-content: space-between;
+  overflow: hidden;
 }
 
 .qna-category-highlow {
-  color: #84ceee;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--main-color);
   font-size: 1em;
   font-weight: 800;
+  text-align: right;
+  margin-left: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
 }
 
-.qna-foot-division {
-  display: flex;
+.qna-category-highlow span:nth-child(1) {
+  flex-grow: 3;
+  text-align: left;
 }
 
-.body {
-  display: flex;
-  flex-direction: column;
+.qna-category-highlow span:nth-child(2) {
+  flex-grow: 1;
+  text-align: center;
+  margin: 2px;
+}
+
+.qna-category-highlow span:nth-child(3) {
+  flex-grow: 3;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .body .text {
@@ -156,11 +161,14 @@ export default {
 }
 
 .footer div {
-  margin-right: 1rem;
   height: 20px;
   display: flex;
   align-items: center;
   cursor: pointer;
+}
+
+.test > div {
+  margin-right: 1rem;
 }
 
 .footer svg {
@@ -172,7 +180,7 @@ export default {
 .viewer span {
   height: 20px;
   width: 20px;
-  background-color: rgb(28, 117, 219);
+  background-color: var(--main-color);
   margin-right: -6px;
   border-radius: 50%;
   border: 1px solid #fff;
@@ -188,6 +196,7 @@ export default {
 .viewer span svg {
   stroke: #fff;
 }
+
 /* QnA card */
 
 /* 댓글 */
@@ -197,6 +206,7 @@ export default {
   height: 100%;
   display: block;
 }
+
 .mantine-18l6s08 {
   -webkit-tap-highlight-color: transparent;
   box-sizing: border-box;
@@ -221,59 +231,7 @@ export default {
   height: 5rem;
   border: 1px solid #dee2e6;
 }
-.mantine-18l6s09 {
-  -webkit-tap-highlight-color: transparent;
-  box-sizing: border-box;
-  position: relative;
-  display: block;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  overflow: hidden;
-  border-radius: 200%;
-  border-top-left-radius: 200%;
-  border-top-right-radius: 200%;
-  border-bottom-right-radius: 200%;
-  border-bottom-left-radius: 200%;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border: 0;
-  background-color: transparent;
-  padding: 0;
-  width: 5rem;
-  height: 5rem;
-  border: 1px solid #dee2e6;
-  justify-content: center;
-  align-items: center;
-}
 
-.mantine-9p81l6 {
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
-  -webkit-tap-highlight-color: transparent;
-  color: #495057;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
-  line-height: 1.5;
-  text-underline-position: under;
-}
-.mantine-9p81l6:focus {
-  outline-offset: 0.125rem;
-  outline: 0.125rem solid #212529;
-}
-.mantine-9p81l6:focus:not(:focus-visible) {
-  outline: 0;
-}
 .mantine-1uguyhf {
   display: -webkit-box;
   display: -webkit-flex;
@@ -281,11 +239,8 @@ export default {
   display: flex;
   gap: 0.5rem;
 }
+
 .mantine-1q4x896 {
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
   -webkit-tap-highlight-color: transparent;
   color: #868e96;
   font-size: 0.875rem;
@@ -295,216 +250,33 @@ export default {
   line-height: 1.5;
   text-underline-position: under;
 }
+
 .mantine-1q4x896:focus {
   outline-offset: 0.125rem;
   outline: 0.125rem solid #212529;
 }
+
 .mantine-1q4x896:focus:not(:focus-visible) {
   outline: 0;
 }
-.mantine-1yjkc96 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  height: 100%;
-  overflow: visible;
-  pointer-events: none;
-}
-.mantine-1ryt1ht {
-  white-space: nowrap;
-  height: 100%;
-  overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-.mantine-19ok7fu {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-right: 0.625rem;
-  margin-right: 6px;
-}
+
 .mantine-19ok7fu svg {
   width: 14px;
   height: 14px;
 }
-.mantine-k7c4r8 {
-  -webkit-tap-highlight-color: transparent;
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
-  cursor: pointer;
-  border: 0;
-  padding: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  -ms-appearance: none;
-  appearance: none;
-  font-size: 1rem;
-  background-color: transparent;
-  text-align: left;
-  color: #000;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  box-sizing: border-box;
-  height: 2.25rem;
-  padding-left: calc(1.125rem / 1.5);
-  padding-right: 1.125rem;
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
-  -webkit-tap-highlight-color: transparent;
-  display: inline-block;
-  width: auto;
-  border-radius: 2rem;
-  font-weight: 600;
-  position: relative;
-  line-height: 1;
-  font-size: 0.875rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  cursor: pointer;
-  border: 0.0625rem solid #ced4da;
-  background-color: #fff;
-  color: #000;
-  color: #212529;
-  padding-left: 18px;
-}
-.mantine-k7c4r8:focus {
-  outline-offset: 0.125rem;
-  outline: 0.125rem solid #212529;
-}
-.mantine-k7c4r8:focus:not(:focus-visible) {
-  outline: 0;
-}
-.mantine-k7c4r8:focus {
-  outline-offset: 0.125rem;
-  outline: 0.125rem solid #212529;
-}
-.mantine-k7c4r8:focus:not(:focus-visible) {
-  outline: 0;
-}
-@media (hover: hover) {
-  .mantine-k7c4r8:hover {
-    background-color: #f8f9fa;
-  }
-}
-@media (hover: none) {
-  .mantine-k7c4r8:active {
-    background-color: #f8f9fa;
-  }
-}
-.mantine-k7c4r8:active {
-  -webkit-transform: translateY(0.0625rem);
-  -moz-transform: translateY(0.0625rem);
-  -ms-transform: translateY(0.0625rem);
-  transform: translateY(0.0625rem);
-}
-.mantine-k7c4r8:disabled,
-.mantine-k7c4r8[data-disabled] {
-  border-color: transparent;
-  background-color: #e9ecef;
-  color: #adb5bd;
-  cursor: not-allowed;
-  background-image: none;
-  pointer-events: none;
-}
-.mantine-k7c4r8:disabled:active,
-.mantine-k7c4r8[data-disabled]:active {
-  -webkit-transform: none;
-  -moz-transform: none;
-  -ms-transform: none;
-  transform: none;
-}
-.mantine-k7c4r8[data-loading] {
-  pointer-events: none;
-}
-.mantine-k7c4r8[data-loading]::before {
-  content: "";
-  position: absolute;
-  top: -0.0625rem;
-  right: -0.0625rem;
-  left: -0.0625rem;
-  bottom: -0.0625rem;
-  background-color: rgba(255, 255, 255, 0.5);
-  border-radius: 2rem;
-  cursor: not-allowed;
-}
-.mantine-1qj7q0z {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: 2.25rem;
-  pointer-events: none;
-}
-.mantine-1ttseea {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  gap: 0;
-  width: 100%;
-  min-width: 0;
-}
+
 .mantine-2j9uwr {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 30px;
+  height: 40px;
   margin-bottom: 20px;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
 }
+
 .mantine-18l6s08 {
   -webkit-tap-highlight-color: transparent;
   box-sizing: border-box;
@@ -526,13 +298,16 @@ export default {
   height: 2.375rem;
   border: 1px solid #dee2e6;
 }
+
 .mantine-18l6s08:focus {
   outline-offset: 0.125rem;
   outline: 0.125rem solid #212529;
 }
+
 .mantine-18l6s08:focus:not(:focus-visible) {
   outline: 0;
 }
+
 .mantine-1l47z8p {
   display: -webkit-box;
   display: -webkit-flex;
@@ -551,6 +326,7 @@ export default {
   justify-content: center;
   gap: 0;
 }
+
 .mantine-824czz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -558,11 +334,8 @@ export default {
   display: flex;
   gap: 0.25rem;
 }
+
 .mantine-3qdwx9 {
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
   -webkit-tap-highlight-color: transparent;
   color: #495057;
   font-size: 0.875rem;
@@ -573,13 +346,16 @@ export default {
   line-height: 1.5;
   text-underline-position: under;
 }
+
 .mantine-3qdwx9:focus {
   outline-offset: 0.125rem;
   outline: 0.125rem solid #212529;
 }
+
 .mantine-3qdwx9:focus:not(:focus-visible) {
   outline: 0;
 }
+
 .mantine-1jlwn9k {
   white-space: nowrap;
   overflow: hidden;
@@ -587,12 +363,9 @@ export default {
   line-height: 100%;
   letter-spacing: normal;
 }
+
 .mantine-11jjpd0 {
   -webkit-tap-highlight-color: transparent;
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
   font-size: 0.6875rem;
   height: 1.25rem;
   line-height: calc(1.25rem - 0.125rem);
@@ -600,7 +373,7 @@ export default {
   text-decoration: none;
   padding: 0 calc(1rem / 1.5);
   box-sizing: border-box;
-  display: -webkit-inline-box;
+  //display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -626,129 +399,80 @@ export default {
   text-transform: none;
   padding: 0 8px;
 }
+
 .mantine-11jjpd0:focus {
   outline-offset: 0.125rem;
   outline: 0.125rem solid #212529;
 }
+
 .mantine-11jjpd0:focus:not(:focus-visible) {
   outline: 0;
 }
-.mantine-6va1do {
-  margin-top: 0.5rem;
-}
-.mantine-12kvhdu {
-  margin-top: 0.75rem;
-}
-.mantine-1qj7haw {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  gap: 0.75rem;
-}
-.mantine-1qj7haw > * {
-  box-sizing: border-box;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-}
-.mantine-17p85na {
-  padding-left: 28px;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.75rem;
-}
+
 .mantine-17p85na:not(.mantine-17p85na:first-of-type) .re-comment-arrow {
   padding-top: 36px;
 }
+
 .mantine-17p85na:not(.mantine-17p85na:first-of-type) .re-comment {
   padding-top: 24px;
   border-top: 1px solid #e9ecef;
 }
-.mantine-155ln8z {
-  left: 0;
-  font-size: 0;
-  position: absolute;
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-}
-.mantine-5n4x4z {
-  width: 100%;
-}
-.mantine-11k5015 {
-  border-radius: 16px;
-  border: 1px solid #e9ecef;
-  padding: 1.5rem;
-}
-body {
-  margin: 0;
-}
+
 h1 {
   font-size: 2em;
 }
+
 pre {
-  font-family: monospace, monospace;
   font-size: 1em;
 }
+
 a {
   background: 0 0;
-  text-decoration-skip: objects;
+  //text-decoration-skip: objects;
 }
+
 a:active,
 a:hover {
   outline-width: 0;
 }
+
 b {
   font-weight: bolder;
 }
+
 code {
-  font-family: monospace, monospace;
   font-size: 1em;
 }
+
 img {
   border-style: none;
   vertical-align: middle;
 }
+
 svg:not(:root) {
   overflow: hidden;
 }
+
 button {
-  font-family: sans-serif;
   font-size: 100%;
   line-height: 1.15;
   margin: 0;
 }
+
 button {
   overflow: visible;
 }
+
 button {
   text-transform: none;
 }
+
 [type="reset"],
 [type="submit"],
 button {
   -webkit-appearance: button;
 }
+
 [type="button"]::-moz-focus-inner,
 [type="reset"]::-moz-focus-inner,
 [type="submit"]::-moz-focus-inner,
@@ -756,27 +480,32 @@ button::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
+
 [type="button"]:-moz-focusring,
 [type="reset"]:-moz-focusring,
 [type="submit"]:-moz-focusring,
 button:-moz-focusring {
   outline: 0.0625rem dotted ButtonText;
 }
+
 [type="checkbox"],
 [type="radio"] {
   box-sizing: border-box;
   padding: 0;
 }
+
 [type="number"]::-webkit-inner-spin-button,
 [type="number"]::-webkit-outer-spin-button {
   height: auto;
 }
+
 [type="search"] {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
   appearance: none;
 }
+
 [type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
@@ -784,41 +513,25 @@ button:-moz-focusring {
   -ms-appearance: none;
   appearance: none;
 }
+
 ::-webkit-file-upload-button {
   -webkit-appearance: button;
   -moz-appearance: button;
   -ms-appearance: button;
-  appearance: button;
+  //appearance: button;
   font: inherit;
 }
+
 ::after,
 ::before {
   box-sizing: border-box;
 }
+
 html {
   -webkit-print-color-scheme: light;
   color-scheme: light;
 }
-body {
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
-    "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    sans-serif;
-  background-color: #fff;
-  color: #000;
-  line-height: 1.5;
-  font-size: 1rem;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-body,
-html {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  vertical-align: baseline;
-}
+
 a,
 b,
 code,
@@ -842,9 +555,11 @@ span {
   font-size: 11px;
   vertical-align: baseline;
 }
+
 q {
   quotes: none;
 }
+
 q:after,
 q:before {
   content: none;
@@ -853,13 +568,16 @@ q:before {
 .answer-name-text {
   font-size: 20px;
 }
+
 /* 댓글 */
 
 .qna-title {
-  margin-bottom: 30px;
-  text-align: center;
-  font-size: 26px;
-  font-weight: 900;
+  text-align: left;
+  font-size: 16px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #good-image {

--- a/frontend/src/components/user/SignInComponent.vue
+++ b/frontend/src/components/user/SignInComponent.vue
@@ -6,7 +6,7 @@
       <input type="password" placeholder="비밀번호" v-model="user.password" />
       <button type="button" @click="submit">로그인</button>
       <img class="github"
-        src="https://user-images.githubusercontent.com/9599/61177475-2ddce800-a58b-11e9-9bf6-aa4794a99f2a.png"
+        src="https://dayun2024-s3.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/14/dfa57956-15f7-44cc-afd6-b1c7ce31c0b2"
         @click="githubLogin">
     </form>
   </div>
@@ -118,6 +118,7 @@
   .github {
     width: 70%;
     margin-top: 10px;
+    padding: 10px;
     cursor: pointer;
   }
 </style>

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="wrap">
+  <div class="custom-container">
     <div class="qna-top">
       <p id="main-title">QnA</p>
       <p id="sub-title">당신의 에러를 해결해보세요</p>
@@ -73,11 +73,12 @@ export default {
 
 <style>
 .qna-top {
-  height: 320px;
-  display: grid;
+  //height: 320px;
+  //display: grid;
+  padding-bottom: 50px;
   align-content: center;
   align-items: center;
-  background-color: #e1e8e8;
+  //background-color: #e1e8e8;
 }
 .qna-bottom {
   height: 70px;
@@ -98,18 +99,20 @@ export default {
 }
 
 .qna-list-flex {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  grid-template-rows: repeat(2, auto);
-  gap: 26px 36px;
-  justify-items: center;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-auto-rows: auto;
+    gap: 26px 36px;
+    justify-items: stretch;
+    max-width: 100%;
+    margin: 0 auto
 }
 
 .qna-inner {
   width: auto;
   height: max-content;
-  margin: 20px 100px;
-  padding: 10px;
+  //margin: 20px 100px;
+  //padding: 10px;
   background-color: #fff;
 }
 


### PR DESCRIPTION
## 연관 이슈


## 작업 내용
- 헤더에 임시로 라우터 추가
- 마이페이지 버튼 드롭다운으로 변경 (회원 정보, 작성 목록, 스크랩 목록, 포인트 및 랭킹, 채팅) 
- 깃허브 로그인 버튼 이미지 수정
- 로그아웃 후 alert 추가
- QnA 목록 css 수정

## 스크린샷 (선택)
<img width="1335" alt="image" src="https://github.com/user-attachments/assets/5485ab14-30f8-475d-94fa-25d9907cd349">


## 리뷰 요구사항 혹은 기타 (선택)
