### PR TITLE
[Feat] 위키 이전버전 목록 조회 API (#33)

### DIFF
--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -6,14 +6,8 @@ import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
-import org.example.backend.Wiki.Model.Req.GetWikiDetailReq;
-import org.example.backend.Wiki.Model.Req.GetWikiListReq;
-import org.example.backend.Wiki.Model.Req.GetWikiUpdateReq;
-import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
-import org.example.backend.Wiki.Model.Res.GetWikiDetailRes;
-import org.example.backend.Wiki.Model.Res.GetWikiUpdateRes;
-import org.example.backend.Wiki.Model.Res.WikiListRes;
-import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
+import org.example.backend.Wiki.Model.Req.*;
+import org.example.backend.Wiki.Model.Res.*;
 import org.example.backend.Wiki.Service.WikiService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -103,6 +97,19 @@ public class WikiController {
 
         return new BaseResponse<>(wikiService.update(getWikiUpdateReq, thumbnailUrl, customUserDetails.getUserId()));
 
+    }
+
+    // 위키 (이번버전) 목록 조회
+    @GetMapping("/version/list")
+    public BaseResponse<List<GetWikiVersionListRes>> versionList(GetWikiVersionListReq getWikiVersionListReq) {
+        if (getWikiVersionListReq.getPage() == null) {
+            getWikiVersionListReq.setPage(0);
+        }
+        if (getWikiVersionListReq.getSize() == null || getWikiVersionListReq.getSize() == 0) {
+            getWikiVersionListReq.setSize(20);
+        }
+        List<GetWikiVersionListRes> wikiVersionList = wikiService.versionList(getWikiVersionListReq);
+        return new BaseResponse<>(wikiVersionList);
     }
 }
 

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiVersionListReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiVersionListReq.java
@@ -1,0 +1,14 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetWikiVersionListReq {
+
+    private Long id;
+    private Integer page;
+    private Integer size;
+
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiVersionListRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiVersionListRes.java
@@ -1,0 +1,16 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class GetWikiVersionListRes {
+
+    private Long wikiContentId;
+    private Integer version;
+    private LocalDateTime createdAt;
+    private String nickname;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiVersionListRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiVersionListRes.java
@@ -13,4 +13,5 @@ public class GetWikiVersionListRes {
     private Integer version;
     private LocalDateTime createdAt;
     private String nickname;
+    private Integer totalPages;
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiContentRepository.java
@@ -1,6 +1,8 @@
 package org.example.backend.Wiki.Repository;
 
 import org.example.backend.Wiki.Model.Entity.WikiContent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,5 @@ import java.util.Optional;
 public interface WikiContentRepository extends JpaRepository<WikiContent, Long> {
 
     Optional<WikiContent> findByWikiIdAndVersion(Long wikiId, Integer version);
+    Page<WikiContent> findAllByWikiId(Long wikiId, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -12,14 +12,8 @@ import org.example.backend.User.Repository.UserRepository;
 import org.example.backend.Wiki.Model.Entity.LatestWiki;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
-import org.example.backend.Wiki.Model.Req.GetWikiDetailReq;
-import org.example.backend.Wiki.Model.Req.GetWikiListReq;
-import org.example.backend.Wiki.Model.Req.GetWikiUpdateReq;
-import org.example.backend.Wiki.Model.Req.WikiRegisterReq;
-import org.example.backend.Wiki.Model.Res.GetWikiDetailRes;
-import org.example.backend.Wiki.Model.Res.GetWikiUpdateRes;
-import org.example.backend.Wiki.Model.Res.WikiListRes;
-import org.example.backend.Wiki.Model.Res.WikiRegisterRes;
+import org.example.backend.Wiki.Model.Req.*;
+import org.example.backend.Wiki.Model.Res.*;
 import org.example.backend.Wiki.Repository.LatestWikiRepository;
 import org.example.backend.Wiki.Repository.WikiContentRepository;
 import org.example.backend.Wiki.Repository.WikiRepository;
@@ -158,12 +152,12 @@ public class WikiService {
         String updateThumbnail = thumbnailUrl;
         if (updateThumbnail == null) {
             updateThumbnail = latestWiki.getThumbnailImgUrl();
-            }
+        }
         // WikiContent 등록
         WikiContent updateWikiContent = WikiContent.builder()
                 .wiki(wiki)
                 .content(getWikiUpdateReq.getContent())
-                .version(latestWiki.getVersion()+1)
+                .version(latestWiki.getVersion() + 1)
                 .user(user)
                 .thumbnail(updateThumbnail)
                 .build();
@@ -176,6 +170,21 @@ public class WikiService {
 
         return GetWikiUpdateRes.builder().wikiId(wiki.getId()).build();
 
+    }
+
+    // 위키 (이전버전) 목록 조회
+    public List<GetWikiVersionListRes> versionList(GetWikiVersionListReq getWikiVersionListReq) {
+        Pageable pageable = PageRequest.of(getWikiVersionListReq.getPage(), getWikiVersionListReq.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<WikiContent> wikiVersionPage = wikiContentRepository.findAllByWikiId(getWikiVersionListReq.getId(), pageable);
+
+        return wikiVersionPage.getContent().stream().map
+                        (wikiContent -> GetWikiVersionListRes.builder()
+                                .wikiContentId(wikiContent.getId())
+                                .version(wikiContent.getVersion())
+                                .createdAt(wikiContent.getCreatedAt())
+                                .nickname(wikiContent.getUser().getNickname())
+                                .build())
+                .collect(Collectors.toList());
     }
 }
 

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -177,12 +177,14 @@ public class WikiService {
         Pageable pageable = PageRequest.of(getWikiVersionListReq.getPage(), getWikiVersionListReq.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<WikiContent> wikiVersionPage = wikiContentRepository.findAllByWikiId(getWikiVersionListReq.getId(), pageable);
 
+
         return wikiVersionPage.getContent().stream().map
                         (wikiContent -> GetWikiVersionListRes.builder()
                                 .wikiContentId(wikiContent.getId())
                                 .version(wikiContent.getVersion())
                                 .createdAt(wikiContent.getCreatedAt())
                                 .nickname(wikiContent.getUser().getNickname())
+                                .totalPages(wikiVersionPage.getTotalPages())
                                 .build())
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 연관 이슈
close #33 


## 작업 내용
📌사용자가 선택한 위키의 이전 버전 목록 조회
- 페이징 처리 및 정렬 설정(createdAt 기준 내림차순)


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/99d9a886-b26c-413b-8b46-dd1a2c0e8b93)


## 리뷰 요구사항 혹은 기타 (선택)