### PR TITLE
[Feat] 포인트 적립/차감 AOP 구현 (#60)

### DIFF
--- a/backend/src/main/java/org/example/backend/Chat/Model/Entity/Chat.java
+++ b/backend/src/main/java/org/example/backend/Chat/Model/Entity/Chat.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.User.Model.Entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -14,14 +16,15 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class Chat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
-    @Builder.Default
-    private LocalDateTime sendTime = LocalDateTime.now();
+    @CreatedDate
+    private LocalDateTime sendTime;
     @Column(columnDefinition = "TEXT", nullable = false)
     private String message;
 

--- a/backend/src/main/java/org/example/backend/Point/Aop/PointAop.java
+++ b/backend/src/main/java/org/example/backend/Point/Aop/PointAop.java
@@ -1,0 +1,37 @@
+package org.example.backend.Point.Aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.example.backend.Point.Model.Enum.PointDescriptionEnum;
+import org.example.backend.Point.Service.PointService;
+import org.example.backend.Security.CustomUserDetails;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class PointAop {
+    private final PointService pointService;
+
+    @AfterReturning("execution(* org.example.backend.Qna.Service.QnaService.saveQuestion(..))")
+    public void givePointAfterSuccessQnaRegister(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        pointService.givePoint((Long) args[1], PointDescriptionEnum.POINT_QNA_WRITE);
+    }
+
+    @AfterReturning("execution(* org.example.backend.Wiki.Service.WikiService.register(..))")
+    public void givePointAfterSuccessWikiRegister(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        pointService.givePoint(((CustomUserDetails) args[2]).getUserId(), PointDescriptionEnum.POINT_WIKI_WRITE);
+    }
+
+    @AfterReturning("execution(* org.example.backend.ErrorArchive.Service.ErrorArchiveService.register(..))")
+    public void givePointAfterSuccessErrorArchiveRegister(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        pointService.givePoint(((CustomUserDetails) args[1]).getUserId(), PointDescriptionEnum.POINT_ERRORARCHIVE_WRITE);
+    }
+
+    //todo - 질문 글 답변 작성, 답변 채택, 추천 10 이상, 비추천 5이상
+}

--- a/backend/src/main/java/org/example/backend/Point/Model/Entity/PointDetail.java
+++ b/backend/src/main/java/org/example/backend/Point/Model/Entity/PointDetail.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.User.Model.Entity.User;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class PointDetail {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,7 +29,7 @@ public class PointDetail {
     private Integer point;
     @Column(nullable = false)
     @CreatedDate
-    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;

--- a/backend/src/main/java/org/example/backend/Point/Model/Enum/PointDescriptionEnum.java
+++ b/backend/src/main/java/org/example/backend/Point/Model/Enum/PointDescriptionEnum.java
@@ -1,0 +1,24 @@
+package org.example.backend.Point.Model.Enum;
+
+import lombok.Getter;
+
+@Getter
+public enum PointDescriptionEnum {
+
+    POINT_QNA_WRITE("질문글 작성", 10),
+    POINT_WIKI_WRITE("위키 작성/수정", 15),
+    POINT_ERRORARCHIVE_WRITE("에러 게시판 작성", 30),
+    POINT_QNA_ANSWER_WRITE("질문 글 답변 작성", 20),
+    POINT_QNA_ANSWER_ACCEPT("본인 답변 채택", 50),
+    POINT_RECOMMEND("에러/답변 추천 10 이상", 10),
+    POINT_DISRECOMMEND("에러/답변 추천 5 이상", -5);
+
+
+    private final String description;
+    private final int value;
+
+    PointDescriptionEnum(String description, int value) {
+        this.description = description;
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
@@ -117,4 +117,12 @@ public class User {
     public void updateProfileImg(String imgUrl) {
         this.profileImg = imgUrl;
     }
+
+    public void updatePoint(Integer point) {
+        this.point += point;
+    }
+
+    public void updateGrade(String grade) {
+        this.grade = grade;
+    }
 }


### PR DESCRIPTION
## 연관 이슈
close #60 


## 작업 내용
포인트 적립/차감 메서드 구현
AOP를 활용하여 적립/차감이 일어날 Method가 정상 종료되면 포인트 적립/차감 메서드가 실행되도록 구현
적립/차감 설명은 Enum으로 관리
적립/차감 후 point에 따라 user의 등급도 업데이트


## 스크린샷 (선택)

## 리뷰 요구사항 혹은 기타 (선택)
현재는 위키 등록, 질문글 등록, 에러아카이브 등록할 때만 포인트 적립됨
나머지 메서드들도 추가되면 이후 수정 예정