### PR TITLE
[Feat] 에러 아카이브 목록 조회 수정(최신순, 좋아요순)

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -43,6 +43,7 @@ public enum BaseResponseStatus {
     WIKI_PERMISSION_DENIED(false, 5006,"수정 권한이 없습니다."),
 
     // 에러 아카이브 기능 - 6000
+    ERRORARCHIVE_INVALID_SEARCH_TYPE(false, 6060, "존재하지 않은 타입의 검색 방식 입니다."),
 
     // 에러 QnA 기능 - 7000
     // - QnA 공통 에러

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
@@ -35,7 +35,7 @@ public class ErrorArchiveController {
             listErrorArchiveReq.setPage(0);
         }
         if(listErrorArchiveReq.getSize() == null || listErrorArchiveReq.getSize() == 0){
-            listErrorArchiveReq.setSize(20);
+            listErrorArchiveReq.setSize(15);
         }
         List<ListErrorArchiveRes> errorArchiveList = errorArchiveService.errorArchiveList(listErrorArchiveReq);
         return new BaseResponse<>(errorArchiveList);

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Req/ListErrorArchiveReq.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Req/ListErrorArchiveReq.java
@@ -1,11 +1,14 @@
 package org.example.backend.ErrorArchive.Model.Req;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
 @Getter
+@NoArgsConstructor
 public class ListErrorArchiveReq {
+    private String sort;
     private Integer page;
     private Integer size;
 }

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/ListErrorArchiveRes.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/ListErrorArchiveRes.java
@@ -14,4 +14,7 @@ public class ListErrorArchiveRes {
     private int likeCnt;
     private String grade;
     private String createAt;
+    private String nickname;
+    private String profileImg;
+    private Integer totalPage;
 }

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/ListErrorArchiveRes.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/ListErrorArchiveRes.java
@@ -13,7 +13,7 @@ public class ListErrorArchiveRes {
     private String subCategory;
     private int likeCnt;
     private String grade;
-    private String createAt;
+    private String createdAt;
     private String nickname;
     private String profileImg;
     private Integer totalPage;

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
@@ -64,10 +64,12 @@ public class ErrorArchiveService {
                                 .id(errorArchive.getId())
                                 .title(errorArchive.getTitle())
                                 .content(errorArchive.getContent())
-                                .superCategory(errorArchive.getCategory().getCategoryName())
-                                .subCategory(errorArchive.getCategory().getCategoryName())
+                                .superCategory(errorArchive.getCategory().getSuperCategory() == null ?
+                                        errorArchive.getCategory().getCategoryName() :
+                                        errorArchive.getCategory().getSuperCategory().getCategoryName())
+                                .subCategory(errorArchive.getCategory().getSuperCategory() == null ? null: errorArchive.getCategory().getCategoryName())
                                 .likeCnt(errorArchive.getLikeCount())
-                                .createAt(String.valueOf(errorArchive.getCreatedAt()))
+                                .createdAt(String.valueOf(errorArchive.getCreatedAt()))
                                 .grade(errorArchive.getUser().getGrade())
                                 .nickname(errorArchive.getUser().getNickname())
                                 .profileImg(errorArchive.getUser().getProfileImg())


### PR DESCRIPTION
## 연관 이슈
close #이슈번호


## 작업 내용
- 좋아요순, 최신순으로 목록 조회 추가 (기본값은 최신순)
- 에러아카이브 엔티티의 데이터를 페이지 단위로 가져오는 메소드 추가

## 스크린샷 (선택)
<img width="904" alt="image" src="https://github.com/user-attachments/assets/3f431f7b-bd53-4515-94d6-e6742d732b86">


## 리뷰 요구사항 혹은 기타 (선택)
