### PR TITLE
[Feat] Qna 좋아요, 싫어요 및 스크랩 설정 및 검증 메소드 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -40,6 +40,7 @@ public enum BaseResponseStatus {
     // 에러 아카이브 기능 - 6000
 
     // 에러 QnA 기능 - 7000
+
     // - QnA 공통 에러
     QNA_FAIL(false, 7001, "요청이 실패하였습니다."),
     QNA_INVALID_OR_EMPTY_DATA(false, 7002, "데이터 값이 비어있거나, 유효하지 않은 데이터입니다."),

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -36,9 +36,39 @@ public class QuestionController {
 
     //qna 상세 조회
     @GetMapping("/detail")
-    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId) {
-        GetQuestionDetailRes questionDetailRes = qnaService.getQuestionDetail(qnaBoardId);
+    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        GetQuestionDetailRes questionDetailRes = qnaService.getQuestionDetail(qnaBoardId,customUserDetails.getUserId());
         return new BaseResponse<>(questionDetailRes);
 
     }
+
+    //qna 질문 좋아요
+    @GetMapping("/like")
+    public BaseResponse<Long> checkLike(Long qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long id = qnaService.checkQnaLike(qnaBoardId, customUserDetails.getUserId());
+        return new BaseResponse<>(id);
+    }
+
+    //qna 질문 싫어요
+    @GetMapping("/hate")
+    public BaseResponse<Long> checkHate(Long qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long id = qnaService.checkQnaHate(qnaBoardId, customUserDetails.getUserId());
+        return new BaseResponse<>(id);
+    }
+
+    //qna 내 상태 확인
+    @GetMapping("/my-state")
+    public BaseResponse<Long> getMyState(Long qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long id = qnaService.checkQnaHate(qnaBoardId, customUserDetails.getUserId());
+
+        return new BaseResponse<>(id);
+    }
+
+    //qna 스크랩
+    @GetMapping("/scrap")
+    public BaseResponse<Long> checkScrap(Long qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long id = qnaService.checkQnaScrap(qnaBoardId, customUserDetails.getUserId());
+        return new BaseResponse<>(id);
+    }
+
 }

--- a/backend/src/main/java/org/example/backend/Qna/Repository/AnswerLikeRepository.java
+++ b/backend/src/main/java/org/example/backend/Qna/Repository/AnswerLikeRepository.java
@@ -1,0 +1,18 @@
+package org.example.backend.Qna.Repository;
+
+import org.example.backend.Qna.model.Entity.AnswerLike;
+import org.example.backend.Qna.model.Entity.QnaLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface AnswerLikeRepository extends JpaRepository<AnswerLike, Long> {
+    // 어떤 유저가 답변에 좋아요 또는 싫어요 혹은 미표기 했는지 확인하는 쿼리문
+    @Query("SELECT al.state FROM AnswerLike al WHERE al.answer.id = :answerId AND al.user.id = :userId")
+    Optional<Boolean> findStateByAnswerIdAndUserId(@Param("answerId") Long answerId, @Param("userId") Long userId);
+
+    @Query("SELECT al FROM AnswerLike al WHERE al.answer.id = :answerId AND al.user.id = :userId")
+    Optional<AnswerLike> findLikeByQnaAnswerIdAndUserId(@Param("answerId") Long answerId, @Param("userId") Long userId);
+}

--- a/backend/src/main/java/org/example/backend/Qna/Repository/QnaLikeRepository.java
+++ b/backend/src/main/java/org/example/backend/Qna/Repository/QnaLikeRepository.java
@@ -1,0 +1,24 @@
+package org.example.backend.Qna.Repository;
+
+import org.example.backend.Qna.model.Entity.QnaBoard;
+import org.example.backend.Qna.model.Entity.QnaLike;
+import org.example.backend.Qna.model.Entity.QnaScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QnaLikeRepository extends JpaRepository<QnaLike, Long> {
+//    // 게시판의 좋아요 또는 싫어요 수를 세는 쿼리
+//    @Query("SELECT COUNT(l) FROM QnaLike l WHERE l.qnaBoard = :qnaBoard AND l.state = :state")
+//    Integer QnaLikeCountByQnaBoard(@Param("qnaBoard") QnaBoard qnaBoard, @Param("state") boolean state);
+
+    // 어떤 유저가 게시글에 좋아요 또는 싫어요 혹은 미표기 했는지 확인하는 쿼리문
+    @Query("SELECT ql.state FROM QnaLike ql WHERE ql.qnaBoard.id = :qnaBoardId AND ql.user.id = :userId")
+    Optional<Boolean> findStateByQnaBoardIdAndUserId(@Param("qnaBoardId") Long qnaBoardId, @Param("userId") Long userId);
+
+    @Query("SELECT ql FROM QnaLike ql WHERE ql.qnaBoard.id = :qnaBoardId AND ql.user.id = :userId AND ql.state = :state")
+    Optional<QnaLike> findLikeByQnaBoardIdAndUserIdAndState(@Param("qnaBoardId") Long qnaBoardId, @Param("userId") Long userId, @Param("state") Boolean state);
+}

