### PR TITLE
[Fix] useErrorArchiveStore state에 comma 추가

### DIFF
--- a/frontend/src/store/useErrorArchiveStore.js
+++ b/frontend/src/store/useErrorArchiveStore.js
@@ -22,7 +22,7 @@ export const useErrorArchiveStore = defineStore('errorarchive', {
       profileImg: "",
       grade: "",
       gradeImg: ""
-    }
+    },
     errorarchiveCards: [],
   }),
   actions: {


### PR DESCRIPTION
## 연관 이슈


## 작업 내용
merge하면서 errorarchivestore의 state에 comma가 빠져서 생긴 오류 해결


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
