### PR TITLE
[Fix] 채팅 페이지에서 라우팅 안되는 현상 수정

### DIFF
--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -101,7 +101,9 @@ export const useChatStore = defineStore("chat", {
             )
         },
         disconnect() {
-            this.stompClient.disconnect();
+            if (this.stompClient !== null){
+                this.stompClient.disconnect();
+            }
             // console.log("소켓 연결 해제");
         },
         send(message) {


### PR DESCRIPTION
## 연관 이슈


## 작업 내용
- 채팅페이지에 접속했을 때 연결 맺고 있지 않으면, 페이지를 벗어나지 못하는 현상 수정
- 페이지를 벗어날 때 disconnect하는데 맺고있는 연결이 있을 때만 disconnect하도로고 수정

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