--- a/backend/src/main/java/org/example/backend/Qna/Repository/QnaScrapRepository.java
+++ b/backend/src/main/java/org/example/backend/Qna/Repository/QnaScrapRepository.java
@@ -1,0 +1,15 @@
+package org.example.backend.Qna.Repository;
+
+import org.example.backend.Qna.model.Entity.QnaLike;
+import org.example.backend.Qna.model.Entity.QnaScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface QnaScrapRepository extends JpaRepository<QnaScrap, Long> {
+  // 어떤 유저가 게시글을 스크랩 했는지 확인하는 쿼리문 (후에 마이페이지에서 사용되기 때문에 scrap 전체를 추출)
+    @Query("SELECT qs FROM QnaScrap qs WHERE qs.qnaBoard.id = :qnaBoardId AND qs.user.id = :userId")
+    Optional<QnaScrap> findScrapByQnaBoardIdAndUserId(@Param("qnaBoardId") Long qnaBoardId, @Param("userId") Long userId);
+}

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -2,18 +2,16 @@ package org.example.backend.Qna.Service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.example.backend.Answer.Model.Entity.Answer;
-import org.example.backend.Answer.Model.Entity.AnswerComment;
-import org.example.backend.Answer.Model.Entity.AnswerLike;
 import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.Category.Repository.CategoryRepository;
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidQnaException;
 import org.example.backend.Exception.custom.InvalidUserException;
+import org.example.backend.Qna.Repository.AnswerLikeRepository;
+import org.example.backend.Qna.Repository.QnaLikeRepository;
+import org.example.backend.Qna.Repository.QnaScrapRepository;
 import org.example.backend.Qna.Repository.QuestionRepository;
-import org.example.backend.Qna.model.Entity.QnaBoard;
-import org.example.backend.Qna.model.Entity.QnaLike;
-import org.example.backend.Qna.model.Entity.QnaScrap;
+import org.example.backend.Qna.model.Entity.*;
 import org.example.backend.Qna.model.Res.GetAnswerCommentDetailListRes;
 import org.example.backend.Qna.model.Res.GetAnswerDetailListRes;
 import org.example.backend.Qna.model.Res.GetQnaListRes;
