### PR TITLE
[Feat] 에러 아카이브 상세 조회 api 구현(#10)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -38,6 +38,7 @@ public enum BaseResponseStatus {
     WIKI_CONTENT_DUPLICATION_FAIL(false, 5004,"중복되는 위키입니다."),
     WIKI_NOT_FOUND_DETAIL(false,5005,"위키 조회를 실패했습니다."),
     // 에러 아카이브 기능 - 6000
+    ERRORARCHIVE_NOT_FOUND(false,6022, "삭제된 게시글입니다."),
 
     // 에러 QnA 기능 - 7000
     // - QnA 공통 에러

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
@@ -2,11 +2,16 @@ package org.example.backend.ErrorArchive.Controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.ErrorArchive.Model.Req.GetErrorArchiveDetailReq;
 import org.example.backend.ErrorArchive.Model.Req.ListErrorArchiveReq;
 import org.example.backend.ErrorArchive.Model.Req.RegisterErrorArchiveReq;
+import org.example.backend.ErrorArchive.Model.Res.GetErrorArchiveDetailRes;
 import org.example.backend.ErrorArchive.Model.Res.ListErrorArchiveRes;
 import org.example.backend.ErrorArchive.Model.Res.RegisterErrorArchiveRes;
 import org.example.backend.ErrorArchive.Service.ErrorArchiveService;
+import org.example.backend.Exception.custom.InvalidErrorBoardException;
+import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.Security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +25,7 @@ public class ErrorArchiveController {
 
     private final ErrorArchiveService errorArchiveService;
 
+    // 아카이브 등록
     @PostMapping()
     public BaseResponse<RegisterErrorArchiveRes> register(
             @RequestBody RegisterErrorArchiveReq registerErrorArchiveReq,
@@ -27,21 +33,34 @@ public class ErrorArchiveController {
         RegisterErrorArchiveRes registerErrorArchiveRes = errorArchiveService.register(registerErrorArchiveReq, customUserDetails);
         return new BaseResponse<>(registerErrorArchiveRes);
 
-        }
+    }
+
     // 아카이브 목록 조회
     @GetMapping("/list")
     public BaseResponse<List<ListErrorArchiveRes>> list(ListErrorArchiveReq listErrorArchiveReq) {
-        if(listErrorArchiveReq.getPage() == null) {
+        if (listErrorArchiveReq.getPage() == null) {
             listErrorArchiveReq.setPage(0);
         }
-        if(listErrorArchiveReq.getSize() == null || listErrorArchiveReq.getSize() == 0){
+        if (listErrorArchiveReq.getSize() == null || listErrorArchiveReq.getSize() == 0) {
             listErrorArchiveReq.setSize(20);
         }
         List<ListErrorArchiveRes> errorArchiveList = errorArchiveService.errorArchiveList(listErrorArchiveReq);
         return new BaseResponse<>(errorArchiveList);
     }
 
+    // 아카이브 상세 조회
+    @GetMapping("/detail")
+    public BaseResponse<GetErrorArchiveDetailRes> detail(GetErrorArchiveDetailReq getErrorArchiveDetailReq,
+                                                         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if(getErrorArchiveDetailReq.getId() == null){
+            throw new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NOT_FOUND);
+        }
+        if(customUserDetails.getUserId() == null){
+            throw new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND);
+        }
+        return new BaseResponse<>(errorArchiveService.detail(getErrorArchiveDetailReq, customUserDetails));
     }
+}
 
 
 

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorArchive.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorArchive.java
@@ -9,6 +9,7 @@ import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.User.Model.Entity.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class ErrorArchive {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorLike.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorLike.java
@@ -3,6 +3,7 @@ package org.example.backend.ErrorArchive.Model.Entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.User.Model.Entity.User;
 
@@ -11,6 +12,7 @@ import org.example.backend.User.Model.Entity.User;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Getter
 public class ErrorLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorScrap.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorScrap.java
@@ -3,6 +3,7 @@ package org.example.backend.ErrorArchive.Model.Entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.User.Model.Entity.User;
 
@@ -11,6 +12,7 @@ import org.example.backend.User.Model.Entity.User;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Getter
 public class ErrorScrap {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,6 +27,6 @@ public class ErrorScrap {
     @JoinColumn(name = "error_archive_id", nullable = false)
     private ErrorArchive errorArchive;
 
-
-
+    @Column(nullable = false)
+    private boolean state;
 }

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorScrap.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Entity/ErrorScrap.java
@@ -27,6 +27,4 @@ public class ErrorScrap {
     @JoinColumn(name = "error_archive_id", nullable = false)
     private ErrorArchive errorArchive;
 
-    @Column(nullable = false)
-    private boolean state;
 }

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Req/GetErrorArchiveDetailReq.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Req/GetErrorArchiveDetailReq.java
@@ -1,0 +1,10 @@
+package org.example.backend.ErrorArchive.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetErrorArchiveDetailReq {
+    private Long id;
+}

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/GetErrorArchiveDetailRes.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/GetErrorArchiveDetailRes.java
@@ -1,0 +1,27 @@
+package org.example.backend.ErrorArchive.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class GetErrorArchiveDetailRes {
+    private Long id;
+    private String nickname;
+    private String title;
+    private String content;
+    private String superCategory;
+    private String subCategory;
+    private LocalDateTime createAt;
+    private LocalDateTime modifiedAt;
+    private Integer likeCnt;
+    private Integer hateCnt;
+    private Boolean checkLike;
+    private Boolean checkHate;
+    private Boolean checkScrap;
+    private String profileImg;
+    private String grade;
+    private String gradeImg;
+}

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorLikeRepository.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorLikeRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ErrorLikeRepository extends JpaRepository<ErrorLike, Long> {
-    Optional<ErrorLike> findByUserAndErrorArchive(User user, ErrorArchive errorArchive);
+    Optional<ErrorLike> findByUserAndErrorArchiveAndState(User user, ErrorArchive errorArchive,Boolean isLike );
 }

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorLikeRepository.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorLikeRepository.java
@@ -1,0 +1,12 @@
+package org.example.backend.ErrorArchive.Repository;
+
+import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
+import org.example.backend.ErrorArchive.Model.Entity.ErrorLike;
+import org.example.backend.User.Model.Entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ErrorLikeRepository extends JpaRepository<ErrorLike, Long> {
+    Optional<ErrorLike> findByUserAndErrorArchive(User user, ErrorArchive errorArchive);
+}

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorScrapRepository.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorScrapRepository.java
@@ -1,0 +1,13 @@
+package org.example.backend.ErrorArchive.Repository;
+
+import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
+import org.example.backend.ErrorArchive.Model.Entity.ErrorScrap;
+import org.example.backend.User.Model.Entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ErrorScrapRepository extends JpaRepository<ErrorScrap, Long> {
+    Optional<ErrorScrap> findByUserAndErrorArchive(User user, ErrorArchive errorArchive);
+
+}

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
@@ -4,23 +4,33 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.Category.Repository.CategoryRepository;
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
+import org.example.backend.ErrorArchive.Model.Entity.ErrorLike;
+import org.example.backend.ErrorArchive.Model.Entity.ErrorScrap;
+import org.example.backend.ErrorArchive.Model.Req.GetErrorArchiveDetailReq;
 import org.example.backend.ErrorArchive.Model.Req.ListErrorArchiveReq;
 import org.example.backend.ErrorArchive.Model.Req.RegisterErrorArchiveReq;
+import org.example.backend.ErrorArchive.Model.Res.GetErrorArchiveDetailRes;
 import org.example.backend.ErrorArchive.Model.Res.ListErrorArchiveRes;
 import org.example.backend.ErrorArchive.Model.Res.RegisterErrorArchiveRes;
 import org.example.backend.ErrorArchive.Repository.ErrorArchiveReository;
+import org.example.backend.ErrorArchive.Repository.ErrorLikeRepository;
+import org.example.backend.ErrorArchive.Repository.ErrorScrapRepository;
 import org.example.backend.Exception.custom.InvalidCategoryException;
+import org.example.backend.Exception.custom.InvalidErrorBoardException;
 import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.Security.CustomUserDetails;
+import org.example.backend.User.Model.Entity.User;
 import org.example.backend.User.Repository.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -32,6 +42,9 @@ public class ErrorArchiveService {
     private final ErrorArchiveReository errorArchiveReository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
+    private final ErrorLikeRepository errorLikeRepository;
+    private final ErrorScrapRepository errorScrapRepository;
+
     public RegisterErrorArchiveRes register(RegisterErrorArchiveReq registerErrorArchiveReq, CustomUserDetails customUserDetails) {
         ErrorArchive errorArchive = ErrorArchive.builder()
                 .title(registerErrorArchiveReq.getTitle())
@@ -60,6 +73,72 @@ public class ErrorArchiveService {
                                 .build())
                 .collect(Collectors.toList());
     }
+    // 에러 아카이브 상세 조회
+    public GetErrorArchiveDetailRes detail(GetErrorArchiveDetailReq getErrorArchiveDetailReq, CustomUserDetails customUserDetails){
+        ErrorArchive errorArchive = errorArchiveReository.findById(getErrorArchiveDetailReq.getId()).orElseThrow(()-> new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NOT_FOUND));
+        Long userId = (customUserDetails != null) ? customUserDetails.getUserId() : null;
+
+        Optional<Boolean> likeStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, true);
+        boolean checkLike = likeStatus.orElse(false);
+        Optional<Boolean> hateStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, true);
+        boolean checkHate = hateStatus.orElse(false);
+
+        GetErrorArchiveDetailRes ErrorArchiveDetailRes = GetErrorArchiveDetailRes.builder()
+                .id(errorArchive.getId())
+                .nickname(errorArchive.getUser().getNickname())
+                .title(errorArchive.getTitle())
+                .content(errorArchive.getContent())
+                .superCategory(errorArchive.getCategory().getCategoryName())
+                .subCategory(errorArchive.getCategory().getCategoryName())
+                .createAt(errorArchive.getCreatedAt())
+                .modifiedAt(errorArchive.getModifiedAt())
+                .likeCnt(errorArchive.getLikeCount())
+                .hateCnt(errorArchive.getHateCount())
+                .checkLike(checkLike)
+                .checkHate(checkHate)
+                .checkScrap(ErrorArchiveScrap(errorArchive.getId(),customUserDetails))
+                .profileImg(errorArchive.getUser().getProfileImg())
+                .grade(errorArchive.getUser().getGrade())
+                .gradeImg(errorArchive.getUser().getProfileImg())
+                .build();
+        return ErrorArchiveDetailRes;
+    }
+    // 로그인한 사용자의 에러 아카이브 좋아요/싫어요 여부 조회 메소드
+    public Optional<Boolean> ErrorArchiveLikeOrHate(Long errorArchiveId,Long userId, boolean isLike){
+        // 로그인한 사용자 ID를 가져오기
+        if(userId == null){
+            return Optional.empty();
+        }
+        ErrorArchive errorArchive = errorArchiveReository.findById(errorArchiveId)
+                .orElseThrow(()-> new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
+        // 사용자와 에러아카이브로 좋아요 조회
+        Optional<ErrorLike> errorLike = errorLikeRepository.findByUserAndErrorArchive(user,errorArchive);
+        return errorLike.map(like -> like.isState() == isLike);
+    }
+
+
+    // 로그인한 사용자의 에러 아카이브 스크랩 여부 조회 메소드
+    private boolean ErrorArchiveScrap(Long errorArchiveId, CustomUserDetails customUserDetails){
+      Long userId = customUserDetails.getUserId();
+      if (userId == null) {
+          return false;
+      }
+        // 에러 아카이브 조회
+        ErrorArchive errorArchive = errorArchiveReository.findById(errorArchiveId)
+                .orElseThrow(()-> new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NOT_FOUND));
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
+        Optional<ErrorScrap> errorScrap = errorScrapRepository.findByUserAndErrorArchive(user, errorArchive);
+            if(errorScrap.isPresent()){
+                return errorScrap.get().isState(); // true(스크랩 함), false(스크랩 안함)
+            }
+            return false; // 조회결과가 없을 경우, 기본값으로 false 반환
+
+    }
+
 }
 
 

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
@@ -80,8 +80,8 @@ public class ErrorArchiveService {
 
         Optional<Boolean> likeStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, true);
         boolean checkLike = likeStatus.orElse(false);
