### PR TITLE
[Feat] 위키 수정(버전 업데이트) 기능 (#79)

### DIFF
--- a/frontend/src/components/wiki/WikiDetailComponent.vue
+++ b/frontend/src/components/wiki/WikiDetailComponent.vue
@@ -7,15 +7,14 @@
                     <div class="sc-fvxzrP jGdQwA" style="display: flex; justify-content: space-between;">
                         <div class="information" style="margin-left: 15px;">
                             <span class="version">
-                                <a href="이전 버전 리스트 링크 달기" class="sc-egiyK cyyZlI">이전 버전</a>
+                                <a href="#" class="sc-egiyK cyyZlI">이전 버전</a>
                             </span>
                             <span class="version" style="margin-left: 15px;">
                                 <span class="sc-egiyK cyyZlI">현재 버전 : {{ wikiDetail.version }}</span>
                             </span>
                         </div>
                         <div class="sc-fbyfCU eYeYLy" style="margin-left: auto;">
-                            <!-- 수정 버튼 (로그인 상태 확인 후 뉴비, Guest가 아닌 경우에만 표시) -->
-                            <button v-if="canEditWiki" @click="goToEditPage"
+                            <button v-if="canEditWiki && wikiDetail.title" @click="goToEditPage"
                                 class="ml-3 bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600">
                                 수정
                             </button>
@@ -44,10 +43,11 @@
         </div>
     </div>
 </template>
-  
+
 <script>
 import { mapStores } from "pinia";
 import { useWikiStore } from "@/store/useWikiStore";
+import { useUserStore } from "@/store/useUserStore";
 import VMdPreview from '@kangc/v-md-editor/lib/preview';
 import githubTheme from '@kangc/v-md-editor/lib/theme/github.js';
 import '@kangc/v-md-editor/lib/style/preview.css';
@@ -61,32 +61,43 @@ export default {
     name: "WikiDetailComponent",
     data() {
         return {
-            id: '', 
+            id: '',
+            userGrade: 'GUEST', // 기본값 설정
         };
     },
     computed: {
         ...mapStores(useWikiStore),
+        ...mapStores(useUserStore),
         wikiDetail() {
             return this.wikiStore.wikiDetail || {};
         },
         canEditWiki() {
-            return this.wikiStore.isLoggedIn && this.wikiStore.userDetails && this.wikiStore.userDetails.grade !== '뉴비' && this.wikiStore.userDetails.grade !== 'GUEST';
+            // 유저 등급과 로그인 상태에 따른 수정 권한 체크
+            return this.userGrade !== '뉴비' && this.userGrade !== 'GUEST' && this.userStore.isLoggedIn;
         },
+    },
+    watch: {
+        // 로그인 상태가 변경될 때 버튼 상태를 갱신
+        'userStore.isLoggedIn'(newValue) {
+            if (!newValue) {
+                this.userGrade = 'GUEST'; // 로그아웃 상태로 변경
+            }
+        }
     },
     created() {
         this.id = this.$route.query.id || this.$route.params.id;
-
         if (this.id) {
-            this.fetchWikiDetail().then(() => {
-                console.log('User Details:', this.wikiStore.userDetails); 
-            }).catch(error => {
-                console.error('Wiki Detail Fetch Error:', error);
-            });
+            this.fetchWikiDetail(); // 위키 상세 조회
         }
     },
     methods: {
         async fetchWikiDetail() {
-            await this.wikiStore.fetchWikiDetail(this.id);
+            try {
+                await this.wikiStore.fetchWikiDetail(this.id);
+                this.userGrade = this.wikiStore.wikiDetail.userGrade || 'GUEST';
+            } catch (error) {
+                console.error('Wiki Detail Fetch Error:', error);
+            }
         },
         goToEditPage() {
             this.$router.push({ name: 'WikiUpdate', query: { id: this.id } });
@@ -98,8 +109,51 @@ export default {
 };
 </script>
 
-    
+
+
 <style scoped>
+v-md-preview {
+    font-size: 1.125rem;
+    line-height: 1.7;
+    word-break: keep-all;
+    overflow-wrap: break-word;
+    color: var(--text1);
+}
+
+v-md-preview h1,
+v-md-preview h2,
+v-md-preview h3 {
+    margin-bottom: 1rem;
+    color: var(--text1);
+}
+
+v-md-preview p {
+    margin-bottom: 1.5rem;
+}
+
+.dXONqK {
+    width: 768px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.head-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 20px;
+}
+
+.sc-egiyK {
+    color: #007bff;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.sc-egiyK:hover {
+    text-decoration: underline;
+}
+
 v-md-preview {
     font-size: 1.125rem;
     line-height: 1.7;

--- a/frontend/src/components/wiki/WikiDetailComponent.vue
+++ b/frontend/src/components/wiki/WikiDetailComponent.vue
@@ -14,15 +14,11 @@
                             </span>
                         </div>
                         <div class="sc-fbyfCU eYeYLy" style="margin-left: auto;">
-                            <div data-testid="follow-btn" class="sc-avest iIZjji">
-                                <button data-testid="scrap-btn" class="sc-avest iIZjji"
-                                    style="border: none; background-color: transparent;">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none"
-                                        stroke="currentColor" class="bi bi-bookmark" viewBox="0 0 16 16">
-                                        <path d="M2 2v13.5l6-3.5 6 3.5V2a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z" />
-                                    </svg>
-                                </button>
-                            </div>
+                            <!-- 수정 버튼 (로그인 상태 확인 후 뉴비, Guest가 아닌 경우에만 표시) -->
+                            <button v-if="canEditWiki" @click="goToEditPage"
+                                class="ml-3 bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600">
+                                수정
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -33,9 +29,7 @@
 
                 <div class="sc-jlRLRk iGRQXB">
                     <div class="sc-dUbtfd kOYWDF">
-                        <div class="sc-jHkVzv dyVEVs sc-htJRVC jfYEFP">
-
-                        </div>
+                        <div class="sc-jHkVzv dyVEVs sc-htJRVC jfYEFP"></div>
                     </div>
                 </div>
             </div>
@@ -44,8 +38,6 @@
         <div class="sc-dFtzxp bfzjcP" style="margin-top: 1px;">
             <div class="sc-bXTejn FTZwa">
                 <div class="sc-eGRUor gdnhbG atom-one">
-
-                    <!-- 마크다운 내용 -->
                     <v-md-preview :text="wikiDetail.content" />
                 </div>
             </div>
@@ -69,7 +61,7 @@ export default {
     name: "WikiDetailComponent",
     data() {
         return {
-            id: '',
+            id: '', 
         };
     },
     computed: {
@@ -77,25 +69,27 @@ export default {
         wikiDetail() {
             return this.wikiStore.wikiDetail || {};
         },
+        canEditWiki() {
+            return this.wikiStore.isLoggedIn && this.wikiStore.userDetails && this.wikiStore.userDetails.grade !== '뉴비' && this.wikiStore.userDetails.grade !== 'GUEST';
+        },
     },
     created() {
         this.id = this.$route.query.id || this.$route.params.id;
+
         if (this.id) {
-            this.fetchWikiDetail();
+            this.fetchWikiDetail().then(() => {
+                console.log('User Details:', this.wikiStore.userDetails); 
+            }).catch(error => {
+                console.error('Wiki Detail Fetch Error:', error);
+            });
         }
     },
     methods: {
         async fetchWikiDetail() {
-            try {
-                await this.wikiStore.fetchWikiDetail(this.id);
-            } catch (error) {
-                console.error("위키 상세 조회 중 오류:", error);
-            }
+            await this.wikiStore.fetchWikiDetail(this.id);
         },
-        async toggleScrap() {
-            if (this.id) {
-                await this.wikiStore.toggleScrap(this.id);
-            }
+        goToEditPage() {
+            this.$router.push({ name: 'WikiUpdate', query: { id: this.id } });
         },
     },
     components: {
@@ -103,7 +97,8 @@ export default {
     },
 };
 </script>
-  
+
+    
 <style scoped>
 v-md-preview {
     font-size: 1.125rem;
@@ -123,7 +118,6 @@ v-md-preview h3 {
 v-md-preview p {
     margin-bottom: 1.5rem;
 }
-
 
 .dXONqK {
     width: 768px;

--- a/frontend/src/components/wiki/WikiRegisterComponent.vue
+++ b/frontend/src/components/wiki/WikiRegisterComponent.vue
@@ -101,10 +101,10 @@ export default {
                 title: '',
                 myText: '',
                 mySuperCategory: '',
-                mySuperCategoryName: '' // 카테고리 이름을 위한 변수 추가
+                mySuperCategoryName: '' 
             },
             thumbnail: null,
-            showSuperCategoryModal: false, // 모달 열림 상태
+            showSuperCategoryModal: false, 
         }
         
     },
@@ -136,7 +136,7 @@ export default {
         },
         clearThumbnail() {
             this.thumbnail = null;
-            this.$refs.thumbnailInput.value = ''; // 파일 입력 필드 초기화
+            this.$refs.thumbnailInput.value = ''; 
         },
         async submitForm() {
             console.log(this.wikiRegisterReq.title);

--- a/frontend/src/components/wiki/WikiRegisterComponent.vue
+++ b/frontend/src/components/wiki/WikiRegisterComponent.vue
@@ -101,12 +101,12 @@ export default {
                 title: '',
                 myText: '',
                 mySuperCategory: '',
-                mySuperCategoryName: '' 
+                mySuperCategoryName: ''
             },
             thumbnail: null,
-            showSuperCategoryModal: false, 
+            showSuperCategoryModal: false,
         }
-        
+
     },
     computed: {
         ...mapStores(useWikiStore),
@@ -125,45 +125,44 @@ export default {
             }
             this.wikiRegisterReq.mySuperCategory = selectedSuperCategory.id;
             this.wikiRegisterReq.mySuperCategoryName = selectedSuperCategory.categoryName; // 수정된 부분
-            this.showSuperCategoryModal = false; 
+            this.showSuperCategoryModal = false;
         },
         closeSuperCategoryModal() {
             this.showSuperCategoryModal = false;
         },
         setImages(event) {
-            const file = event.target.files[0]; 
+            const file = event.target.files[0];
             this.thumbnail = file;
         },
         clearThumbnail() {
             this.thumbnail = null;
-            this.$refs.thumbnailInput.value = ''; 
+            this.$refs.thumbnailInput.value = '';
         },
         async submitForm() {
-            console.log(this.wikiRegisterReq.title);
-     
-            if (this.wikiRegisterReq.myText.trim() === '') {
-                alert('본문을 입력해주세요.');
-                return;
-            }
-            if (!this.wikiRegisterReq.mySuperCategory) {
-                alert('상위 카테고리를 선택해주세요.');
-                return;
-            }
-            console.log("mySuperCategory 값:", this.wikiRegisterReq.mySuperCategory);
-            console.log("mySuperCategory 값:", this.wikiRegisterReq.myText);
+    console.log(this.wikiRegisterReq.title);
 
+    if (this.wikiRegisterReq.myText.trim() === '') {
+        alert('본문을 입력해주세요.');
+        return;
+    }
+    if (!this.wikiRegisterReq.mySuperCategory) {
+        alert('상위 카테고리를 선택해주세요.');
+        return;
+    }
 
-            this.wikiStore.wikiRegisterReq.title=this.wikiRegisterReq.title;
-            this.wikiStore.wikiRegisterReq.content=this.wikiRegisterReq.myText;
-            this.wikiStore.wikiRegisterReq.categoryId=this.wikiRegisterReq.mySuperCategory;
-            const result = await this.wikiStore.registerWiki(this.thumbnail);
-            if (result) {
-                alert("정상적으로 등록되었습니다.");
-                this.$router.push("/wiki");
-            } else {
-                alert("등록에 실패하였습니다. 다시 시도해주세요.");
-                this.$router.go();
-            }
+    this.wikiStore.wikiRegisterReq.title = this.wikiRegisterReq.title;
+    this.wikiStore.wikiRegisterReq.content = this.wikiRegisterReq.myText;
+    this.wikiStore.wikiRegisterReq.categoryId = this.wikiRegisterReq.mySuperCategory;
+    
+    const result = await this.wikiStore.registerWiki(this.thumbnail);
+
+    if (result) {
+        alert("정상적으로 등록되었습니다.");
+        // 등록된 위키의 상세 페이지로 리다이렉트
+        this.$router.push({ name: "WikiDetail", query: { id: result } });
+    } else {
+        alert("등록에 실패하였습니다. 다시 시도해주세요.");
+    }
         },
         cancel() {
         }

--- a/frontend/src/components/wiki/WikiUpdateComponent.vue
+++ b/frontend/src/components/wiki/WikiUpdateComponent.vue
@@ -1,0 +1,149 @@
+<template>
+  <div id="__next">
+    <main class="mx-auto mt-2 w-full max-w-7xl px-4 lg:mt-[18px] lg:px-0">
+      <div class="flex lg:space-x-10">
+        <div class="w-full min-w-0 flex-auto lg:static lg:max-h-full lg:overflow-visible">
+          <div class="space-y-10">
+            <div class="space-y-2">
+              <h3 class="text-xl font-medium sm:text-3xl sm:leading-10">기술 위키 수정하기</h3>
+            </div>
+            <form @submit.prevent="submitUpdate">
+              <div class="space-y-12 sm:space-y-14">
+                <div class="grid grid-cols-1 gap-y-7">
+                  
+                  <!-- 제목 (수정 불가) -->
+                  <div class="space-y-1">
+                    <label for="title" class="text-sm font-medium text-gray-700">제목</label>
+                    <input type="text" v-model="updatedTitle" class="form-control" readonly />
+                  </div>
+
+                  <!-- 카테고리 (수정 불가) -->
+                  <div class="space-y-1">
+                    <label for="category" class="text-sm font-medium text-gray-700">카테고리</label>
+                    <input type="text" v-model="updatedCategory" class="form-control" readonly />
+                  </div>
+
+                  <!-- 내용 수정 -->
+                  <div class="space-y-1">
+                    <label for="content" class="text-sm font-medium text-gray-700">내용</label>
+                    <v-md-editor v-model="updatedContent" height="400px"></v-md-editor>
+                  </div>
+
+                  <!-- 썸네일 수정 -->
+                  <div class="space-y-1">
+                    <label for="thumbnail" class="text-sm font-medium text-gray-700">썸네일 수정</label>
+                    <div class="flex w-full">
+                      <input type="file" id="thumbnail" name="thumbnail" ref="thumbnailInput"
+                             class="block w-full appearance-none rounded-md border border-gray-500/30 pl-3 pr-3 py-2 text-base placeholder-gray-500/80 shadow-sm focus:border-gray-500 focus:outline-none focus:ring-0 dark:bg-gray-500/20"
+                             accept="image/*" @change="setImages" />
+                      <button type="button" id="clearThumbnail"
+                              class="ml-3 w-20 items-center space-x-2 rounded-md bg-red-500 px-4 py-2 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-red-600"
+                              @click="clearThumbnail">취소
+                      </button>
+                    </div>
+                    <!-- 현재 썸네일 미리보기 -->
+                    <div v-if="currentThumbnail" class="mt-2">
+                      <p>현재 썸네일:</p>
+                      <img :src="currentThumbnail" alt="썸네일 미리보기" width="150px" />
+                    </div>
+                  </div>
+                </div>
+
+                <!-- 버튼 -->
+                <div class="mt-5 flex justify-between gap-x-3 mb-10">
+                  <button type="button"
+                          class="w-20 rounded-md bg-white px-4 py-2 text-sm font-medium shadow-sm ring-1 ring-gray-500/30 hover:bg-gray-100 focus:outline-none dark:bg-gray-700 dark:ring-gray-500/70 dark:hover:bg-gray-600"
+                          @click="cancel">취소
+                  </button>
+                  <div class="relative flex shrink-0 items-center gap-x-3">
+                    <button type="submit"
+                            class="inline-flex items-center space-x-2 rounded-md bg-blue-500 px-8 py-2 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-blue-600 disabled:bg-blue-500 disabled:opacity-40"
+                            :disabled="isNullOrEmpty">저장
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script>
+import { useWikiStore } from "@/store/useWikiStore";
+import { mapStores } from "pinia";
+import VMdEditor from '@kangc/v-md-editor';
+
+export default {
+  name: "WikiUpdateComponent",
+  components: {
+    VMdEditor,
+  },
+  data() {
+    return {
+      updatedTitle: "", 
+      updatedCategory: "", 
+      updatedContent: "", 
+      updatedThumbnail: null, 
+      currentThumbnail: "", 
+    };
+  },
+  computed: {
+    ...mapStores(useWikiStore),
+    isNullOrEmpty() {
+      return this.updatedContent.trim() === "";
+    },
+  },
+  created() {
+    const id = this.$route.query.id;
+    if (id) {
+      this.fetchWikiDetail(id); 
+    }
+  },
+  methods: {
+    async fetchWikiDetail(id) {
+      try {
+        await this.wikiStore.fetchWikiDetail(id); 
+        this.updatedTitle = this.wikiStore.wikiDetail.title; 
+        this.updatedCategory = this.wikiStore.wikiDetail.category; 
+        this.updatedContent = this.wikiStore.wikiDetail.content;
+        this.currentThumbnail = this.wikiStore.wikiDetail.thumbnail;
+      } catch (error) {
+        console.error("위키 상세 조회 중 오류:", error);
+      }
+    },
+    setImages(event) {
+      const file = event.target.files[0];
+      this.updatedThumbnail = file;
+    },
+    clearThumbnail() {
+      this.updatedThumbnail = null;
+      this.$refs.thumbnailInput.value = ''; 
+    },
+    async submitUpdate() {
+      try {
+        const id = this.$route.query.id;
+        console.log("Updating Wiki with ID:", id);
+        await this.wikiStore.updateWiki(id, this.updatedContent, this.updatedThumbnail);  // Store 메서드 호출
+        alert("수정이 완료되었습니다.");
+        this.$router.push({ name: "WikiDetail", query: { id } });
+      } catch (error) {
+        console.error("수정 중 오류 발생:", error);
+        alert("수정에 실패했습니다. 다시 시도해주세요.");
+      }
+    },
+    cancel() {
+      const id = this.$route.query.id;
+      this.$router.push({ name: "WikiDetail", query: { id } });
+    },
+  },
+};
+</script>
+
+<style scoped>
+#rowGapZero {
+  row-gap: 0;
+}
+</style>

--- a/frontend/src/components/wiki/WikiUpdateComponent.vue
+++ b/frontend/src/components/wiki/WikiUpdateComponent.vue
@@ -11,25 +11,21 @@
               <div class="space-y-12 sm:space-y-14">
                 <div class="grid grid-cols-1 gap-y-7">
                   
-                  <!-- 제목 (수정 불가) -->
                   <div class="space-y-1">
                     <label for="title" class="text-sm font-medium text-gray-700">제목</label>
                     <input type="text" v-model="updatedTitle" class="form-control" readonly />
                   </div>
 
-                  <!-- 카테고리 (수정 불가) -->
                   <div class="space-y-1">
                     <label for="category" class="text-sm font-medium text-gray-700">카테고리</label>
                     <input type="text" v-model="updatedCategory" class="form-control" readonly />
                   </div>
 
-                  <!-- 내용 수정 -->
                   <div class="space-y-1">
                     <label for="content" class="text-sm font-medium text-gray-700">내용</label>
                     <v-md-editor v-model="updatedContent" height="400px"></v-md-editor>
                   </div>
 
-                  <!-- 썸네일 수정 -->
                   <div class="space-y-1">
                     <label for="thumbnail" class="text-sm font-medium text-gray-700">썸네일 수정</label>
                     <div class="flex w-full">
@@ -49,7 +45,6 @@
                   </div>
                 </div>
 
-                <!-- 버튼 -->
                 <div class="mt-5 flex justify-between gap-x-3 mb-10">
                   <button type="button"
                           class="w-20 rounded-md bg-white px-4 py-2 text-sm font-medium shadow-sm ring-1 ring-gray-500/30 hover:bg-gray-100 focus:outline-none dark:bg-gray-700 dark:ring-gray-500/70 dark:hover:bg-gray-600"

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,6 +9,7 @@ import '@kangc/v-md-editor/lib/style/base-editor.css';
 import githubTheme from '@kangc/v-md-editor/lib/theme/github.js';
 import '@kangc/v-md-editor/lib/theme/style/github.css';
 import VMdPreview from '@kangc/v-md-editor/lib/preview';
+import '@kangc/v-md-editor/lib/style/preview.css';
 
 // highlightjs
 import hljs from 'highlight.js';

--- a/frontend/src/pages/WikiDetailPage.vue
+++ b/frontend/src/pages/WikiDetailPage.vue
@@ -20,13 +20,6 @@
   </script>
   
   <style scoped>
-  .custom-container {
-    padding: 20px;
-  }
-  .content-wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
+
   </style>
   

--- a/frontend/src/pages/WikiUpdatePage.vue
+++ b/frontend/src/pages/WikiUpdatePage.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="custom-container">
+      <div id="root">
+        <div class="content-wrapper">
+          <WikiUpdateComponent />
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  import WikiUpdateComponent from '@/components/wiki/WikiUpdateComponent.vue';
+  
+  export default {
+    name: "WikiUpdatePage",
+    data() {
+        return {
+            isLoading: true
+        }
+    },
+    components: {
+      WikiUpdateComponent
+    }
+  }
+  </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,6 +11,7 @@ import PointInfoComponent from "@/components/Point/PointInfoComponent.vue";
 import PointRankingComponent from "@/components/Point/PointRankingComponent.vue";
 import WikiDetailPage from "@/pages/WikiDetailPage.vue";
 import QnaDetailPage from "@/pages/QnaDetailPage.vue";
+import WikiUpdatePage from "@/pages/WikiUpdatePage.vue";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -27,7 +28,8 @@ const router = createRouter({
         { path: "info", component: PointInfoComponent },
         { path: "rank", component: PointRankingComponent },
       ]},
-    { path: "/wiki/detail", component: WikiDetailPage }
+    { path: "/wiki/detail", name: "WikiDetail", component: WikiDetailPage },
+    { path: "/wiki/update", name: "WikiUpdate", component: WikiUpdatePage },
   ]
   
 });


### PR DESCRIPTION
## 연관 이슈
close #79 


## 작업 내용
📌위키 수정 기능 구현
- 위키 thumbnail, content만 수정 가능하도록 설정
 - 썸네일 미등록시, 기존 썸네일을 유지하도록 로직 구성
- 페이지 라우터 설정
- axios 설정
- 권한이 있는 사용자만 수정 버튼을 볼 수 있도록 구현
 - 비로그인 유저, '뉴비' 등급은 수정 권한이 없으며, 해당 등급에 해당하는 사용자는 수정 버튼을 보지 못하게 설정
- 수정 완료시, 버전 업데이트 되어 현재 버전과 함께 상세페이지로 리다이렉트 처리


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/c15c953a-453b-42e0-8803-0ad3d9b5f178)
![image](https://github.com/user-attachments/assets/bd4f51d0-03d2-41a9-8fcd-f3e932b64080)
![image](https://github.com/user-attachments/assets/c92cd57b-2dd0-4fb8-9f4c-1aa7686a02f9)



## 리뷰 요구사항 혹은 기타 (선택)
아직 이쁘게 꾸미지는 못했엉 ^_ㅠ