### PR TITLE
[Feat] 위키 수정(버전 업데이트) API (#25)

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -37,6 +37,8 @@ public enum BaseResponseStatus {
     WIKI_CONTENT_REGIST_FAIL(false, 5003,"내용을 입력해주세요."),
     WIKI_CONTENT_DUPLICATION_FAIL(false, 5004,"중복되는 위키입니다."),
     WIKI_NOT_FOUND_DETAIL(false,5005,"위키 조회를 실패했습니다."),
+    WIKI_PERMISSION_DENIED(false, 5006,"수정 권한이 없습니다."),
+
     // 에러 아카이브 기능 - 6000
 
     // 에러 QnA 기능 - 7000

--- a/backend/src/main/java/org/example/backend/Security/CustomUserDetails.java
+++ b/backend/src/main/java/org/example/backend/Security/CustomUserDetails.java
@@ -41,4 +41,8 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return user.getEnable();
     }
+
+    public String getGrade() {
+        return user.getGrade();
+    }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -76,14 +76,20 @@ public class WikiController {
     public BaseResponse<GetWikiDetailRes> detail(GetWikiDetailReq getWikiDetailReq,
                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        Long userId = (customUserDetails != null) ? customUserDetails.getUserId() : null;
+        Long userId = null;
+        String userGrade = "GUEST";
+
+        if (customUserDetails != null) {
+            userId = customUserDetails.getUserId();
+            userGrade = customUserDetails.getGrade();
+        }
 
         return new BaseResponse<>(wikiService.detail(getWikiDetailReq, userId));
     }
 
     // 위키 수정
     @PatchMapping
-    public BaseResponse<GetWikiUpdateRes> update(GetWikiUpdateReq getWikiUpdateReq,
+    public BaseResponse<GetWikiUpdateRes> update(@RequestPart GetWikiUpdateReq getWikiUpdateReq,
                                                  @RequestPart(required = false) MultipartFile thumbnail,
                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -8,8 +8,10 @@ import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
 import org.example.backend.Wiki.Model.Req.GetWikiDetailReq;
 import org.example.backend.Wiki.Model.Req.GetWikiListReq;
+import org.example.backend.Wiki.Model.Req.GetWikiUpdateReq;
 import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
 import org.example.backend.Wiki.Model.Res.GetWikiDetailRes;
+import org.example.backend.Wiki.Model.Res.GetWikiUpdateRes;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
 import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
 import org.example.backend.Wiki.Service.WikiService;
@@ -20,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-
 
 
 @RestController
@@ -78,6 +79,25 @@ public class WikiController {
 
         Long userId = (customUserDetails != null) ? customUserDetails.getUserId() : null;
 
-        return new BaseResponse<>(wikiService.detail(getWikiDetailReq,userId));
+        return new BaseResponse<>(wikiService.detail(getWikiDetailReq, userId));
+    }
+
+    // 위키 수정
+    @PatchMapping
+    public BaseResponse<GetWikiUpdateRes> update(GetWikiUpdateReq getWikiUpdateReq,
+                                                 @RequestPart(required = false) MultipartFile thumbnail,
+                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        // 썸네일 등록 확인 로직
+        String thumbnailUrl;
+        if (thumbnail == null || thumbnail.isEmpty()) {
+            thumbnailUrl = null;
+        } else {
+            thumbnailUrl = cloudFileUploadService.uploadImg(thumbnail);
+        }
+
+        return new BaseResponse<>(wikiService.update(getWikiUpdateReq, thumbnailUrl, customUserDetails.getUserId()));
+
     }
 }
+

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 
 

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
@@ -1,11 +1,9 @@
 package org.example.backend.Wiki.Model.Entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +12,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
 public class LatestWiki {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,6 +23,7 @@ public class LatestWiki {
     private String content;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @Column(nullable = false)

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
@@ -2,7 +2,7 @@ package org.example.backend.Wiki.Model.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -22,7 +22,7 @@ public class LatestWiki {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @CreatedDate
+    @LastModifiedDate
     private LocalDateTime createdAt;
 
     @Column(nullable = false)

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -12,7 +11,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
 @EntityListeners(AuditingEntityListener.class)
 public class LatestWiki {
     @Id
@@ -32,4 +30,12 @@ public class LatestWiki {
     private String thumbnailImgUrl;
 
 
+    public void updateContentAndVersion(String content, int newVersion) {
+        this.content = content;
+        this.version = newVersion;
+    }
+
+    public void updateThumbnail(String thumbnailImgUrl) {
+        this.thumbnailImgUrl = thumbnailImgUrl;
+    }
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/LatestWiki.java
@@ -23,7 +23,6 @@ public class LatestWiki {
     private String content;
 
     @CreatedDate
-    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @Column(nullable = false)

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
@@ -2,9 +2,9 @@ package org.example.backend.Wiki.Model.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.example.backend.Qna.model.Entity.QnaScrap;
 import org.example.backend.User.Model.Entity.User;
-
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -13,6 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class WikiContent {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,8 +23,8 @@ public class WikiContent {
     @NonNull
     private String content;
 
-    @Builder.Default
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @LastModifiedDate
+    private LocalDateTime createdAt;
 
     @Column(nullable = false)
     private Integer version;

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Entity/WikiContent.java
@@ -3,7 +3,7 @@ package org.example.backend.Wiki.Model.Entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.backend.User.Model.Entity.User;
-import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,7 +23,7 @@ public class WikiContent {
     @NonNull
     private String content;
 
-    @LastModifiedDate
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @Column(nullable = false)

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiUpdateReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiUpdateReq.java
@@ -1,0 +1,12 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetWikiUpdateReq {
+
+    private Long id;
+    private String content;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiDetailRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiDetailRes.java
@@ -13,5 +13,6 @@ public class GetWikiDetailRes {
     private String category;
     private Integer version;
     private Boolean checkScrap;
+    private String userGrade;
 
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiUpdateRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiUpdateRes.java
@@ -1,0 +1,11 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetWikiUpdateRes {
+
+    private Long wikiId;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -27,7 +27,6 @@ import org.example.backend.Wiki.Repository.WikiScrapRepository;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -26,6 +26,7 @@ import org.example.backend.Wiki.Repository.WikiRepository;
 import org.example.backend.Wiki.Repository.WikiScrapRepository;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,7 @@ public class WikiService {
     private final UserRepository userRepository;
     private final WikiScrapRepository wikiScrapRepository;
 
+    @Transactional
     public WikiRegisterRes register(WikiRegisterReq wikiRegisterReq, String thumbnail, CustomUserDetails customUserDetails
     ) {
         // 위키 등록시 중복 확인 로직
@@ -131,6 +133,7 @@ public class WikiService {
     }
 
     // 위키 수정
+    @Transactional
     public GetWikiUpdateRes update(GetWikiUpdateReq getWikiUpdateReq, String thumbnailUrl, Long userId) {
 
         User user = userRepository.findById(userId).get();


### PR DESCRIPTION
## 연관 이슈
close #25 


## 작업 내용
📌위키 수정(버전 업데이트) 기능
- 위키 수정시, 버전 +1로 처리되어 버전 갱신
- 썸네일, 내용만 수정 가능
- 썸네일 미등록시 이전 버전 위키의 썸네일 들고오도록 처리
- 회원등급에 따른 수정 제한 처리
- 수정한 유저 정보도 함께 저장


## 스크린샷 (선택)

## 리뷰 요구사항 혹은 기타 (선택)
💡비로그인 유저에게는 GUEST 등급 부여함 => null로 관리하기엔  비로그인 상태인지, 등급을 제대로 가져오지 못한 것인지 명확하지 않을 수 있을 것 같고, 유연한 관리 차원