### PR TITLE
[Feat] 에러 아카이브 목록 조회(최신순, 좋아요순)

### DIFF
--- a/frontend/src/components/Common/SortTypeComponent.vue
+++ b/frontend/src/components/Common/SortTypeComponent.vue
@@ -19,7 +19,7 @@ import {mapStores} from "pinia";
 import {useQnaStore} from "@/store/useQnaStore";
 
 export default {
-  name: "QnaListPage",
+  name: "SortTypeComponent",
   data() {
     return {
       selectedSort: null

--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -16,7 +16,7 @@
         <div class="details">
           <a class="nickname">{{ errorarchiveCard.nickname }}</a>
           <div class="PostCard_subInfo__KqVkC">
-            <span>{{ formatDateTime(errorarchiveCard.createAt) }}</span>
+            <span>{{ formatDateTime(errorarchiveCard.createdAt) }}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -58,7 +58,6 @@ export default {
     },
     components: {},
     mounted() { 
-    console.log(this.errorarchiveCard);
   },
 };
 </script>

--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -1,0 +1,135 @@
+<template>
+    <div class="container">
+      <div class="PostCard_block__FTMsy">
+        <div class="PostCard_content__W3lPm">
+          <div class="PostCard_title">{{ errorarchiveCard.title }}</div>
+          <!-- <div class="PostCard_descriptionWrapper__UQSKA">
+              <p class="PostCard_title">그것이야말로 「행복」에 다다르는 길!</p>
+            </div> -->
+          <div class="PostCard_subInfo__KqVkC">
+            <span>{{ errorarchiveCard.createAt }}</span>
+          </div>
+        </div>
+        <div class="PostCard_footer__9J5Wd">
+          <a class="PostCard_userInfo__Cu1X5" href="/@juunini/posts">
+            <img 
+              loading="lazy" 
+              width="24" 
+              height="24" 
+              decoding="async" 
+              :src="errorarchiveCard.profileImage" 
+              alt="Profile Image"
+              style="color: transparent;"
+            />
+            <span>by <b>{{ errorarchiveCard.nickname }}</b></span> 
+          </a>
+          <div class="PostCard_likes___lp_I">
+            <svg viewBox="0 0 24 24">
+              <path fill="currentColor" d="m18 1-6 4-6-4-6 5v7l12 10 12-10V6z"></path>
+            </svg>
+            <span>{{ errorarchiveCard.likeCnt }}</span> <!-- 바인딩 수정 -->
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  export default {
+    name: "ErrorArchiveCardComponent",
+    props: {
+      errorarchiveCard: {
+        type: Object,
+        required: true,
+      }
+    },
+  };
+  </script>
+  
+  <style scoped>
+  /* 전역 스타일은 제거했습니다. 여기에서의 스타일은 각 컴포넌트에만 적용됩니다. */
+  
+  .PostCard_block__FTMsy {
+    border-left: 1.5px solid #8d8d8d;
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column;
+    width: 100%;
+    background: #fff;
+    box-shadow: 5px 5px 7px 0 rgba(0, 0, 0, 0.08);
+    transition: box-shadow .25s ease-in, transform .25s ease-in;
+  }
+  
+  .PostCard_block__FTMsy:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 20px 0 rgba(0, 0, 0, 0.1);
+  }
+  
+  .PostCard_content__W3lPm {
+    box-sizing: inherit;
+    margin: 0;
+    padding: 1rem;
+    display: flex;
+    flex: 1 1;
+    flex-direction: column;
+  }
+  
+  .PostCard_title {
+    font-size: 1rem;
+    margin: 0 0 .25rem;
+    line-height: 1.5;
+    word-break: break-word;
+    color: #212529;
+  }
+  
+  .PostCard_subInfo__KqVkC {
+    margin-top: auto;
+    font-size: .75rem;
+    line-height: 1.5;
+    color: #868e96;
+  }
+  
+  .PostCard_footer__9J5Wd {
+    border-radius: 0 0 15px 15px;
+    background-color: #f8f9fa;
+    padding: .625rem 1rem;
+    border-top: 1px solid #f1f3f5;
+    display: flex;
+    font-size: .75rem;
+    line-height: 1.5;
+    justify-content: space-between;
+  }
+  
+  .PostCard_userInfo__Cu1X5 {
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    align-items: center;
+  }
+  
+  .PostCard_userInfo__Cu1X5 > img {
+    object-fit: cover;
+    border-radius: 50%;
+    width: 1.5rem;
+    height: 1.5rem;
+    display: block;
+    margin-right: .5rem;
+  }
+  
+  .PostCard_userInfo__Cu1X5 span {
+    color: #868e96;
+  }
+  
+  .PostCard_likes___lp_I {
+    display: flex;
+    align-items: center;
+    color: #212529;
+  }
+  
+  .PostCard_likes___lp_I > svg {
+    width: .75rem;
+    height: .75rem;
+    margin-right: .5rem;
+  }
+  </style>
+  

--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -1,135 +1,168 @@
 <template>
-    <div class="container">
-      <div class="PostCard_block__FTMsy">
-        <div class="PostCard_content__W3lPm">
-          <div class="PostCard_title">{{ errorarchiveCard.title }}</div>
-          <!-- <div class="PostCard_descriptionWrapper__UQSKA">
-              <p class="PostCard_title">그것이야말로 「행복」에 다다르는 길!</p>
-            </div> -->
+  <div class="PostCard_block__FTMsy">
+    <div class="header">
+      <div class="user-info">
+        <a class="PostCard_userInfo__Cu1X5" :href="'/@' + errorarchiveCard.nickname + '/posts'">
+          <img
+            loading="lazy"
+            width="40"
+            height="40"
+            decoding="async"
+            :src="errorarchiveCard.profileImg"
+            alt="Profile Image"
+            class="PostCard_avatar"
+          />
+        </a>
+        <div class="details">
+          <a class="nickname">{{ errorarchiveCard.nickname }}</a>
           <div class="PostCard_subInfo__KqVkC">
-            <span>{{ errorarchiveCard.createAt }}</span>
-          </div>
-        </div>
-        <div class="PostCard_footer__9J5Wd">
-          <a class="PostCard_userInfo__Cu1X5" href="/@juunini/posts">
-            <img 
-              loading="lazy" 
-              width="24" 
-              height="24" 
-              decoding="async" 
-              :src="errorarchiveCard.profileImage" 
-              alt="Profile Image"
-              style="color: transparent;"
-            />
-            <span>by <b>{{ errorarchiveCard.nickname }}</b></span> 
-          </a>
-          <div class="PostCard_likes___lp_I">
-            <svg viewBox="0 0 24 24">
-              <path fill="currentColor" d="m18 1-6 4-6-4-6 5v7l12 10 12-10V6z"></path>
-            </svg>
-            <span>{{ errorarchiveCard.likeCnt }}</span> <!-- 바인딩 수정 -->
+            <span>{{ formatDateTime(errorarchiveCard.createAt) }}</span>
           </div>
         </div>
       </div>
     </div>
-  </template>
-  
-  <script>
-  export default {
-    name: "ErrorArchiveCardComponent",
-    props: {
-      errorarchiveCard: {
-        type: Object,
-        required: true,
-      }
+
+    <div class="PostCard_content__W3lPm">
+      <div class="PostCard_title">{{ errorarchiveCard.title }}</div>
+    </div>
+
+    <div class="PostCard_categories">
+      <span>{{ errorarchiveCard.superCategory }}</span>
+      <span v-if="errorarchiveCard.subCategory">/ {{ errorarchiveCard.subCategory }}</span>
+    </div>
+
+    <div class="PostCard_footer__9J5Wd">
+      <div class="PostCard_likes___lp_I">
+        <svg viewBox="0 0 24 24">
+          <path fill="currentColor" d="m18 1-6 4-6-4-6 5v7l12 10 12-10V6z"></path>
+        </svg>
+        <span>{{ errorarchiveCard.likeCnt }}</span>
+      </div>
+      <div class="PostCard_author__nickname">
+        <span>{{ errorarchiveCard.nickname }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { formatDateTime } from '@/utils/FormatDate';
+export default {
+  name: "ErrorArchiveCardComponent",
+  data() {
+    return {};
+  },
+  props: ["errorarchiveCard"],
+  methods: {
+    formatDateTime
     },
-  };
-  </script>
-  
-  <style scoped>
-  /* 전역 스타일은 제거했습니다. 여기에서의 스타일은 각 컴포넌트에만 적용됩니다. */
-  
-  .PostCard_block__FTMsy {
-    border-left: 1.5px solid #8d8d8d;
-    box-sizing: border-box;
-    display: flex;
-    flex-flow: column;
-    width: 100%;
-    background: #fff;
-    box-shadow: 5px 5px 7px 0 rgba(0, 0, 0, 0.08);
-    transition: box-shadow .25s ease-in, transform .25s ease-in;
-  }
-  
-  .PostCard_block__FTMsy:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 12px 20px 0 rgba(0, 0, 0, 0.1);
-  }
-  
-  .PostCard_content__W3lPm {
-    box-sizing: inherit;
-    margin: 0;
-    padding: 1rem;
-    display: flex;
-    flex: 1 1;
-    flex-direction: column;
-  }
-  
-  .PostCard_title {
-    font-size: 1rem;
-    margin: 0 0 .25rem;
-    line-height: 1.5;
-    word-break: break-word;
-    color: #212529;
-  }
-  
-  .PostCard_subInfo__KqVkC {
-    margin-top: auto;
-    font-size: .75rem;
-    line-height: 1.5;
-    color: #868e96;
-  }
-  
-  .PostCard_footer__9J5Wd {
-    border-radius: 0 0 15px 15px;
-    background-color: #f8f9fa;
-    padding: .625rem 1rem;
-    border-top: 1px solid #f1f3f5;
-    display: flex;
-    font-size: .75rem;
-    line-height: 1.5;
-    justify-content: space-between;
-  }
-  
-  .PostCard_userInfo__Cu1X5 {
-    text-decoration: none;
-    color: inherit;
-    display: flex;
-    align-items: center;
-  }
-  
-  .PostCard_userInfo__Cu1X5 > img {
-    object-fit: cover;
-    border-radius: 50%;
-    width: 1.5rem;
-    height: 1.5rem;
-    display: block;
-    margin-right: .5rem;
-  }
-  
-  .PostCard_userInfo__Cu1X5 span {
-    color: #868e96;
-  }
-  
-  .PostCard_likes___lp_I {
-    display: flex;
-    align-items: center;
-    color: #212529;
-  }
-  
-  .PostCard_likes___lp_I > svg {
-    width: .75rem;
-    height: .75rem;
-    margin-right: .5rem;
-  }
-  </style>
-  
+    components: {},
+    mounted() { 
+    console.log(this.errorarchiveCard);
+  },
+};
+</script>
+
+<style scoped>
+/* 기존 스타일 유지 */
+.PostCard_block__FTMsy {
+  /* border-left: 1.5px solid #8d8d8d; */
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  background: #fff;
+  box-shadow: 5px 5px 7px 0 rgba(0, 0, 0, 0.08);
+  transition: box-shadow .25s ease-in, transform .25s ease-in;
+}
+
+.PostCard_block__FTMsy:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 20px 0 rgba(0, 0, 0, 0.1);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+}
+
+.PostCard_userInfo__Cu1X5 {
+  margin-right: 0.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.PostCard_avatar {
+  object-fit: cover;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+}
+
+.nickname {
+  font-weight: bold;
+  color: #212529;
+}
+
+.PostCard_subInfo__KqVkC {
+  font-size: .75rem;
+  color: #868e96;
+}
+
+.PostCard_content__W3lPm {
+  box-sizing: inherit;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.PostCard_title {
+  font-size: 1rem;
+  margin: 0 0 .25rem;
+  line-height: 1.5;
+  word-break: break-word;
+  color: #212529;
+}
+
+.PostCard_footer__9J5Wd {
+  border-radius: 0 0 15px 15px;
+  background-color: #f8f9fa;
+  padding: .625rem 1rem;
+  border-top: 1px solid #f1f3f5;
+  display: flex;
+  justify-content: space-between;
+  align-items: center; /* 수직 중앙 정렬 */
+}
+
+.PostCard_likes___lp_I {
+  display: flex;
+  align-items: center;
+  color: #212529;
+}
+
+.PostCard_likes___lp_I > svg {
+  width: .75rem;
+  height: .75rem;
+  margin-right: .5rem;
+}
+.PostCard_author__nickname {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+  color: #212529;
+}
+
+
+</style>

--- a/frontend/src/components/errorarchive/ErrorArchiveRegisterComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveRegisterComponent.vue
@@ -142,7 +142,7 @@ export default {
       this.showSuperModal = true;
     },
     closeSuperCategoryModal() {
-      this.showSupeModal = false;
+      this.showSuperModal = false;
     },
     handleSuperCategorySelection(category){
       this.selectedSuperCategory = category;

--- a/frontend/src/components/user/SignUpComponent.vue
+++ b/frontend/src/components/user/SignUpComponent.vue
@@ -67,6 +67,7 @@ import axios from 'axios';
         }
         console.log("success");
         this.$emit('signup', this.userInfo, this.selectedProfileFile);
+        alert("가입 하시겠습니까?");
       },
       handleProfileImageUpload(event) {
         const file = event.target.files[0];

--- a/frontend/src/pages/ErrorArchiveListPage.vue
+++ b/frontend/src/pages/ErrorArchiveListPage.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="card-list">
+    <ErrorArchiveCardComponent
+      v-for="errorarchiveCard in errorarchiveCards"
+      :key="errorarchiveCard.id"
+      :errorarchiveCard="errorarchiveCard"
+    />
+  </div>
+</template>
+
+<script>
+import { useErrorArchiveStore } from '@/store/useErrorArchiveStore';
+import ErrorArchiveCardComponent from '@/components/errorarchive/ErrorArchiveCardComponent.vue'
+
+export default {
+  name: 'ErrorArchiveListPage',
+  data() {
+    return {
+      errorarchiveCards: [],  // 데이터는 여기에서 가져올 수 있도록 합니다.
+    };
+  },
+  async mounted() {
+    // Pinia 스토어 인스턴스를 가져옵니다.
+    const store = useErrorArchiveStore();
+
+    // 초기 정렬 기준과 페이지 번호를 설정합니다.
+    const sort = 'date';  // 예시로 정렬 기준을 날짜로 설정
+    const page = 1;       // 첫 페이지부터 시작
+
+    try {
+      // 스토어의 메소드 호출
+      await store.getErrorArchiveList(sort, page);
+      this.errorarchiveCards = store.errorarchiveCards; // 스토어에서 가져온 데이터로 업데이트
+    } catch (error) {
+      console.error("Error fetching errorarchive list:", error);
+    }
+  },
+  components: {
+    ErrorArchiveCardComponent,
+  },
+};
+</script>
+
+<style scoped>
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+</style>

--- a/frontend/src/pages/ErrorArchiveListPage.vue
+++ b/frontend/src/pages/ErrorArchiveListPage.vue
@@ -63,24 +63,11 @@ export default {
     },
   },
   methods: {
-    async handleCheckLatest() {
-      this.selectedSort = "latest";
-      await this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage - 1);
-      if (this.errorarchiveStore.errorarchiveCards.length !== 0){
-        this.totalPage = this.errorarchiveStore.errorarchiveCards[0].totalPage;
-        console.log("total"+this.totalPage);
-
-      }
-      this.isLoading=true;
+    handleCheckLatest() {
+      this.selectedSort = "latest";    
     },
-    async handleCheckLike() {
+    handleCheckLike() {
       this.selectedSort = "like";
-      await this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage - 1);
-      if (this.errorarchiveStore.errorarchiveCards.length !== 0){
-        this.totalPage = this.errorarchiveStore.errorarchiveCards[0].totalPage;
-        console.log("total"+this.totalPage);
-      }
-      this.isLoading=true;
     },
     handlePageUpdate(newPage) {
       this.selectedPage = newPage;

--- a/frontend/src/pages/ErrorArchiveListPage.vue
+++ b/frontend/src/pages/ErrorArchiveListPage.vue
@@ -1,50 +1,151 @@
 <template>
-  <div class="card-list">
-    <ErrorArchiveCardComponent
-      v-for="errorarchiveCard in errorarchiveCards"
-      :key="errorarchiveCard.id"
-      :errorarchiveCard="errorarchiveCard"
-    />
+  <div v-if="isLoading"></div>
+  <div v-else class="custom-container">
+    <div class="errorarchive-top">
+      <p id="main-title">에러 아카이브</p>
+      <p id="sub-title">당신의 에러 해결 방법을 공유해주세요</p>
+    </div>
+    <div class="errorarchive-inner">
+      <SortTypeComponent @checkLatest="handleCheckLatest"
+                         @checkLike="handleCheckLike"/>
+      <div class="errorarchive-list-flex">
+        <ErrorArchiveCardComponent
+            v-for="errorarchiveCard in errorarchiveStore.errorarchiveCards"
+            :key="errorarchiveCard.id"
+            v-bind:errorarchiveCard="errorarchiveCard"
+        />
+      </div>
+    </div>
+  </div>
+  <div class="errorarchive-bottom">
+    <div v-if="isLoading"></div>
+    <PaginationComponent v-else @updatePage="handlePageUpdate" :totalPage="totalPage"/>
   </div>
 </template>
 
 <script>
+import {mapStores} from "pinia";
 import { useErrorArchiveStore } from '@/store/useErrorArchiveStore';
-import ErrorArchiveCardComponent from '@/components/errorarchive/ErrorArchiveCardComponent.vue'
+import ErrorArchiveCardComponent from '@/components/errorarchive/ErrorArchiveCardComponent.vue';
+import PaginationComponent from "@/components/Common/PaginationComponent.vue";
+import SortTypeComponent from "@/components/Common/SortTypeComponent.vue";
 
 export default {
   name: 'ErrorArchiveListPage',
-  data() {
-    return {
-      errorarchiveCards: [],  // 데이터는 여기에서 가져올 수 있도록 합니다.
-    };
-  },
-  async mounted() {
-    // Pinia 스토어 인스턴스를 가져옵니다.
-    const store = useErrorArchiveStore();
-
-    // 초기 정렬 기준과 페이지 번호를 설정합니다.
-    const sort = 'date';  // 예시로 정렬 기준을 날짜로 설정
-    const page = 1;       // 첫 페이지부터 시작
-
-    try {
-      // 스토어의 메소드 호출
-      await store.getErrorArchiveList(sort, page);
-      this.errorarchiveCards = store.errorarchiveCards; // 스토어에서 가져온 데이터로 업데이트
-    } catch (error) {
-      console.error("Error fetching errorarchive list:", error);
-    }
-  },
   components: {
     ErrorArchiveCardComponent,
+    SortTypeComponent,
+    PaginationComponent,
+  },
+  data() {
+    return {
+      selectedSort: null,
+      selectedPage: 0,
+      page: 0,
+      totalPage: 1,
+      isLoading:true
+    };
+  },
+  computed: {
+    ...mapStores(useErrorArchiveStore),
+  },
+  mounted() {
+    this.selectedSort = "latest";
+    this.selectedPage = 1;
+    this.getErrorArchiveList();
+  },
+  watch: {
+    selectedSort() {
+      this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage-1);
+    },
+    selectedPage() {
+      this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage-1);
+    },
+  },
+  methods: {
+    async handleCheckLatest() {
+      this.selectedSort = "latest";
+      await this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage - 1);
+      if (this.errorarchiveStore.errorarchiveCards.length !== 0){
+        this.totalPage = this.errorarchiveStore.errorarchiveCards[0].totalPage;
+        console.log("total"+this.totalPage);
+
+      }
+      this.isLoading=true;
+    },
+    async handleCheckLike() {
+      this.selectedSort = "like";
+      await this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage - 1);
+      if (this.errorarchiveStore.errorarchiveCards.length !== 0){
+        this.totalPage = this.errorarchiveStore.errorarchiveCards[0].totalPage;
+        console.log("total"+this.totalPage);
+      }
+      this.isLoading=true;
+    },
+    handlePageUpdate(newPage) {
+      this.selectedPage = newPage;
+      this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage - 1);
+    },
+    updatePage(page){
+      this.page = page-1
+      if(this.$route.path.endsWith("info")){
+        this.getErrorArchiveHistory();
+      } else if (this.$route.path.endsWith("rank")){
+        this.getPointRankList();
+      }
+    },
+    async getErrorArchiveList(){
+      await this.errorarchiveStore.getErrorArchiveList(this.selectedSort, this.selectedPage - 1);
+      if (this.errorarchiveStore.errorarchiveCards.length !== 0){
+        this.totalPage = this.errorarchiveStore.errorarchiveCards[0].totalPage;
+        console.log("total"+this.totalPage);
+      }
+      this.isLoading=false;
+    }
   },
 };
 </script>
 
 <style scoped>
