### PR TITLE
[Feat] 회원가입 시 이메일 인증 api 구현(#3)

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -83,6 +83,9 @@ public enum BaseResponseStatus {
     EXCEED_MAX_SIZE(false, 10013, "파일의 크기가 허용된 최대 크기를 초과하였습니다."),
     INTERNAL_SERVER_ERROR(false,10014,"에러가 발생했습니다"),
 
+    // 이메일 인증 - 11000
+    EMAIL_VERIFY_FAIL(false, 11001, "이메일 인증에 실패하였습니다"),
+
 
     // 실패 - 40000 (위치 바꾸지 마시오)
     FAIL(false, 40000, "요청에 실패하였습니다.");

--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -85,6 +85,7 @@ public enum BaseResponseStatus {
 
     // 이메일 인증 - 11000
     EMAIL_VERIFY_FAIL(false, 11001, "이메일 인증에 실패하였습니다"),
+    UUID_ALREADY_USED(false,11002,"이미 사용된 UUID 입니다"),
 
 
     // 실패 - 40000 (위치 바꾸지 마시오)

--- a/backend/src/main/java/org/example/backend/Common/GlobalMessage.java
+++ b/backend/src/main/java/org/example/backend/Common/GlobalMessage.java
@@ -1,0 +1,19 @@
+package org.example.backend.Common;
+
+public enum GlobalMessage {
+    // 이메일 인증 관련 메시지
+    EMAIL_TITLE("[SENAGAE] 인증 메세지 "),
+    EMAIL_URL_TEMPLATE("http://localhost:8080/email/verify?email=%s&uuid=%s");
+
+    private final String message;
+    GlobalMessage(String message){
+        this.message = message;
+    }
+    public String getMessage(){
+        return message;
+    }
+    public String formatUrl(String email, String uuid){
+        return String.format(message, email, uuid);
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
@@ -1,22 +1,25 @@
 package org.example.backend.EmailVerify.Controller;
 
 import lombok.RequiredArgsConstructor;
+
 import org.example.backend.Common.BaseResponse;
-import org.example.backend.Common.BaseResponseStatus;
-import org.example.backend.EmailVerify.Model.Entity.EmailVerify;
 import org.example.backend.EmailVerify.Service.EmailVerifyService;
 import org.example.backend.Exception.custom.InvalidEmailException;
-import org.example.backend.User.Service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping(value="/email")
 @RequiredArgsConstructor
+@CrossOrigin(origins = "http://localhost:8081")
 public class EmailVerifyController {
     private final EmailVerifyService emailVerifyService;
 
-    @PostMapping("/verify")
-    public BaseResponse<String> verify(@RequestParam String email,@RequestParam String uuid){
+    @GetMapping("/verify")
+    public BaseResponse<String> verify(@RequestParam String email, @RequestParam String uuid){
         try {
             emailVerifyService.verifyEmail(email, uuid);
             return new BaseResponse<>("EMAIL VERIFICATION SUCCESS!");
@@ -25,4 +28,5 @@ public class EmailVerifyController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
 }

--- a/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
@@ -1,0 +1,28 @@
+package org.example.backend.EmailVerify.Controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.EmailVerify.Model.Entity.EmailVerify;
+import org.example.backend.EmailVerify.Service.EmailVerifyService;
+import org.example.backend.Exception.custom.InvalidEmailException;
+import org.example.backend.User.Service.UserService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value="/email")
+@RequiredArgsConstructor
+public class EmailVerifyController {
+    private final EmailVerifyService emailVerifyService;
+
+    @PostMapping("/verify")
+    public BaseResponse<String> verify(@RequestParam String email,@RequestParam String uuid){
+        try {
+            emailVerifyService.verifyEmail(email, uuid);
+            return new BaseResponse<>("EMAIL VERIFICATION SUCCESS!");
+        } catch(InvalidEmailException e){
+            // 인증 실패시 에러 메시지 반환
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
@@ -18,7 +18,7 @@ public class EmailVerifyController {
     private final EmailVerifyService emailVerifyService;
 
     @PostMapping("/verify")
-    public BaseResponse<String> verify(@RequestParam String email, @RequestParam String uuid){
+    public BaseResponse<String> verify(@RequestBody String email, @RequestBody String uuid){
             emailVerifyService.verifyEmail(email, uuid);
             return new BaseResponse<>("EMAIL VERIFICATION SUCCESS!");
     }

--- a/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Controller/EmailVerifyController.java
@@ -14,19 +14,13 @@ import java.net.URI;
 @RestController
 @RequestMapping(value="/email")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:8081")
 public class EmailVerifyController {
     private final EmailVerifyService emailVerifyService;
 
-    @GetMapping("/verify")
+    @PostMapping("/verify")
     public BaseResponse<String> verify(@RequestParam String email, @RequestParam String uuid){
-        try {
             emailVerifyService.verifyEmail(email, uuid);
             return new BaseResponse<>("EMAIL VERIFICATION SUCCESS!");
-        } catch(InvalidEmailException e){
-            // 인증 실패시 에러 메시지 반환
-            return new BaseResponse<>(e.getStatus());
-        }
     }
 
 }

--- a/backend/src/main/java/org/example/backend/EmailVerify/Model/Entity/EmailVerify.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Model/Entity/EmailVerify.java
@@ -16,8 +16,15 @@ public class EmailVerify {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, unique = true)
     private  String email;
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, unique = true)
     private String uuid;
+
+    // UUID 업데이트 메소드
+    public void updateUuid(String uuid){
+        this.uuid = uuid;
+    }
+
+
 }

--- a/backend/src/main/java/org/example/backend/EmailVerify/Repository/EmailVerifyRepository.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Repository/EmailVerifyRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface EmailVerifyRepository extends JpaRepository<EmailVerify, Long> {
-   List<EmailVerify> findAllByEmail(String email);
+   Optional<EmailVerify> findByEmail(String email);
 
 }

--- a/backend/src/main/java/org/example/backend/EmailVerify/Repository/EmailVerifyRepository.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Repository/EmailVerifyRepository.java
@@ -1,0 +1,14 @@
+package org.example.backend.EmailVerify.Repository;
+
+import org.example.backend.EmailVerify.Model.Entity.EmailVerify;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EmailVerifyRepository extends JpaRepository<EmailVerify, Long> {
+   List<EmailVerify> findAllByEmail(String email);
+
+}

--- a/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
@@ -1,0 +1,61 @@
+package org.example.backend.EmailVerify.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Common.GlobalMessage;
+import org.example.backend.EmailVerify.Model.Entity.EmailVerify;
+import org.example.backend.EmailVerify.Repository.EmailVerifyRepository;
+import org.example.backend.Exception.custom.InvalidEmailException;
+import org.example.backend.Exception.custom.InvalidErrorBoardException;
+import org.example.backend.User.Service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerifyService {
+
+    private final EmailVerifyRepository emailVerifyRepository;
+    private final JavaMailSender javaMailSender;
+    private final UserService userService;
+
+
+    public void sendEmail(String email){
+        String uuid = UUID.randomUUID().toString();
+        EmailVerify emailVerify = EmailVerify.builder()
+                .email(email)
+                .uuid(uuid)
+                .build();
+       emailVerifyRepository.save(emailVerify);
+        // 이메일 전송 설정
+       SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject(GlobalMessage.EMAIL_TITLE.getMessage());
+        message.setText(GlobalMessage.EMAIL_URL_TEMPLATE.formatUrl(email,uuid));
+        javaMailSender.send(message); // 이메일 전송
+    }
+
+    public void verifyEmail(@RequestParam String email,@RequestParam String uuid){
+        List<EmailVerify> emailVerifies = emailVerifyRepository.findAllByEmail(email);
+        if (emailVerifies.isEmpty()) {
+            throw new InvalidEmailException(BaseResponseStatus.EMAIL_VERIFY_FAIL);
+        }
+
+        for (EmailVerify emailVerify : emailVerifies) {
+            if (emailVerify.getUuid().equals(uuid)) {
+                userService.updateVerifiedStatus(email);
+                return;
+            }
+        }
+
+        throw new InvalidEmailException(BaseResponseStatus.EMAIL_VERIFY_FAIL);
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
@@ -1,22 +1,17 @@
 package org.example.backend.EmailVerify.Service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.backend.Common.BaseResponse;
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Common.GlobalMessage;
 import org.example.backend.EmailVerify.Model.Entity.EmailVerify;
 import org.example.backend.EmailVerify.Repository.EmailVerifyRepository;
 import org.example.backend.Exception.custom.InvalidEmailException;
-import org.example.backend.Exception.custom.InvalidErrorBoardException;
 import org.example.backend.User.Service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.List;
-import java.util.Optional;
+
 import java.util.UUID;
 
 @Service

--- a/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
@@ -47,21 +47,14 @@ public class EmailVerifyService {
         EmailVerify existingEmailVerify = emailVerifyRepository.findByEmail(email)
                 .orElseThrow(() -> new InvalidEmailException(BaseResponseStatus.EMAIL_VERIFY_FAIL));
 
-        // 이전 uuid와 비교하여 인증할 수 없는 경우 처리
-        if (existingEmailVerify.getUuid().equals(uuid)) {
-            throw new InvalidEmailException(BaseResponseStatus.UUID_ALREADY_USED);
+        // 기존 UUID와 비교하여 인증을 시도
+        if (!existingEmailVerify.getUuid().equals(uuid)) {
+            throw new InvalidEmailException(BaseResponseStatus.EMAIL_VERIFY_FAIL); // UUID 불일치
         }
 
-        // UUID 업데이트
-        existingEmailVerify.updateUuid(uuid);
-        emailVerifyRepository.save(existingEmailVerify);
-
-        // UUID 검증 로직: 이메일이 존재하고 UUID가 일치하면 verified 상태 업데이트
-        if (existingEmailVerify.getUuid().equals(uuid)) {
-            userService.updateVerifiedStatus(email);
-        } else {
-            throw new InvalidEmailException(BaseResponseStatus.EMAIL_VERIFY_FAIL);
-        }
+        // UUID가 일치할 경우 verified 상태 업데이트
+        userService.updateVerifiedStatus(email);
     }
+
 
 }

--- a/backend/src/main/java/org/example/backend/Exception/custom/InvalidEmailException.java
+++ b/backend/src/main/java/org/example/backend/Exception/custom/InvalidEmailException.java
@@ -1,0 +1,9 @@
+package org.example.backend.Exception.custom;
+
+import org.example.backend.Common.BaseResponseStatus;
+
+public class InvalidEmailException extends InvalidCustomException {
+    public InvalidEmailException(BaseResponseStatus status){
+        super(status);
+    }
+}

--- a/backend/src/main/java/org/example/backend/User/Controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/User/Controller/UserController.java
@@ -3,6 +3,7 @@ package org.example.backend.User.Controller;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.EmailVerify.Service.EmailVerifyService;
 import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
@@ -26,6 +27,7 @@ public class UserController {
     private final UserService userService;
     private final CloudFileUploadService cloudFileUploadService;
     private final JwtUtil jwtUtil;
+    private final EmailVerifyService emailVerifyService;
 
     @PostMapping("/signup")
     public BaseResponse<String> signup(
@@ -46,8 +48,8 @@ public class UserController {
         if(!userService.checkDuplicateNickname(userSignupReq.getNickname())){
             return new BaseResponse<>(BaseResponseStatus.USER_DUPLICATE_NICKNAME);
         }
-
         userService.signup(userSignupReq, profileImgUrl);
+        emailVerifyService.sendEmail(userSignupReq.getEmail());
         return new BaseResponse<>();
     }
 

--- a/backend/src/main/java/org/example/backend/User/Controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/User/Controller/UserController.java
@@ -32,7 +32,11 @@ public class UserController {
     @PostMapping("/signup")
     public BaseResponse<String> signup(
             @RequestPart UserSignupReq userSignupReq,
-            @RequestPart MultipartFile profileImg) {
+            @RequestPart(required=false) MultipartFile profileImg) {
+
+        System.out.println("회원가입 요청 수신: " + userSignupReq.getEmail());
+
+
         String profileImgUrl;
         if(profileImg == null || profileImg.isEmpty()){
             profileImgUrl = "https://dayun2024-s3.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/11/0d7ca962-ccee-4fbb-9b5d-f5deec5808c6";
@@ -49,7 +53,15 @@ public class UserController {
             return new BaseResponse<>(BaseResponseStatus.USER_DUPLICATE_NICKNAME);
         }
         userService.signup(userSignupReq, profileImgUrl);
-        emailVerifyService.sendEmail(userSignupReq.getEmail());
+        System.out.println("회원가입 완료: " + userSignupReq.getEmail());
+
+        // 이메일 인증 메일 발송
+        try {
+            emailVerifyService.sendEmail(userSignupReq.getEmail());
+            System.out.println("이메일 발송 성공: " + userSignupReq.getEmail());
+        } catch (Exception e) {
+            System.err.println("이메일 발송 실패: " + e.getMessage());
+        }
         return new BaseResponse<>();
     }
 

--- a/backend/src/main/java/org/example/backend/User/Controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/User/Controller/UserController.java
@@ -33,10 +33,6 @@ public class UserController {
     public BaseResponse<String> signup(
             @RequestPart UserSignupReq userSignupReq,
             @RequestPart(required=false) MultipartFile profileImg) {
-
-        System.out.println("회원가입 요청 수신: " + userSignupReq.getEmail());
-
-
         String profileImgUrl;
         if(profileImg == null || profileImg.isEmpty()){
             profileImgUrl = "https://dayun2024-s3.s3.ap-northeast-2.amazonaws.com/IMAGE/2024/09/11/0d7ca962-ccee-4fbb-9b5d-f5deec5808c6";

--- a/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
+++ b/backend/src/main/java/org/example/backend/User/Model/Entity/User.java
@@ -135,4 +135,6 @@ public class User {
     public void updateEnable(Boolean enable) {
         this.enable = enable;
     }
+    public void updateVerified(boolean verify){ this.verify =verify; }
+
 }

--- a/backend/src/main/java/org/example/backend/User/Service/UserService.java
+++ b/backend/src/main/java/org/example/backend/User/Service/UserService.java
@@ -2,6 +2,7 @@ package org.example.backend.User.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Exception.custom.InvalidEmailException;
 import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.User.Model.Entity.User;
 import org.example.backend.User.Model.Req.UpdateUserPasswordReq;
@@ -115,5 +116,12 @@ public class UserService {
                     .build();
         }
         throw new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND);
+    }
+
+    public void updateVerifiedStatus(String email){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()-> new InvalidEmailException(BaseResponseStatus.EMAIL_VERIFY_FAIL));
+        user.updateVerified(true);
+        userRepository.save(user);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,18 +18,18 @@ spring:
       max-file-size: 20MB
       max-request-size: 20MB
 
-#  mail:
-#    host: smtp.gmail.com
-#    port: 587
-#    username: ${EMAIL}
-#    password: ${EMAIL_PASSWORD}
-#    properties:
-#      mail:
-#        smtp:
-#          starttls:
-#            enable: true
-#            required: true
-#          auth: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
 
 
 


### PR DESCRIPTION
## 연관 이슈
close #3 


## 작업 내용
이메일 인증 로직은 다음과 같음
1. 회원은 인증 받을 이메일을 요청에 포함하여 서버에 보냄
2. 서버는 일정 시간 동안 인증 코드를 발행함
3. 서버는 인증 코드를 회원에게 받은 이메일로 전송함
4. 회원은 입력 받은 인증 코드를 요청에 포함하여 서버에 보냄
5. 회원의 verify의 상태는 true가 됨

## 스크린샷 (선택)
<img width="781" alt="image" src="https://github.com/user-attachments/assets/e0e5de65-818c-4382-9443-c1002c202020">
<img width="933" alt="image" src="https://github.com/user-attachments/assets/9472e86c-5103-4cca-baf6-737dd4965652">
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/0270eab7-a5df-42fe-9756-869a088e2fcd">



## 리뷰 요구사항 혹은 기타 (선택)