-        Optional<Boolean> hateStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, true);
-        boolean checkHate = hateStatus.orElse(false);
+        Optional<Boolean> hateStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, false);
+        boolean checkHate = hateStatus.orElse(true);
 
         GetErrorArchiveDetailRes ErrorArchiveDetailRes = GetErrorArchiveDetailRes.builder()
                 .id(errorArchive.getId())

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
@@ -77,11 +77,12 @@ public class ErrorArchiveService {
     public GetErrorArchiveDetailRes detail(GetErrorArchiveDetailReq getErrorArchiveDetailReq, CustomUserDetails customUserDetails){
         ErrorArchive errorArchive = errorArchiveReository.findById(getErrorArchiveDetailReq.getId()).orElseThrow(()-> new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NOT_FOUND));
         Long userId = (customUserDetails != null) ? customUserDetails.getUserId() : null;
-
+        // 좋아요 상태 조회
         Optional<Boolean> likeStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, true);
         boolean checkLike = likeStatus.orElse(false);
+        // 싫어요 상태 조회
         Optional<Boolean> hateStatus = ErrorArchiveLikeOrHate(errorArchive.getId(), userId, false);
-        boolean checkHate = hateStatus.orElse(true);
+        boolean checkHate = hateStatus.orElse(false);
 
         GetErrorArchiveDetailRes ErrorArchiveDetailRes = GetErrorArchiveDetailRes.builder()
                 .id(errorArchive.getId())