-.card-list {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+.errorarchive-top{
+ 
+ 
+  padding-bottom: 50px;
+  align-content: center;
+  align-items: center;
+
 }
+#main-title {
+  text-align: center;
+  font-size: 40px;
+}
+
+#sub-title {
+  text-align: center;
+  font-size: 25px;
+}
+.errorarchive-inner {
+  width: auto;
+  height: max-content;
+  background-color: #fff;
+}
+.errorarchive-list-flex {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-auto-rows: auto;
+    gap: 26px 36px;
+    justify-items: stretch;
+    max-width: 100%;
+    margin: 0 auto
+}
+.errorarchive-bottom {
+  height: 70px;
+  display: grid;
+  background-color: #ffffff;
+  justify-content: center;
+  align-content: space-around;
+}
+
+
+
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,6 +11,7 @@ import PointInfoComponent from "@/components/Point/PointInfoComponent.vue";
 import PointRankingComponent from "@/components/Point/PointRankingComponent.vue";
 import WikiDetailPage from "@/pages/WikiDetailPage.vue";
 import QnaDetailPage from "@/pages/QnaDetailPage.vue";
+import ErrorArchiveListPage from "@/pages/ErrorArchiveListPage.vue";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -22,12 +23,14 @@ const router = createRouter({
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPage },
     { path: "/errorarchive", component: ErrorArchiveRegisterPage },
+    { path: "/errorarchive/list", component: ErrorArchiveListPage },
     { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } },
     { path: "/point", component: PointPage, children: [
         { path: "info", component: PointInfoComponent },
         { path: "rank", component: PointRankingComponent },
       ]},
