### PR TITLE
[Feat] 채팅 시작 API 구현 (#52)

### DIFF
--- a/backend/src/main/java/org/example/backend/Chat/Controller/ChatController.java
+++ b/backend/src/main/java/org/example/backend/Chat/Controller/ChatController.java
@@ -1,15 +1,15 @@
 package org.example.backend.Chat.Controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.backend.Chat.Model.Req.StartChatReq;
 import org.example.backend.Chat.Model.Res.GetChatMessageRes;
 import org.example.backend.Chat.Model.Res.GetChatRoomRes;
+import org.example.backend.Chat.Model.Res.StartChatRes;
 import org.example.backend.Chat.Service.ChatService;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,7 +28,11 @@ public class ChatController {
     public BaseResponse<List<GetChatMessageRes>> getChatMessageList(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                                     Long chatRoomId, Integer page, Integer size) {
         return new BaseResponse<>(chatService.getChatMessageList(customUserDetails.getUserId(), chatRoomId, page, size));
-
     }
 
+    @PostMapping("/start")
+    public BaseResponse<StartChatRes> createChatRoom(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody StartChatReq startChatReq){
+        System.out.println(startChatReq.getNickname());
+        return new BaseResponse<>(chatService.startChat(customUserDetails.getUserId(), startChatReq));
+    }
 }

--- a/backend/src/main/java/org/example/backend/Chat/Model/Req/StartChatReq.java
+++ b/backend/src/main/java/org/example/backend/Chat/Model/Req/StartChatReq.java
@@ -1,0 +1,10 @@
+package org.example.backend.Chat.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StartChatReq {
+    private String nickname;
+}

--- a/backend/src/main/java/org/example/backend/Chat/Model/Res/StartChatRes.java
+++ b/backend/src/main/java/org/example/backend/Chat/Model/Res/StartChatRes.java
@@ -1,0 +1,13 @@
+package org.example.backend.Chat.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class StartChatRes {
+    private Long chatRoomId;
+    private String recipientNickname;
+    private String recipientProfile;
+    private Long recipientId;
+}

--- a/backend/src/main/java/org/example/backend/Chat/Repository/ChatRoomRepository.java
+++ b/backend/src/main/java/org/example/backend/Chat/Repository/ChatRoomRepository.java
@@ -4,8 +4,10 @@ import org.example.backend.Chat.Model.Entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findAllByUser1Id(Long userId);
     List<ChatRoom> findAllByUser2Id(Long userId);
+    Optional<ChatRoom> findByUser1IdAndUser2Id(Long userId, Long user2Id);
 }


### PR DESCRIPTION
## 연관 이슈
close #52 


## 작업 내용
- 채팅 시작 API 구현
  - 상대방의 닉네임을 통해 상대방의 User 엔티티 조회
  - 나의 user id 와 상대방의 user id 중 작은쪽이 user1, 큰쪽이 user2
  - ChatRoom을 user1, user2로 및 저장
  - 이미 상대방과의 채팅방이 있을 경우 해당 채팅방을 조회
  - 응답으로 채팅방 id, 상대방 id, 상대방 닉네임, 프로필 이미지를 반환

``` json
{
    "code": 1000,
    "isSuccess": true,
    "message": "요청이 성공하였습니다.",
    "result": {
        "chatRoomId": 4,
        "recipientNickname": "test01",
        "recipientProfile": "https://enadu.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/15/3ebf7f81-7f52-4309-8eb5-d79f5a5e8007",
        "recipientId": 3
    }
}
```
## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