@@ -115,7 +116,8 @@ public class ErrorArchiveService {
                 .orElseThrow(()-> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
         // 사용자와 에러아카이브로 좋아요 조회
         Optional<ErrorLike> errorLike = errorLikeRepository.findByUserAndErrorArchive(user,errorArchive);
-        return errorLike.map(like -> like.isState() == isLike);
+        // 엔티티가 존재하면 상태를 반환하고, 존재하지 않으면 Optional.empty()를 반환
+        return errorLike.map(ErrorLike::isState);
     }
 
 
@@ -131,10 +133,8 @@ public class ErrorArchiveService {
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
+        // 스크랩 여부 조회
         Optional<ErrorScrap> errorScrap = errorScrapRepository.findByUserAndErrorArchive(user, errorArchive);
-            if(errorScrap.isPresent()){
-                return errorScrap.get().isState(); // true(스크랩 함), false(스크랩 안함)
-            }
             return false; // 조회결과가 없을 경우, 기본값으로 false 반환
 
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,18 +18,18 @@ spring:
       max-file-size: 20MB
       max-request-size: 20MB
 
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${EMAIL}
-    password: ${EMAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: true
-            required: true
-          auth: true
+#  mail:
+#    host: smtp.gmail.com
+#    port: 587
+#    username: ${EMAIL}
+#    password: ${EMAIL_PASSWORD}
+#    properties:
+#      mail:
+#        smtp:
+#          starttls:
+#            enable: true
+#            required: true
+#          auth: true
 
 
 


### PR DESCRIPTION
## 연관 이슈
close #10 


## 작업 내용
로그인한 사용자가 자신이 좋아요/싫어요 한 에러 아카이브 상세를 조회 할 수 있음
서비스단에 ErrorArchiveLikeOrHate 메소드 추가해서, 
에러아카이브와 사용자Id로 사용자를 조회해서 사용자와 에러아카이브로 좋아요/싫어요를 조회

로그인한 사용자가 자신이 스크랩한 에러 아카이브 상세를 조회할 수 있음
서비스단에 ErrorArchiveScrap 메소드 추가해서,
에러아카이브와 사용자Id로 사용자를 조회해서 사용자와 에러아카이브로 스크랩 여부를 조회

## 스크린샷 (선택)
<img width="869" alt="image" src="https://github.com/user-attachments/assets/8d26143c-7ab3-4874-bc2d-118a3ea876ed">



## 리뷰 요구사항 혹은 기타 (선택)
