### PR TITLE
[Feat] 메인 페이지 구현 및 API 연결(#61)

### DIFF
--- a/frontend/src/components/Common/LoadingComponent.vue
+++ b/frontend/src/components/Common/LoadingComponent.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="spinner"></div>
+</template>
+
+<script>
+export default {
+  name: "LoadingComponent",
+}
+</script>
+
+<style scoped>
+.spinner {
+  border: 8px solid rgba(0, 0, 0, 0.1);
+  border-left-color: #000;
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  animation: spin 1s linear infinite;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/components/Common/TagComponent.vue
+++ b/frontend/src/components/Common/TagComponent.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="tag-box">
+    <div class="tag-sub-box">
+      <div class="tag-title">{{ tagTitle }}</div>
+      <div class="tag-sub-title">{{ tagSubTitle }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "TagComponent",
+  props: ["tagTitle", "tagSubTitle"]
+}
+</script>
+
+<style scoped>
+.tag-box {
+  width: 100%;
+  margin-bottom: 40px;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  display: inline-flex
+}
+
+.tag-sub-box {
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 8px;
+  display: flex
+}
+
+.tag-title {
+  align-self: stretch;
+  text-align: center;
+  color: #1E1E1E;
+  font-size: 40px;
+  font-family: Inter;
+  font-weight: 700;
+  word-wrap: break-word
+}
+
+.tag-sub-title {
+  align-self: stretch;
+  text-align: center;
+  color: #757575;
+  font-size: 25px;
+  font-family: Inter;
+  font-weight: 400;
+  word-wrap: break-word
+}
+</style>

--- a/frontend/src/components/Header/HeaderComponent.vue
+++ b/frontend/src/components/Header/HeaderComponent.vue
@@ -5,7 +5,7 @@
         </div>
         <nav class="navigation">
             <ul>
-                <li><router-link :to="{ path: '/' }"><i class="fas fa-code"></i> 아카이브</router-link></li>
+                <li><router-link :to="{ path: '/errorarchive/list' }"><i class="fas fa-code"></i> 아카이브</router-link></li>
                 <li class="divider">|</li>
                 <li><router-link :to="{ path: '/wiki/list' }"><i class="fas fa-book"></i> 위키</router-link></li>
                 <li class="divider">|</li>

--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -1,4 +1,5 @@
 <template>
+  <router-link :to="{ path: '/errorarchive/detail', query: { id: errorarchiveCard.id }}">
   <div class="PostCard_block__FTMsy">
     <div class="header">
       <div class="user-info">
@@ -43,6 +44,7 @@
       </div>
     </div>
   </div>
+  </router-link>
 </template>
 
 <script>

--- a/frontend/src/components/qna/QnaDetailHeaderComponent.vue
+++ b/frontend/src/components/qna/QnaDetailHeaderComponent.vue
@@ -5,7 +5,7 @@
     </div>
     <span class="title-text">{{ qnaDetail.title }}</span>
   </div>
-  <span class="username-text">{{ qnaDetail.nickname }}</span>
+  <span class="username-text"><NicknameComponent :nickname="qnaDetail.nickname"/></span>
   <span class="datetime-text">{{ formatDateTime(qnaDetail.createdAt) }}</span>
   <div class="label-custom">
     <div class="ui tag labels">
@@ -102,6 +102,7 @@
 
 <script>
 import {formatDateTime} from "@/utils/FormatDate";
+import NicknameComponent from "@/components/Common/NicknameComponent.vue";
 
 export default {
   name: "QnaDetailHeaderComponent",
@@ -114,6 +115,7 @@ export default {
     formatDateTime
   },
   components: {
+    NicknameComponent
   },
 };
 </script>

--- a/frontend/src/components/qna/QnaListCardComponent.vue
+++ b/frontend/src/components/qna/QnaListCardComponent.vue
@@ -103,6 +103,7 @@ export default {
   transition: 200ms ease-in-out;
   justify-content: space-between;
   overflow: hidden;
+  cursor: pointer;
 }
 
 .qna-category-highlow {

--- a/frontend/src/pages/ErrorArchiveListPage.vue
+++ b/frontend/src/pages/ErrorArchiveListPage.vue
@@ -1,10 +1,7 @@
 <template>
   <div v-if="isLoading"></div>
   <div v-else class="custom-container">
-    <div class="errorarchive-top">
-      <p id="main-title">에러 아카이브</p>
-      <p id="sub-title">당신의 에러 해결 방법을 공유해주세요</p>
-    </div>
+    <TagComponent :tagTitle="'에러 아카이브'" :tagSubTitle="'당신의 에러 해결 방법을 공유해주세요'"/>
     <div class="errorarchive-inner">
       <SortTypeComponent @checkLatest="handleCheckLatest"
                          @checkLike="handleCheckLike"/>
@@ -29,10 +26,12 @@ import { useErrorArchiveStore } from '@/store/useErrorArchiveStore';
 import ErrorArchiveCardComponent from '@/components/errorarchive/ErrorArchiveCardComponent.vue';
 import PaginationComponent from "@/components/Common/PaginationComponent.vue";
 import SortTypeComponent from "@/components/Common/SortTypeComponent.vue";
+import TagComponent from "@/components/Common/TagComponent.vue";
 
 export default {
   name: 'ErrorArchiveListPage',
   components: {
+    TagComponent,
     ErrorArchiveCardComponent,
     SortTypeComponent,
     PaginationComponent,

--- a/frontend/src/pages/MainPage.vue
+++ b/frontend/src/pages/MainPage.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class ="custom-container">
+    <TagComponent :tagTitle="'ENADU'" :tagSubTitle="'에러의 모든 것'"/>
+
+    <LoadingComponent v-if="isLoading" />
+    <div v-else class="subject-container">
+      <div class="subject-box">
+        <router-link to="/qna/list" class="subject">QnA</router-link>
+        <router-link to="/qna/list" class="show-all-button">더 보기</router-link>
+      </div>
+      <div class="qna-inner">
+        <div class="qna-list-flex">
+          <QnaCardComponent
+              v-for="qnaCard in mainStore.mainPageInfo.qnaListResList"
+              :key="qnaCard.id"
+              v-bind:qnaCard="qnaCard"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="isLoading" style="text-align:center;"></div>
+    <div v-else class="subject-container">
+      <div class="subject-box">
+        <router-link to="/wiki/list" class="subject">위키</router-link>
+        <router-link to="/wiki/list" class="show-all-button">더 보기</router-link>
+      </div>
+      <div class="wiki-list-grid" v-if="!isLoading">
+        <WikiCardComponent v-for="wikiCard in mainStore.mainPageInfo.wikiListResList" :key="wikiCard.id" :wikiCard="wikiCard" />
+      </div>
+    </div>
+
+    <div v-if="isLoading" style="text-align:center;"></div>
+    <div v-else class="subject-container">
+      <div class="subject-box">
+        <router-link to="/errorarchive/list" class="subject">에러 아카이브</router-link>
+        <router-link to="/errorarchive/list" class="show-all-button">더 보기</router-link>
+      </div>
+      <div class="errorarchive-inner">
+        <div class="errorarchive-list-flex">
+          <ErrorArchiveCardComponent
+            v-for="errorarchiveCard in mainStore.mainPageInfo.errorArchiveListResList"
+            :key="errorarchiveCard.id"
+            v-bind:errorarchiveCard="errorarchiveCard"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+
+<script>
+
+
+import {mapStores} from "pinia";
+import {useMainStore} from "@/store/useMainStore";
+import ErrorArchiveCardComponent from "@/components/errorarchive/ErrorArchiveCardComponent.vue";
+import WikiCardComponent from "@/components/wiki/WikiCardComponent.vue";
+import QnaCardComponent from "@/components/qna/QnaListCardComponent.vue";
+import TagComponent from "@/components/Common/TagComponent.vue";
+import LoadingComponent from "@/components/Common/LoadingComponent.vue";
+
+export default {
+  name: "MainPage",
+  components: {LoadingComponent, TagComponent, QnaCardComponent, WikiCardComponent, ErrorArchiveCardComponent},
+  computed: {
+    ...mapStores(useMainStore),
+  },
+  data() {
+    return {
+      isLoading: true,
+    }
+  },
+  methods: {
+    async getMainPageInfo(){
+      await this.mainStore.getMainPageInfo();
+      this.isLoading= false;
+    }
+  },
+  mounted() {
+    this.getMainPageInfo();
+  }
+}
+</script>
+
+
+<style scoped>
+.custom-container {
+  width: 75%;
+  max-width: 1400px;
+  margin: 30px auto;
+  padding: 30px;
+  border-radius: 10px;
+}
+.subject-container {
+  margin-bottom: 70px;
+}
+.subject-box {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 15px;
+  font-weight: bold;
+}
+.subject {
+  font-size: 25px;
+
+}
+
+.qna-list-flex {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-auto-rows: auto;
+  gap: 26px 36px;
+  justify-items: stretch;
+  max-width: 100%;
+  margin: 0 auto
+}
+
+.qna-inner {
+  width: auto;
+  height: max-content;
+  background-color: #fff;
+}
+
+.errorarchive-inner {
+  width: auto;
+  height: max-content;
+  background-color: #fff;
+}
+.errorarchive-list-flex {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-auto-rows: auto;
+  gap: 26px 36px;
+  justify-items: stretch;
+  max-width: 100%;
+  margin: 0 auto
+}
+
+.wiki-list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-auto-rows: auto;
+  gap: 64px;
+  width: 100%;
+  justify-items: center;
+}
+</style>

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="custom-container">
-    <div class="qna-top">
-      <p id="main-title">QnA</p>
-      <p id="sub-title">당신의 에러를 해결해보세요</p>
-    </div>
+    <TagComponent :tagTitle="'QnA'" :tagSubTitle="'당신의 에러를 해결해보세요'"/>
     <div class="qna-inner">
       <SearchComponent  @checkLatest="handleCheckLatest"
                         @checkLike="handleCheckLike"/>
@@ -27,6 +24,7 @@ import {useQnaStore} from "@/store/useQnaStore";
 import QnaCardComponent from "@/components/qna/QnaListCardComponent.vue";
 import PaginationComponent from "@/components/Common/PaginationComponent.vue";
 import SearchComponent from "@/components/Common/SearchComponent.vue";
+import TagComponent from "@/components/Common/TagComponent.vue";
 
 export default {
   name: "QnaListPage",
@@ -63,6 +61,7 @@ export default {
     },
   },
   components: {
+    TagComponent,
     QnaCardComponent,
     PaginationComponent,
     SearchComponent,

--- a/frontend/src/pages/WikiListPage.vue
+++ b/frontend/src/pages/WikiListPage.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="custom-container">
-    <p id="main-title">WIKI</p>
-    <p id="sub-title">당신의 위키를 만들어보세요</p>
+    <TagComponent :tagTitle="'WIKI'" :tagSubTitle="'당신의 위키를 만들어보세요'"/>
 
     <div v-if="isLoading" style="text-align:center;">
       <p>로딩 중...</p>
@@ -22,10 +21,12 @@ import WikiCardComponent from "@/components/wiki/WikiCardComponent.vue";
 import PaginationComponent from "@/components/Common/PaginationComponent.vue";
 import { mapStores } from "pinia";
 import { useWikiStore } from "@/store/useWikiStore";
+import TagComponent from "@/components/Common/TagComponent.vue";
 
 export default {
   name: "WikiListPage",
   components: {
+    TagComponent,
     WikiCardComponent,
     PaginationComponent,
   },
@@ -80,7 +81,6 @@ export default {
   grid-auto-rows: auto;
   gap: 64px;
   width: 100%;
-  max-width: 1200px;
   padding: 20px;
   justify-items: center;
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -20,6 +20,7 @@ import UserLogComponent from "@/components/Mypage/UserLogComponent.vue";
 import ScrapListComponent from "@/components/Mypage/ScrapListComponent.vue";
 import ErrorArchiveDetailPage from "@/pages/ErrorArchiveDetailPage.vue";
 import WikiListPage from "@/pages/WikiListPage.vue";
+import MainPage from "@/pages/MainPage.vue";
 
 
 const router = createRouter({
@@ -47,6 +48,7 @@ const router = createRouter({
         { path: "scrap", component: ScrapListComponent }
       ] },
     { path:"/errorarchive/detail", component: ErrorArchiveDetailPage},
+    { path:"/", component: MainPage},
   ]
 });
 

--- a/frontend/src/store/useMainStore.js
+++ b/frontend/src/store/useMainStore.js
@@ -1,0 +1,39 @@
+import {defineStore} from 'pinia';
+import axios from 'axios';
+
+const backend = "/api";
+
+export const useMainStore = defineStore('main', {
+    state: () => ({
+        mainPageInfo: {
+            wikiListResList: [],
+            errorArchiveListResList: [],
+            qnaListResList: []
+        }
+    }),
+    actions: {
+        async getMainPageInfo() {
+            const request = {
+                errorArchiveSize: 5,
+                wikiSize: 4,
+                qnaSize: 5
+            }
+            try {
+                const response= await axios.get(backend+'/main', request,{
+                    headers: { 'Content-Type': 'multipart/form-data' },
+                    withCredentials: true
+                });
+                if (response.data.isSuccess){
+                    this.mainPageInfo = response.data.result;
+                } else {
+                    throw new Error(response.data.message);
+                }
+            } catch (error) {
+                console.error('메인 페이지 로딩 실패:', error);
+                return null;
+            }
+        }
+    }
+});
+
+


### PR DESCRIPTION
## 연관 이슈
close #61 


## 작업 내용
- 메인 페이지 구성
- TagComponent 생성 및 각 목록 페이지에 적용
  - props로 tagTitle이랑 tagSubTitle 주면 됨(메인 페이지 참고)
- LoadingComponent 생성 및 메인 페이지에 적용
  - 그냥 사용하면됨(메인페이지 참고)
- 위키 목록 가운데 정렬 안되어 있어 css 수정
- 에러아카이브 카드 클릭시 상세 페이지로 routing 설정
- QnA 카드 마우스 올리면 pointer 바꾸는 css추가
- 헤더에 아카이브 routing 설정


## 스크린샷 (선택)
![modified_image](https://github.com/user-attachments/assets/e685ec1c-ba1e-4a00-ab13-736ef2b92c4d)

![image](https://github.com/user-attachments/assets/90b41a6c-0b33-42f6-bb0c-e2073ba09c86)

## 리뷰 요구사항 혹은 기타 (선택)
리뷰어들이 참고해야할 사항이나 집중적으로 봐줬으면 하는 사항을 작성한다.