### PR TITLE
[Feat] 게시글 등록할 시 이미지 업로드기능 추가 (#225)

### DIFF
--- a/frontend/src/components/errorarchive/ErrorArchiveRegisterComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveRegisterComponent.vue
@@ -50,7 +50,7 @@
                   <!-- 본문 -->
                   <div class="space-y-1">
                     <label for="text" class="text-sm font-medium text-gray-700 dark:text-gray-300">본문</label>
-                    <v-md-editor v-model="errorArchive.content" height="400px"></v-md-editor>
+                    <v-md-editor v-model="errorArchive.content" :disabled-menus="[]" @upload-image="commonStore.imageUpload" height="400px"></v-md-editor>
                   </div>
                 </div>
 
@@ -97,6 +97,7 @@ import {mapStores} from "pinia";
 import SuperCategoryModal from '@/components/Category/SuperCategoryModal.vue';
 import SubCategoryModal from '@/components/Category/SubCategoryModal.vue';
 import { useErrorArchiveStore } from '@/store/useErrorArchiveStore';
+import {useCommonStore} from "@/store/useCommonStore";
 
 export default {
   name: 'ErrorArchiveRegisterComponent',
@@ -105,7 +106,8 @@ export default {
     SubCategoryModal,
   },
   computed: {
-    ...mapStores(useErrorArchiveStore) // 어떤 저장소랑 연결시켜 주겠다.
+    ...mapStores(useErrorArchiveStore), // 어떤 저장소랑 연결시켜 주겠다.
+    ...mapStores(useCommonStore)
   },
   data () {
     return {

--- a/frontend/src/components/qna/QnaRegisterComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterComponent.vue
@@ -44,7 +44,7 @@
                                     <!-- 본문 -->
                                     <div class="space-y-1">
                                         <label for="text" class="text-sm font-medium text-gray-700 dark:text-gray-300" >본문</label>
-                                        <v-md-editor v-model="myText" height="400px"></v-md-editor>
+                                        <v-md-editor v-model="myText" :disabled-menus="[]" @upload-image="commonStore.imageUpload" height="400px"></v-md-editor>
                                     </div>
                                 </div>
 
@@ -91,6 +91,7 @@ import { mapStores } from "pinia";
 import { useQnaStore } from "@/store/useQnaStore";
 import SuperCategoryModal from "@/components/Category/SuperCategoryModal.vue";
 import SubCategoryModal from "@/components/Category/SubCategoryModal.vue";
+import {useCommonStore} from "@/store/useCommonStore";
 
 export default {
   name: "QnaRegisterComponent",
@@ -107,6 +108,7 @@ export default {
   },
   computed: {
     ...mapStores(useQnaStore),
+    ...mapStores(useCommonStore),
     isNullOrEmpty() {
       return (this.myTitle === '' || this.myText === '' || this.selectedSuperCategory === '' || this.selectedSubCategory === '')
     },

--- a/frontend/src/components/wiki/WikiRegisterComponent.vue
+++ b/frontend/src/components/wiki/WikiRegisterComponent.vue
@@ -57,7 +57,7 @@
                                     <div class="space-y-1">
                                         <label for="text"
                                             class="text-sm font-medium text-gray-700 dark:text-gray-300">본문</label>
-                                        <v-md-editor v-model="wikiRegisterReq.myText" height="400px"></v-md-editor>
+                                        <v-md-editor v-model="wikiRegisterReq.myText" :disabled-menus="[]" height="400px" @upload-image="commonStore.imageUpload"></v-md-editor>
                                     </div>
                                 </div>
 
@@ -92,6 +92,7 @@
 import { useWikiStore } from "@/store/useWikiStore";
 import { mapStores } from "pinia";
 import SuperCategoryModal from '../../components/Category/SuperCategoryModal.vue';
+import {useCommonStore} from "@/store/useCommonStore";
 
 export default {
     name: "WikiRegisterComponent",
@@ -110,6 +111,7 @@ export default {
     },
     computed: {
         ...mapStores(useWikiStore),
+        ...mapStores(useCommonStore),
         isNullOrEmpty() {
             return (this.wikiRegisterReq.title === '' || this.wikiRegisterReq.myText === '' || this.wikiRegisterReq.mySuperCategory === '')
         },

--- a/frontend/src/store/useCommonStore.js
+++ b/frontend/src/store/useCommonStore.js
@@ -1,0 +1,33 @@
+import {defineStore} from 'pinia';
+import axios from 'axios';
+
+const backend = "/api";
+
+export const useCommonStore = defineStore('common', {
+    state: () => ({
+    }),
+    actions: {
+        async imageUpload(event, insertImage, files){
+            try {
+                const formData = new FormData();
+                formData.append('imgFile', files[0]);
+
+                const response= await axios.post(backend+'/img/upload', formData, {
+                    headers: { 'Content-Type': 'multipart/form-data' },
+                    withCredentials: true
+                });
+                insertImage({
+                    url:response.data.result,
+                    desc: 'desc',
+                    width: 'auto',
+                    height: 'auto'
+                });
+            } catch (error) {
+                console.error('이미지 업로드 실패:', error);
+                return null;  // 업로드 실패 시 null 반환
+            }
+        }
+    }
+});
+
+


### PR DESCRIPTION
## 연관 이슈
close #225 


## 작업 내용
- 게시글 등록 시 이미지 업로드 기능 추가
- 아래와 같이 사용하면 된다.
- 위키 등록, 에러아카이브 등록, QnA등록엔 적용 해놓았다.
``` html
<v-md-editor v-model="myText" :disabled-menus="[]" @upload-image="commonStore.imageUpload" height="400px"></v-md-editor>
```

useCommonStore.js
``` javascript
async imageUpload(event, insertImage, files){
            try {
                const formData = new FormData();
                formData.append('imgFile', files[0]);

                const response= await axios.post(backend+'/img/upload', formData, {
                    headers: { 'Content-Type': 'multipart/form-data' },
                    withCredentials: true
                });
                insertImage({
                    url:response.data.result,
                    desc: 'desc',
                    width: 'auto',
                    height: 'auto'
                });
            } catch (error) {
                console.error('이미지 업로드 실패:', error);
                return null;  // 업로드 실패 시 null 반환
            }
        }
```

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/368abe41-6dd0-4f00-823d-eebe74196287)
![image](https://github.com/user-attachments/assets/c6c23f1a-b59a-4355-b664-4396584a09da)

## 리뷰 요구사항 혹은 기타 (선택)
