### PR TITLE
[Feat] 목록 상세 조회 라우터 설정

### DIFF
--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="PostCard_block__FTMsy">
+  <router-link
+  :to="{ path: '/errorarchive/detail', query: { id: errorarchiveCard.id } }"> <!-- 수정된 부분 -->
+    <div class ="PostCard_block__FTMsy">
     <div class="header">
       <div class="user-info">
         <a class="PostCard_userInfo__Cu1X5" :href="'/@' + errorarchiveCard.nickname + '/posts'">
@@ -42,7 +44,8 @@
         <span>{{ errorarchiveCard.nickname }}</span>
       </div>
     </div>
-  </div>
+    </div>
+  </router-link>
 </template>
 
 <script>
@@ -52,7 +55,12 @@ export default {
   data() {
     return {};
   },
-  props: ["errorarchiveCard"],
+  props: {
+    errorarchiveCard: {
+      type: Object, //props 검증 추가: 타입 확인
+      required: true // 필수 props로 설정
+    }
+  },
   methods: {
     formatDateTime
     },

--- a/frontend/src/components/errorarchive/ErrorArchiveDetailComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveDetailComponent.vue
@@ -243,6 +243,7 @@ export default {
   async mounted() {
     this.id = this.$route.query.id;
     await this.getErrorArchiveDetail();
+    this.setModifiedTime();
     this.isLoading = false;
 
     this.$nextTick(() => {

--- a/frontend/src/pages/ErrorArchiveDetailPage.vue
+++ b/frontend/src/pages/ErrorArchiveDetailPage.vue
@@ -1,18 +1,52 @@
 <template>
   <div class="custom-container">
-    <ErrorArchiveDetailComponent/>
+    <ErrorArchiveDetailComponent :errorId="errorId"/> <!-- props로 전달 -->
   </div>
 </template>
 
 
 <script>
 import ErrorArchiveDetailComponent from "@/components/errorarchive/ErrorArchiveDetailComponent.vue";
+import { ref, onMounted } from 'vue'; 
+import { useRoute } from 'vue-router';
+import axios from 'axios';
 
 export default {
   name: "ErrorArchiveDetailPage",
   components: {
     ErrorArchiveDetailComponent
+  },
+  setup() {
+    const route = useRoute(); // 현재 라우트 정보 가져오기
+    const errorId = route.query.id; // 쿼리 파라미터에서 id 가져오기
+    const errorData = ref(null); // 상세 데이터를 저장할 ref
+    const isLoading = ref(true); // 로딩 상태
+
+    onMounted(()=> {
+      if (errorId){
+        fetchErrorArchiveDetail(errorId);
+      } else {
+        console.log("error id is not provided.");
+        isLoading.value = false;
+      }
+
+    });
+    const fetchErrorArchiveDetail = async (id) => {
+      try {
+        const response = await axios.get(`api/erorarchive/detail?id=${id}`); // api호출
+        errorData.value = response.data // 응답 데이터 저장
+      } catch (error) {
+        console.log("error fetching errorarchive detail:", error);
+      } finally {
+        isLoading.value = false; // 로딩 완료
+      }
+    };
+    return {
+      errorData,
+      isLoading
+    };
   }
+  
 }
 </script>
 

--- a/frontend/src/pages/ErrorArchiveListPage.vue
+++ b/frontend/src/pages/ErrorArchiveListPage.vue
@@ -9,11 +9,14 @@
       <SortTypeComponent @checkLatest="handleCheckLatest"
                          @checkLike="handleCheckLike"/>
       <div class="errorarchive-list-flex">
-        <ErrorArchiveCardComponent
-            v-for="errorarchiveCard in errorarchiveStore.errorarchiveCards"
-            :key="errorarchiveCard.id"
-            v-bind:errorarchiveCard="errorarchiveCard"
-        />
+        <router-link 
+          v-for="errorarchiveCard in errorarchiveStore.errorarchiveCards" 
+          :key="errorarchiveCard.id" 
+          :to="{ path: '/errorarchive/detail', query: { id: errorarchiveCard.id } }"> <!-- 수정된 부분 -->
+          <ErrorArchiveCardComponent
+            :errorarchiveCard="errorarchiveCard"
+          />
+        </router-link>
       </div>
     </div>
   </div>
@@ -22,6 +25,7 @@
     <PaginationComponent v-else @updatePage="handlePageUpdate" :totalPage="totalPage"/>
   </div>
 </template>
+
 
 <script>
 import {mapStores} from "pinia";


### PR DESCRIPTION
## 연관 이슈
close #이슈번호


## 작업 내용
navigation방식으로 목록페이지에서 카드를 각각 누르면 상세 조회 페이지로 이동
- router-link로 경로 설정
- useRoute를 사용하여 현재 url의 id를 가져옴
- 데이터를 errorarchivedetailcomponent에 props로 전달함

## 스크린샷 (선택)
https://github.com/user-attachments/assets/1d344515-0300-463a-8e8e-49e3062b36df



## 리뷰 요구사항 혹은 기타 (선택)
리뷰어들이 참고해야할 사항이나 집중적으로 봐줬으면 하는 사항을 작성한다.