-    { path: "/wiki/detail", component: WikiDetailPage }
+    { path: "/wiki/detail", component: WikiDetailPage },
+    
   ]
   
 });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -22,7 +22,7 @@ const router = createRouter({
     { path: '/qna/detail/:id', component: QnaDetailPage },
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPage },
-    { path: "/errorarchive", component: ErrorArchiveRegisterPage },
+    { path: "/errorarchive/register", component: ErrorArchiveRegisterPage },
     { path: "/errorarchive/list", component: ErrorArchiveListPage },
     { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } },
     { path: "/point", component: PointPage, children: [
@@ -30,6 +30,7 @@ const router = createRouter({
         { path: "rank", component: PointRankingComponent },
       ]},
     { path: "/wiki/detail", component: WikiDetailPage },
+
     
   ]
   

--- a/frontend/src/store/useErrorArchiveStore.js
+++ b/frontend/src/store/useErrorArchiveStore.js
@@ -5,6 +5,7 @@ const backend = "/api";
 export const useErrorArchiveStore = defineStore('errorarchive', {
   state: () => ({
     errorArchiveId: 1,
+    errorarchiveCards: [],
   }),
   actions: {
     async registerErrorArchive(errorarchive) {
@@ -32,7 +33,23 @@ export const useErrorArchiveStore = defineStore('errorarchive', {
         throw error;
       }
     },
+    async getErrorArchiveList(sort, page) {
+      const params = {
+        sort: sort,
+        page: page,
+        size: 15
+      };
+      try {
+        const response = await axios.get("http://localhost:8080/errorarchive/list", { params });
+        if (response && response.data) {
+          this.errorarchiveCards = response.data.result;
+          console.log(this.errorarchiveCards);
+        } else {
+          console.error("Unexpected response structure:", response);
+        }
+      } catch (error) {
+        console.error("Error fetching errorarchive list:", error);
+      }
   },
+}
 });
-
-

--- a/frontend/src/store/useErrorArchiveStore.js
+++ b/frontend/src/store/useErrorArchiveStore.js
@@ -4,7 +4,6 @@ const backend = "/api";
 
 export const useErrorArchiveStore = defineStore('errorarchive', {
   state: () => ({
-    errorArchiveId: 1,
     errorarchiveCards: [],
   }),
   actions: {
@@ -40,15 +39,14 @@ export const useErrorArchiveStore = defineStore('errorarchive', {
         size: 15
       };
       try {
-        const response = await axios.get("http://localhost:8080/errorarchive/list", { params });
-        if (response && response.data) {
-          this.errorarchiveCards = response.data.result;
-          console.log(this.errorarchiveCards);
-        } else {
-          console.error("Unexpected response structure:", response);
-        }
-      } catch (error) {
-        console.error("Error fetching errorarchive list:", error);
+        const response = await axios.get(backend+"/errorarchive/list", { 
+          params: params,
+          withCredentials: true });
+
+        this.errorarchiveCards  = response.data.result;
+        console.log(this.errorarchiveCards);
+      } catch(error) {
+        console.error("error fetching errorarchive list:",  error);
       }
   },
 }


### PR DESCRIPTION
## 연관 이슈
close #221 


## 작업 내용
에러아카이브 목록을 최신순, 좋아요순으로 볼 수 있게 처리
데이터베이스에 데이터양에 맞게 페이지 설정(this.totalPage = this.errorarchiveStore.errorarchiveCards[0].totalPage)

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f3a80bb4-b9fc-4fbf-b5d6-1253b09671b9)
![image](https://github.com/user-attachments/assets/43cf52fb-79d2-4a83-92b1-b801e352f541)


## 리뷰 요구사항 혹은 기타 (선택)