@@ -38,6 +36,9 @@ public class QnaService {
     private final QuestionRepository questionRepository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
+    private final QnaLikeRepository qnaLikeRepository;
+    private final AnswerLikeRepository answerLikeRepository;
+    private final QnaScrapRepository qnaScrapRepository;
 
     @Transactional
     public Long saveQuestion(CreateQuestionReq createQuestionReq, Long userId) {
@@ -93,10 +94,11 @@ public class QnaService {
                 .collect(Collectors.toList());
     }
 
-    public GetQuestionDetailRes getQuestionDetail(Integer qnaBoardId) {
+    public GetQuestionDetailRes getQuestionDetail(Integer qnaBoardId, Long userId) {
+        Optional<User> user = userRepository.findById(userId);
         Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId.longValue());
         GetQuestionDetailRes questionDetail;
-        if (qnaBoard.isPresent()) {
+        if (qnaBoard.isPresent() && user.isPresent()) {
             questionDetail = GetQuestionDetailRes.builder()
                     .title(qnaBoard.get().getTitle())
                     .content(qnaBoard.get().getContent())
@@ -106,14 +108,13 @@ public class QnaService {
                             qnaBoard.get().getCategory().getCategoryName() : null)
                     .likeCnt(qnaBoard.get().getLikeCount())
                     .hateCnt(qnaBoard.get().getHateCount())
-                    .checkLike(isQuestionLikeORHate(qnaBoard.get().getQnaLikeList()))
-                    .checkHate(isQuestionLikeORHate(qnaBoard.get().getQnaLikeList()))
-                    .checkScrap(isQuestionScarp(qnaBoard.get().getQnaScrapList()))
+                    .checkLikeOrHate(isQuestionLikeORHate(qnaBoard.get(), user.get()))
+                    .checkScrap(isQuestionScarp(qnaBoard.get(), user.get()))
                     .nickname(qnaBoard.get().getUser().getNickname())
                     .grade(qnaBoard.get().getUser().getGrade())
                     .profileImage(qnaBoard.get().getUser().getProfileImg())
                     .createdAt(qnaBoard.get().getCreatedAt())
-                    .answers(getAnswerDetails(qnaBoard.get().getAnswerList()))
+                    .answers(getAnswerDetails(qnaBoard.get().getAnswerList(), user.get()))
                     .build();
         } else {
             throw new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND);
@@ -121,15 +122,14 @@ public class QnaService {
         return questionDetail;
     }
 
-    public List<GetAnswerDetailListRes> getAnswerDetails(List<Answer> answers) {
+    public List<GetAnswerDetailListRes> getAnswerDetails(List<Answer> answers, User user) {
         return answers.stream()
                 .map(answer -> GetAnswerDetailListRes.builder()
                         .id(answer.getId())
                         .answer(answer.getContent())
                         .likeCnt(answer.getLikeCnt())
                         .hateCnt(answer.getHateCnt())
-                        .checkLike(isAnswerLikeORHate(answer.getAnswerLikeList()))
-                        .checkHate(isAnswerLikeORHate(answer.getAnswerLikeList()))
+                        .checkLikeOrHate(isAnswerLikeORHate(answer, user))
                         .nickname(answer.getUser().getNickname())
                         .grade(answer.getUser().getGrade())
                         .profileImage(answer.getUser().getProfileImg())
@@ -137,6 +137,7 @@ public class QnaService {
                         .comments(getAnswerCommentDetails(answer.getAnswerCommentList()))
                         .build())
                 .collect(Collectors.toList());
+
     }
 
     public List<GetAnswerCommentDetailListRes> getAnswerCommentDetails(List<AnswerComment> answerComments) {
@@ -144,7 +145,7 @@ public class QnaService {
                 .map(answerComment -> GetAnswerCommentDetailListRes.builder()
                         .id(answerComment.getId())
                         .superCommentId(answerComment.getAnswerComment() != null ?
-                        answerComment.getId() : null)
+                                answerComment.getId() : null)
                         .answerComment(answerComment.getContent())
                         .nickname(answerComment.getUser().getNickname())
                         .grade(answerComment.getUser().getGrade())
@@ -154,21 +155,143 @@ public class QnaService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public Long checkQnaLike(Long qnaBoardId, Long userId) {
+        Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId);
+        Optional<User> user = userRepository.findById(userId);
+
+        if (qnaBoard.isPresent() && user.isPresent()) {
+            QnaLike qnaLike = QnaLike.builder()
+                    .qnaBoard(qnaBoard.get())
+                    .user(user.get())
+                    .state(true)
+                    .build();
+
+            Optional<QnaLike> beforeLike = qnaLikeRepository.findLikeByQnaBoardIdAndUserIdAndState(qnaBoard.get().getId(), userId, true);
+            Optional<QnaLike> beforeHate = qnaLikeRepository.findLikeByQnaBoardIdAndUserIdAndState(qnaBoard.get().getId(), userId, false);
+            //이전에 좋아요만 했을 경우
+            if (beforeLike.isPresent() && beforeHate.isEmpty()) {
+                qnaLikeRepository.delete(beforeLike.get());
+                qnaBoard.get().decreaseLikeCount();
+                return 0L;
+            }
+            //이전에 싫어요만 했을 경우
+            else if (beforeLike.isEmpty() && beforeHate.isPresent()) {
+                throw new InvalidQnaException(BaseResponseStatus.QNA_CONFLICT_LIKE_DISLIKE);
+            }
+            // 둘다 체크하는 거는 이전 검사로 불가능하므로, 둘다 없는 경우
+            else {
+                qnaLikeRepository.save(qnaLike);
+                qnaBoard.get().increaseLikeCount();
+                return qnaLike.getId();
+            }
+
+        } else if (qnaBoard.isEmpty()) {
+            throw new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND);
+        } else {
+            throw new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND);
+        }
+    }
+
+    @Transactional
+    public Long checkQnaHate(Long qnaBoardId, Long userId) {
+        Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId);
+        Optional<User> user = userRepository.findById(userId);
+
+        if (qnaBoard.isPresent() && user.isPresent()) {
+            QnaLike qnaLike = QnaLike.builder()
+                    .qnaBoard(qnaBoard.get())
+                    .user(user.get())
+                    .state(false)
+                    .build();
+
+            Optional<QnaLike> beforeLike = qnaLikeRepository.findLikeByQnaBoardIdAndUserIdAndState(qnaBoard.get().getId(), userId, true);
+            Optional<QnaLike> beforeHate = qnaLikeRepository.findLikeByQnaBoardIdAndUserIdAndState(qnaBoard.get().getId(), userId, false);
+            //이전에 싫어요만 했을 경우
+            if (beforeHate.isPresent() && beforeLike.isEmpty()) {
+                qnaLikeRepository.delete(beforeHate.get());
+                qnaBoard.get().decreaseHateCount();
+                return 0L;
+            }
+            //이전에 좋아요만 했을 경우
+            else if (beforeHate.isEmpty() && beforeLike.isPresent()) {
+                throw new InvalidQnaException(BaseResponseStatus.QNA_CONFLICT_LIKE_DISLIKE);
+            }
+            // 둘다 체크하는 거는 이전 검사로 불가능하므로, 둘다 없는 경우
+            else {
+                qnaLikeRepository.save(qnaLike);
+                qnaBoard.get().increaseHateCount();
+                return qnaLike.getId();
+            }
+
+        } else if (qnaBoard.isEmpty()) {
+            throw new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND);
+        } else {
+            throw new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND);
+        }
+    }
+
+
+    @Transactional
+    public Long checkQnaScrap(Long qnaBoardId, Long userId) {
+        Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId);
+        Optional<User> user = userRepository.findById(userId);
+
+        if (qnaBoard.isPresent() && user.isPresent()) {
+            QnaScrap qnaScrap = QnaScrap.builder()
+                    .qnaBoard(qnaBoard.get())
+                    .user(user.get())
+                    .build();
+            Optional<QnaScrap> beforeScrap = qnaScrapRepository.findScrapByQnaBoardIdAndUserId(qnaScrap.getId(), userId);
+            if (beforeScrap.isPresent()) {
+                qnaScrapRepository.delete(beforeScrap.get());
+                return 0L;
+            } else {
+                qnaScrapRepository.save(qnaScrap);
+                return qnaScrap.getId();
+            }
+
+        } else if (qnaBoard.isEmpty()) {
+            throw new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND);
+        } else {
+            throw new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND);
+        }
+    }
+
+
+//    public Integer CntLikeOrHateInQna(Long qnaBoardId, boolean state) {
+//        Optional<QnaBoard> qnaBoard = questionRepository.findById(qnaBoardId);
+//        if (qnaBoard.isPresent()) {
+//            Integer likeOrHateCnt = qnaLikeRepository.QnaLikeCountByQnaBoard(qnaBoard.get(), state);
+//            return likeOrHateCnt;
+//
+//        } else {
+//            throw new InvalidUserException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND);
+//        }
+//    }
+
+
     // 현재 접속한 사용자의 좋아요/싫어요/선택 X 상태를 알아내는 함수
