### PR TITLE
[Feat] 위키 목록 조회 (#84)

### DIFF
--- a/frontend/src/components/Header/HeaderComponent.vue
+++ b/frontend/src/components/Header/HeaderComponent.vue
@@ -7,7 +7,7 @@
             <ul>
                 <li><router-link :to="{ path: '/' }"><i class="fas fa-code"></i> 아카이브</router-link></li>
                 <li class="divider">|</li>
-                <li><router-link :to="{ path: '/' }"><i class="fas fa-book"></i> 위키</router-link></li>
+                <li><router-link :to="{ path: '/wiki/list' }"><i class="fas fa-book"></i> 위키</router-link></li>
                 <li class="divider">|</li>
                 <li>
                     <router-link :to="{ path: '/qna/list' }"><i class="fas fa-question-circle"></i> QnA</router-link>

--- a/frontend/src/components/wiki/WikiCardComponent.vue
+++ b/frontend/src/components/wiki/WikiCardComponent.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="wiki-card">
+    <a :href="'/wiki/detail?id=' + wikiCard.id" class="wiki-card-link">
+      <div class="wiki-card-image-wrapper">
+        <img
+          v-if="wikiCard.thumbnail"
+          :src="wikiCard.thumbnail"
+          alt="Wiki Thumbnail"
+          class="wiki-card-image"
+        />
+        <img
+          v-else
+          src="/path-to-default-thumbnail.png"
+          alt="Default Thumbnail"
+          class="wiki-card-image"
+        />
+      </div>
+      <div class="wiki-card-content">
+        <h3 class="wiki-card-title">"{{ wikiCard.title }}"</h3>
+        <p class="wiki-card-description">{{ truncatedContent }}</p>
+        <div class="wiki-card-category">
+          {{ wikiCard.category }}
+        </div>
+      </div>
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "WikiCardComponent",
+  props: {
+    wikiCard: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    truncatedContent() {
+      return this.wikiCard.content.length > 80
+        ? this.wikiCard.content.substring(0, 80) + "..."
+        : this.wikiCard.content;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.wiki-card {
+  display: flex;
+  flex-direction: column;
+  width: 270px;
+  height: 400px;
+  border-radius: 20px;
+  background-color: white;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease;
+}
+
+.wiki-card-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  height: 100%;
+}
+
+.wiki-card:hover {
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.wiki-card-image-wrapper {
+  height: 50%;
+  background-color: #f0f0f0;
+}
+
+.wiki-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.wiki-card-content {
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 50%;
+  position: relative;
+}
+
+.wiki-card-title {
+  font-size: 1.2rem;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.wiki-card-description {
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 15px;
+  line-height: 1.4;
+  flex-grow: 1; 
+  overflow: hidden;
+}
+
+.wiki-card-category {
+  font-size: 1rem;
+  color: #999;
+  text-align: right;
+  margin-top: auto; 
+}
+</style>

--- a/frontend/src/pages/WikiListPage.vue
+++ b/frontend/src/pages/WikiListPage.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="custom-container">
+    <p id="main-title">WIKI</p>
+    <p id="sub-title">당신의 위키를 만들어보세요</p>
+
+    <div v-if="isLoading" style="text-align:center;">
+      <p>로딩 중...</p>
+    </div>
+
+    <div class="wiki-list-grid" v-if="!isLoading">
+      <WikiCardComponent v-for="wikiCard in wikiCards" :key="wikiCard.id" :wikiCard="wikiCard" />
+    </div>
+
+    <div class="pagination-container" v-if="!isLoading">
+      <PaginationComponent :totalPage="totalPages" @updatePage="handlePageUpdate" />
+    </div>
+  </div>
+</template>
+
+<script>
+import WikiCardComponent from "@/components/wiki/WikiCardComponent.vue";
+import PaginationComponent from "@/components/Common/PaginationComponent.vue";
+import { mapStores } from "pinia";
+import { useWikiStore } from "@/store/useWikiStore";
+
+export default {
+  name: "WikiListPage",
+  components: {
+    WikiCardComponent,
+    PaginationComponent,
+  },
+  data() {
+    return {
+      selectedPage: 1,
+      totalPages: 1,
+      isLoading: true,
+    };
+  },
+  computed: {
+    ...mapStores(useWikiStore),
+    wikiCards() {
+      return this.wikiStore.wikiCards;
+    },
+  },
+  mounted() {
+    this.fetchWikiList(this.selectedPage);
+  },
+  methods: {
+    async fetchWikiList(page) {
+      this.isLoading = true;
+      console.log(`Fetching page ${page}`);
+
+      await this.wikiStore.fetchWikiList(page);
+
+
+      if (this.wikiStore.wikiCards.length > 0) {
+        this.totalPages = this.wikiStore.wikiCards[0].totalPages || 1;
+      } else {
+        this.totalPages = 1;
+      }
+
+      this.isLoading = false;
+      console.log("Current Page:", page);
+      console.log("Total Pages:", this.totalPages);
+    },
+    handlePageUpdate(newPage) {
+      console.log("weweewewnewPage: "+newPage);
+      if (newPage !== this.selectedPage) {
+        this.selectedPage = newPage;
+        this.wikiStore.fetchWikiList(this.selectedPage);
+
+        // this.fetchWikiList(this.selectedPage);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.wiki-list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-auto-rows: auto;
+  gap: 64px;
+  width: 100%;
+  max-width: 1200px;
+  padding: 20px;
+  justify-items: center;
+}
+
+.pagination-container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+</style>

--- a/frontend/src/pages/WikiListPage.vue
+++ b/frontend/src/pages/WikiListPage.vue
@@ -52,7 +52,6 @@ export default {
 
       await this.wikiStore.fetchWikiList(page);
 
-
       if (this.wikiStore.wikiCards.length > 0) {
         this.totalPages = this.wikiStore.wikiCards[0].totalPages || 1;
       } else {
@@ -64,12 +63,10 @@ export default {
       console.log("Total Pages:", this.totalPages);
     },
     handlePageUpdate(newPage) {
-      console.log("weweewewnewPage: "+newPage);
       if (newPage !== this.selectedPage) {
         this.selectedPage = newPage;
         this.wikiStore.fetchWikiList(this.selectedPage);
 
-        // this.fetchWikiList(this.selectedPage);
       }
     },
   },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -19,6 +19,7 @@ import InfoComponent from "@/components/Mypage/Info/InfoComponent.vue";
 import UserLogComponent from "@/components/Mypage/UserLogComponent.vue";
 import ScrapListComponent from "@/components/Mypage/ScrapListComponent.vue";
 import ErrorArchiveDetailPage from "@/pages/ErrorArchiveDetailPage.vue";
+import WikiListPage from "@/pages/WikiListPage.vue";
 
 
 const router = createRouter({
@@ -39,6 +40,7 @@ const router = createRouter({
       ]},
     { path: "/wiki/detail", name: "WikiDetail", component: WikiDetailPage },
     { path: "/wiki/update", name: "WikiUpdate", component: WikiUpdatePage },
+    { path: "/wiki/list", component: WikiListPage },
     { path: "/mypage", component: MypagePage, children: [
         { path: "info", component: InfoComponent },
         { path: "history", component: UserLogComponent },

--- a/frontend/src/store/useWikiStore.js
+++ b/frontend/src/store/useWikiStore.js
@@ -23,6 +23,7 @@ axios.interceptors.response.use(
 export const useWikiStore = defineStore("wiki", {
     state: () => ({
         wikiCards: [],
+        totalPages: 0,
         wikiRegisterReq: {
             title: '',
             categoryId: '',
@@ -44,19 +45,19 @@ export const useWikiStore = defineStore("wiki", {
                 const formData = new FormData();
                 const jsonBlob = new Blob([JSON.stringify(this.wikiRegisterReq)], { type: "application/json" });
                 formData.append("wikiRegisterReq", jsonBlob);
-        
+
                 if (thumbnail) {
                     formData.append("thumbnail", thumbnail);
                 }
-        
+
                 const response = await axios.post(backend + "/wiki", formData, {
                     withCredentials: true,
                     headers: { "Content-Type": "multipart/form-data" }
                 });
-        
+
                 if (response && response.data) {
                     console.log("응답 데이터:", response.data);
-                    
+
                     if (response.data.isSuccess) {
                         const newWikiId = response.data.result.wikiId; // 서버에서 반환된 ID 사용
                         return newWikiId; // 성공적으로 위키 등록되었을 때 ID 반환
@@ -114,7 +115,7 @@ export const useWikiStore = defineStore("wiki", {
         // 위키 상세 조회
         async fetchWikiDetail(id) {
             try {
-                const response = await axios.get(`${backend}/wiki/detail`, {
+                const response = await axios.get(backend + "wiki/detail", {
                     params: { id },
                     withCredentials: true,
                 });
@@ -123,7 +124,7 @@ export const useWikiStore = defineStore("wiki", {
                     console.log('Wiki Detail Response:', response.data);
                     this.wikiDetail = response.data.result;
 
-                    
+
                 } else {
                     throw new Error("위키 상세 조회 실패");
                 }
@@ -131,6 +132,30 @@ export const useWikiStore = defineStore("wiki", {
                 console.error("위키 상세 조회 중 오류 발생:", error);
             }
         },
-        
+
+        // 위키 목록 조회
+        async fetchWikiList(page) {
+            console.log(`Fetching page ${page}`);
+            const params = {
+                page: page - 1,
+                size: 20,
+            };
+            try {
+                const response = await axios.get(backend + "/wiki/list", {
+                    params: params,
+                    withCredentials: true,
+                });
+                this.wikiCards = response.data.result;
+                if (this.wikiCards.length > 0) {
+                    this.totalPages = this.wikiCards[0].totalPages;
+                } else {
+                    this.totalPages = 1;
+                }
+
+                console.log(`Total Pages: ${this.totalPages}`);
+            } catch (error) {
+                console.error("Error fetching wiki list:", error);
+            }
+        },
     }
 });


### PR DESCRIPTION
## 연관 이슈
close #84 


## 작업 내용
- 위키 카드 컴포넌트 구현
- 위키 목록 페이지
    - 목록에서 카드 클릭 시, 상세페이지로 라우팅 처리
    - 헤더 위키 클릭 시 위키 목록 페이지로 라우팅 처리
    - 하단 버튼에 전체 페이지 수 출력 처리


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f87bee5d-e858-4080-89ea-b2c732c2c93b)



## 리뷰 요구사항 혹은 기타 (선택)