### PR TITLE
[Feat] 비밀번호 확인, 비밀번호 수정, 회원탈퇴, 회원 정보 조회 추가 (#16, #17, #18, #20)

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -23,6 +23,8 @@ public enum BaseResponseStatus {
     USER_INVALID_NICKNAME(false, 2023,"닉네임이 비어있습니다."),
     USER_DUPLICATE_NICKNAME(false, 2031, "이미 있는 닉네임입니다."),
     USER_DUPLICATE_EMAIL(false,2032,"이미 있는 이메일입니다"),
+    USER_PASSWORDS_DO_NOT_MATCH(false,2041, "비밀번호가 일치하지 않습니다."),
+    USER_NEW_PASSWORDS_DO_NOT_MATCH(false, 2042, "새로운 비밀번호와 비밀번호 확인이 일치하지 않습니다"),
 
     // 이메일 인증 실패
     USER_EMAIL_VERIFY_FAIL(false,2500,"이메일 인증에 실패했습니다"),

--- a/backend/src/main/java/org/example/backend/File/Service/CloudFileUploadService.java
+++ b/backend/src/main/java/org/example/backend/File/Service/CloudFileUploadService.java
@@ -60,7 +60,7 @@ public class CloudFileUploadService {
         if (dotIndex == -1) {
             throw new InvalidFileException(BaseResponseStatus.INVALID_FILE_TYPE);
         }
-        String fileExtension = fileName.substring(dotIndex + 1);
+        String fileExtension = fileName.substring(dotIndex + 1).toLowerCase();
         if (!IMAGE_EXTENSIONS.contains(fileExtension)) {
             throw new InvalidFileException(BaseResponseStatus.INVALID_FILE_TYPE);
         }

--- a/backend/src/main/java/org/example/backend/User/Controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/User/Controller/UserController.java
@@ -3,9 +3,12 @@ package org.example.backend.User.Controller;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
+import org.example.backend.User.Model.Req.UpdateUserPasswordReq;
 import org.example.backend.User.Model.Req.UserSignupReq;
+import org.example.backend.User.Model.Res.GetUserInfoRes;
 import org.example.backend.User.Service.UserService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +16,8 @@ import org.springframework.web.multipart.MultipartFile;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.backend.Util.JwtUtil;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/user")
@@ -34,11 +39,11 @@ public class UserController {
         }
 
         // 이메일 중복 확인
-        if (userService.checkDuplicateEmail(userSignupReq.getEmail())){
+        if (!userService.checkDuplicateEmail(userSignupReq.getEmail())){
             return new BaseResponse<>(BaseResponseStatus.USER_DUPLICATE_EMAIL);
         }
         // 닉네임 중복 확인
-        if(userService.checkDuplicateNickname(userSignupReq.getNickname())){
+        if(!userService.checkDuplicateNickname(userSignupReq.getNickname())){
             return new BaseResponse<>(BaseResponseStatus.USER_DUPLICATE_NICKNAME);
         }
 
@@ -50,24 +55,55 @@ public class UserController {
     public BaseResponse<String> logout(HttpServletResponse response) {
         Cookie expiredCookie = jwtUtil.removeCookie();
         response.addCookie(expiredCookie);
-        return new BaseResponse<>("로그아웃");
+        return new BaseResponse<>();
     }
+
     @GetMapping("/duplicate/email")
     public BaseResponse<Boolean> duplicateEmail(String email) {
         return new BaseResponse<>(userService.checkDuplicateEmail(email));
     }
+
     @GetMapping("/duplicate/nickname")
     public BaseResponse<Boolean> duplicateName(String nickname) {
         return new BaseResponse<>(userService.checkDuplicateNickname(nickname));
     }
+
     @PatchMapping("/nickname")
-    public BaseResponse<String> updateNickname(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody String nickname) {
-        userService.updateNickname(customUserDetails.getUserId(), nickname);
+    public BaseResponse<String> updateNickname(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody Map<String, String> nicknameMap ) {
+        userService.updateNickname(customUserDetails.getUserId(), nicknameMap.get("nickname"));
         return new BaseResponse<>();
     }
+
     @PatchMapping("/img")
     public BaseResponse<String> updateImg(@AuthenticationPrincipal CustomUserDetails customUserDetails, MultipartFile imgFile) {
-        userService.updateImg(customUserDetails.getUserId(), cloudFileUploadService.uploadImg(imgFile));
+        String imgUrl = cloudFileUploadService.uploadImg(imgFile);
+        userService.updateImg(customUserDetails.getUserId(), imgUrl);
+        return new BaseResponse<>(imgUrl);
+    }
+
+    @PatchMapping("/password")
+    public BaseResponse<String> updatePassword(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody UpdateUserPasswordReq updateUserPasswordReq) {
+        if(updateUserPasswordReq.getNewPassword().equals(updateUserPasswordReq.getConfirmPassword())){
+            userService.updatePassword(customUserDetails.getUserId(), updateUserPasswordReq);
+        } else {
+            throw new InvalidUserException(BaseResponseStatus.USER_NEW_PASSWORDS_DO_NOT_MATCH);
+        }
         return new BaseResponse<>();
+    }
+
+    @PostMapping("/password/verify")
+    public BaseResponse<Boolean> checkPassword(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody Map<String, String> passwordMap) {
+        return new BaseResponse<>(userService.checkPassword(customUserDetails.getUserId(), passwordMap.get("password")));
+    }
+
+    @PatchMapping("/quit")
+    public BaseResponse<String> quit(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody Map<String, String> passwordMap) {
+        userService.disableUser(customUserDetails.getUserId(), passwordMap.get("password"));
+        return new BaseResponse<>();
+    }
+
+    @PostMapping("/info")
+    public BaseResponse<GetUserInfoRes> getUserInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return new BaseResponse<>(userService.getUserInfo(customUserDetails.getUserId()));
     }
 }

--- a/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
@@ -17,6 +17,7 @@ import org.example.backend.Wiki.Model.Entity.WikiContent;
 import org.example.backend.Wiki.Model.Entity.WikiScrap;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -124,5 +126,13 @@ public class User {
 
     public void updateGrade(String grade) {
         this.grade = grade;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void updateEnable(Boolean enable) {
+        this.enable = enable;
     }
 }

--- a/backend/src/main/java/org/example/backend/User/Model/Req/UpdateUserPasswordReq.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Req/UpdateUserPasswordReq.java
@@ -1,0 +1,10 @@
+package org.example.backend.User.Model.Req;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserPasswordReq {
+    private String oldPassword;
+    private String newPassword;
+    private String confirmPassword;
+}

--- a/backend/src/main/java/org/example/backend/User/Model/Res/GetUserInfoRes.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Res/GetUserInfoRes.java
@@ -1,0 +1,15 @@
+package org.example.backend.User.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+public class GetUserInfoRes {
+    private final String email;
+    private final String nickname;
+    private final Boolean isSocialUser;
+    private final String profileImg;
+    private final String grade;
+}


### PR DESCRIPTION
## 연관 이슈
close #16, #17, #18, #20


## 작업 내용
- 유저 엔티티 수정
- 비밀번호 확인, 비밀번호 수정, 회원탈퇴, 회원정보 조회 추가
- 유저 업데이트 관련 api String 타입 말고 Map<String, String> 으로 바꾸고 .get()으로 데이터 사용으로 수정
- 파일 업데이트 서비스 .JPG로  되어있으면 파일타입 오류 뜨는거 수정

## 스크린샷 (선택)



## 리뷰 요구사항 혹은 기타 (선택)