+
     //userID-qnaBoardId를 활용해서 해당 사용자가 답변글에 어떤 상태를 표시했는지 나타내는 함수
-    public Boolean isQuestionLikeORHate(List<QnaLike> qnaLikeList) {
-        return true;
+    public Boolean isQuestionLikeORHate(QnaBoard qnaBoard, User user) {
+        Optional<Boolean> state = qnaLikeRepository.findStateByQnaBoardIdAndUserId(qnaBoard.getId(), user.getId());
+        return state.orElse(null);
     }
 
     // userID-qnaBoardId를 활용해서 해당 사용자가 답변글에 어떤 상태를 표시했는지 나타내는 함수
-    public Boolean isAnswerLikeORHate(List<AnswerLike> answerLikeList) {
-        return true;
+    public Boolean isAnswerLikeORHate(Answer answer, User user) {
+        Optional<Boolean> state = answerLikeRepository.findStateByAnswerIdAndUserId(answer.getId(), user.getId());
+        return state.orElse(null);
     }
 
     // 현재 접속한 사용자의 질문에 대한 스크랩 상태를 알아내는 함수
-    private boolean isQuestionScarp(List<QnaScrap> qnaScrapList) {
-        return true;
+    private boolean isQuestionScarp(QnaBoard qnaBoard, User user) {
+        Optional<QnaScrap> qnaScrap = qnaScrapRepository.findScrapByQnaBoardIdAndUserId(qnaBoard.getId(), user.getId());
+        if (qnaScrap.isPresent()) {
+            return true;
+        } else {
+            return false;
+        }
     }
-
-
 }

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/Answer.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/Answer.java
@@ -1,4 +1,4 @@
-package org.example.backend.Answer.Model.Entity;
+package org.example.backend.Qna.model.Entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.User.Model.Entity.User;
-import org.example.backend.Qna.model.Entity.QnaBoard;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/AnswerComment.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/AnswerComment.java
@@ -1,11 +1,10 @@
-package org.example.backend.Answer.Model.Entity;
+package org.example.backend.Qna.model.Entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.User.Model.Entity.User;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/AnswerLike.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/AnswerLike.java
@@ -1,4 +1,4 @@
-package org.example.backend.Answer.Model.Entity;
+package org.example.backend.Qna.model.Entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaBoard.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaBoard.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.backend.Answer.Model.Entity.Answer;
 import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
 import org.example.backend.User.Model.Entity.User;
@@ -74,4 +73,18 @@ public class QnaBoard {
     @LastModifiedDate
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
+
+    public void increaseHateCount() {
+        this.hateCount++;
+    }
+    public void decreaseHateCount() {
+        this.hateCount--;
+    }
 }

--- a/backend/src/main/java/org/example/backend/Qna/model/Res/GetAnswerDetailListRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Res/GetAnswerDetailListRes.java
@@ -12,8 +12,7 @@ public class GetAnswerDetailListRes {
     private String answer;
     private Integer likeCnt;
     private Integer hateCnt;
-    private boolean checkLike;
-    private boolean checkHate;
+    private Boolean checkLikeOrHate;
     private String nickname;
     private String grade;
     private String profileImage;

--- a/backend/src/main/java/org/example/backend/Qna/model/Res/GetQuestionDetailRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Res/GetQuestionDetailRes.java
@@ -14,9 +14,8 @@ public class GetQuestionDetailRes {
     private String subCategoryName;
     private Integer likeCnt;
     private Integer hateCnt;
-    private boolean checkLike;
-    private boolean checkHate;
-    private boolean checkScrap;
+    private Boolean checkLikeOrHate;
+    private Boolean checkScrap;
     private String nickname;
     private String grade;
     private String profileImage;

--- a/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
@@ -2,9 +2,9 @@ package org.example.backend.User.Model.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.example.backend.Answer.Model.Entity.Answer;
-import org.example.backend.Answer.Model.Entity.AnswerComment;
-import org.example.backend.Answer.Model.Entity.AnswerLike;
+import org.example.backend.Qna.model.Entity.Answer;
+import org.example.backend.Qna.model.Entity.AnswerComment;
+import org.example.backend.Qna.model.Entity.AnswerLike;
 import org.example.backend.Chat.Model.Entity.Chat;
 import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
 import org.example.backend.ErrorArchive.Model.Entity.ErrorLike;


### PR DESCRIPTION
## 연관 이슈
close #39 #40 


## 작업 내용
- 좋아요 및 싫어요 각각의 선택 api 구현
- 기존 상태가 선택 상태일 때 해당 like또는 hate를 제거하고 cnt 업데이트
- scrap 선택 api 구현
- 기존 스크랩한 질문의 경우 스크랩 취소
- 질문의 상세 조회에서 현재 사용자가 스크랩 또는 좋아요 및 싫어요를 표기했는지여부를 boolean 값으로 전달
- 각종 에러처리


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)