### PR TITLE
[Feat] 위키 이전버전 목록조회 기능, 이전버전 상세조회 기능  (#245 #246)

### DIFF
--- a/frontend/src/components/wiki/WikiDetailComponent.vue
+++ b/frontend/src/components/wiki/WikiDetailComponent.vue
@@ -13,10 +13,10 @@
                         </div>
                         <div class="sc-fbyfCU eYeYLy" style="margin-left: auto;">
                             <button v-if="canEditWiki && wikiDetail.title" @click="goToEditPage"
-                                class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:var(--main-color)">
+                                class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:#f4c2c2">
                                 수정
                             </button>
-                            <button class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:#12B886"
+                            <button class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:#42a5f5"
                                 @click="goToVersionList">
                                 이전 버전 위키
                             </button>
@@ -80,8 +80,8 @@ export default {
     data() {
         return {
             id: '',
-            userGrade: 'GUEST', // 기본값 설정
-            titles: [], // 목차 저장할 변수
+            userGrade: 'GUEST', 
+            titles: [], 
             isLoading: true,
         };
     },
@@ -92,22 +92,20 @@ export default {
             return this.wikiStore.wikiDetail || {};
         },
         canEditWiki() {
-            // 유저 등급과 로그인 상태에 따른 수정 권한 체크
             return this.userGrade !== '뉴비' && this.userGrade !== 'GUEST' && this.userStore.isLoggedIn;
         },
     },
     watch: {
-        // 로그인 상태가 변경될 때 버튼 상태를 갱신
         'userStore.isLoggedIn'(newValue) {
             if (!newValue) {
-                this.userGrade = 'GUEST'; // 로그아웃 상태로 변경
+                this.userGrade = 'GUEST'; 
             }
         }
     },
     async mounted() {
         this.id = this.$route.query.id || this.$route.params.id;
         if (this.id) {
-            await this.fetchWikiDetail(); // 위키 상세 조회
+            await this.fetchWikiDetail(); 
         }
         this.isLoading = false;
         this.$nextTick(() => {
@@ -201,7 +199,7 @@ v-md-preview p {
 }
 
 .sc-egiyK {
-    color: #12B886;
+    color: #2689d2;
     text-decoration: none;
     cursor: pointer;
 }
@@ -683,7 +681,7 @@ textarea {
     -webkit-box-align: center;
     align-items: center;
     margin-right: 0.875rem;
-    color: #12B886;
+    color: #2689d2;
     text-decoration: none;
     font-weight: 700;
     font-size: 1rem;
@@ -1523,7 +1521,7 @@ body[data-theme="light"] {
     --border2: #ADB5BD;
     --border3: #DEE2E6;
     --border4: #F1F3F5;
-    --primary1: #12B886;
+    --primary1: #42a5f5;
     --primary2: #20C997;
     --destructive1: #FF6B6B;
     --destructive2: #FF8787;

--- a/frontend/src/components/wiki/WikiVersionDetailComponent.vue
+++ b/frontend/src/components/wiki/WikiVersionDetailComponent.vue
@@ -8,17 +8,13 @@
                     <div class="sc-fvxzrP jGdQwA" style="display: flex; justify-content: space-between;">
                         <div class="information">
                             <span class="version">
-                                <span class="sc-egiyK cyyZlI">현재 버전 : V{{ wikiDetail.version }}</span>
+                                <span class="sc-egiyK cyyZlI">버전 : V{{ wikiDetail.version }}</span>
                             </span>
                         </div>
                         <div class="sc-fbyfCU eYeYLy" style="margin-left: auto;">
-                            <button v-if="canEditWiki && wikiDetail.title" @click="goToEditPage"
-                                class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:var(--main-color)">
-                                수정
-                            </button>
                             <button class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:#12B886"
                                 @click="goToVersionList">
-                                이전 버전 위키
+                                이전 버전 목록
                             </button>
                             <div class="bookmark-checkbox">
                                 <input type="checkbox" id="bookmark-toggle" :checked="wikiDetail.checkScrap"
@@ -76,7 +72,7 @@ VMdPreview.use(githubTheme, {
 });
 
 export default {
-    name: "WikiDetailComponent",
+    name: "WikiVersionDetailComponent",
     data() {
         return {
             id: '',
@@ -91,23 +87,11 @@ export default {
         wikiDetail() {
             return this.wikiStore.wikiDetail || {};
         },
-        canEditWiki() {
-            // 유저 등급과 로그인 상태에 따른 수정 권한 체크
-            return this.userGrade !== '뉴비' && this.userGrade !== 'GUEST' && this.userStore.isLoggedIn;
-        },
-    },
-    watch: {
-        // 로그인 상태가 변경될 때 버튼 상태를 갱신
-        'userStore.isLoggedIn'(newValue) {
-            if (!newValue) {
-                this.userGrade = 'GUEST'; // 로그아웃 상태로 변경
-            }
-        }
     },
     async mounted() {
         this.id = this.$route.query.id || this.$route.params.id;
         if (this.id) {
-            await this.fetchWikiDetail(); // 위키 상세 조회
+            await this.fetchWikiVersionDetail(); // 버전 상세 조회
         }
         this.isLoading = false;
         this.$nextTick(() => {
@@ -129,16 +113,13 @@ export default {
         });
     },
     methods: {
-        async fetchWikiDetail() {
+        async fetchWikiVersionDetail() {
             try {
-                await this.wikiStore.fetchWikiDetail(this.id);
+                await this.wikiStore.fetchWikiVersionDetail(this.id); // 버전 상세 조회 API 호출
                 this.userGrade = this.wikiStore.wikiDetail.userGrade || 'GUEST';
             } catch (error) {
-                console.error('Wiki Detail Fetch Error:', error);
+                console.error('Wiki Version Detail Fetch Error:', error);
             }
-        },
-        goToEditPage() {
-            this.$router.push({ name: 'WikiUpdate', query: { id: this.id } });
         },
         goToVersionList() {
             this.$router.push({ path: '/wiki/version/list', query: { id: this.id } });
@@ -150,7 +131,6 @@ export default {
             const heading = preview.$el.querySelector(`[data-v-md-line="${lineIndex}"]`);
 
             if (heading) {
-                // Note: If you are using the preview mode of the editing component, the method name here is changed to previewScrollToTarget
                 preview.scrollToTarget({
                     target: heading,
                     scrollContainer: window,
@@ -164,8 +144,6 @@ export default {
     },
 };
 </script>
-
-
 
 <style scoped>
 v-md-preview {

--- a/frontend/src/components/wiki/WikiVersionDetailComponent.vue
+++ b/frontend/src/components/wiki/WikiVersionDetailComponent.vue
@@ -12,10 +12,13 @@
                             </span>
                         </div>
                         <div class="sc-fbyfCU eYeYLy" style="margin-left: auto;">
-                            <button class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:#12B886"
-                                @click="goToVersionList">
-                                이전 버전 목록
+                            <!-- 최신 위키로 돌아가기 버튼 -->
+                            <button class="ml-3 text-white px-4 py-2 rounded-md" style="background-color:#42a5f5"
+                                @click="goToLatestWiki">
+                                최신 위키 돌아가기
                             </button>
+
+                            <!-- 스크랩 북마크 -->
                             <div class="bookmark-checkbox">
                                 <input type="checkbox" id="bookmark-toggle" :checked="wikiDetail.checkScrap"
                                     class="bookmark-checkbox__input">
@@ -32,7 +35,7 @@
                 </div>
 
                 <div class="sc-cZMNgc bpMcZw">
-                    <a class="sc-dtMgUX gISUXI" href="/tags/LomBok">{{ wikiDetail.category }}</a>
+                    <a class="sc-dtMgUX gISUXI" href="/tags/{{ wikiDetail.category }}">{{ wikiDetail.category }}</a>
                 </div>
 
                 <div class="sc-jlRLRk iGRQXB">
@@ -61,7 +64,6 @@
 <script>
 import { mapStores } from "pinia";
 import { useWikiStore } from "@/store/useWikiStore";
-import { useUserStore } from "@/store/useUserStore";
 import VMdPreview from '@kangc/v-md-editor/lib/preview';
 import githubTheme from '@kangc/v-md-editor/lib/theme/github.js';
 import '@kangc/v-md-editor/lib/style/preview.css';
@@ -75,25 +77,26 @@ export default {
     name: "WikiVersionDetailComponent",
     data() {
         return {
-            id: '',
-            userGrade: 'GUEST', // 기본값 설정
-            titles: [], // 목차 저장할 변수
-            isLoading: true,
+            id: '', 
+            wikiId: '',  
+            isLoading: true, 
+            titles: [],      
         };
     },
     computed: {
         ...mapStores(useWikiStore),
-        ...mapStores(useUserStore),
         wikiDetail() {
             return this.wikiStore.wikiDetail || {};
-        },
+        }
     },
     async mounted() {
         this.id = this.$route.query.id || this.$route.params.id;
         if (this.id) {
-            await this.fetchWikiVersionDetail(); // 버전 상세 조회
+            const result = await this.wikiStore.fetchWikiVersionDetail(this.id);
+            this.wikiId = result.wikiId; 
         }
         this.isLoading = false;
+
         this.$nextTick(() => {
             const anchors = this.$refs.preview.$el.querySelectorAll('h1,h2,h3,h4,h5,h6');
             const titles = Array.from(anchors).filter((title) => !!title.innerText.trim());
@@ -113,16 +116,16 @@ export default {
         });
     },
     methods: {
-        async fetchWikiVersionDetail() {
+        async goToLatestWiki() {
             try {
-                await this.wikiStore.fetchWikiVersionDetail(this.id); // 버전 상세 조회 API 호출
-                this.userGrade = this.wikiStore.wikiDetail.userGrade || 'GUEST';
+                await this.wikiStore.fetchWikiDetail(this.wikiDetail.id);
+                this.$router.push({ path: '/wiki/detail', query: { id: this.wikiDetail.id } });
             } catch (error) {
-                console.error('Wiki Version Detail Fetch Error:', error);
+                console.error('최신 위키로 이동 중 오류 발생:', error);
             }
         },
-        goToVersionList() {
-            this.$router.push({ path: '/wiki/version/list', query: { id: this.id } });
+        goToVersionDetail(wikiContentId) {
+            this.$router.push({ path: '/wiki/version/detail', query: { id: wikiContentId } });
         },
         handleAnchorClick(anchor) {
             const { preview } = this.$refs;
@@ -144,6 +147,8 @@ export default {
     },
 };
 </script>
+
+
 
 <style scoped>
 v-md-preview {
@@ -179,7 +184,7 @@ v-md-preview p {
 }
 
 .sc-egiyK {
-    color: #12B886;
+    color: #2689d2;
     text-decoration: none;
     cursor: pointer;
 }
@@ -237,7 +242,7 @@ body[data-theme="light"] {
     --border2: #ADB5BD;
     --border3: #DEE2E6;
     --border4: #F1F3F5;
-    --primary1: #12B886;
+    --primary1: #42a5f5;
     --primary2: #20C997;
     --destructive1: #FF6B6B;
     --destructive2: #FF8787;
@@ -401,23 +406,6 @@ body[data-theme="light"] {
     cursor: pointer;
     margin-right: 0.5rem;
 }
-
-.bnYoDz {
-    height: 2rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    font-size: 1rem;
-    border-radius: 1rem;
-    outline: none;
-    font-weight: bold;
-    word-break: keep-all;
-    background: var(--bg-element2);
-    border: 1px solid var(--bg-element5);
-    color: var(--bg-element5);
-    transition: 0.125s ease-in;
-    cursor: pointer;
-}
-
 .gegLws {
     cursor: pointer;
     display: flex;
@@ -661,7 +649,7 @@ textarea {
     -webkit-box-align: center;
     align-items: center;
     margin-right: 0.875rem;
-    color: #12B886;
+    color: #2689d2;
     text-decoration: none;
     font-weight: 700;
     font-size: 1rem;

--- a/frontend/src/pages/WikiVersionDetailPage.vue
+++ b/frontend/src/pages/WikiVersionDetailPage.vue
@@ -16,5 +16,4 @@ export default {
 </script>
 
 <style scoped>
-/* 스타일 */
 </style>

--- a/frontend/src/pages/WikiVersionDetailPage.vue
+++ b/frontend/src/pages/WikiVersionDetailPage.vue
@@ -1,0 +1,20 @@
+<template>
+    <div class="custom-container">
+      <WikiVersionDetailComponent />
+    </div>
+</template>
+
+<script>
+import WikiVersionDetailComponent from '@/components/wiki/WikiVersionDetailComponent.vue';
+
+export default {
+    name: "WikiVersionDetailPage",
+    components: {
+        WikiVersionDetailComponent
+    }
+};
+</script>
+
+<style scoped>
+/* 스타일 */
+</style>

--- a/frontend/src/pages/WikiVersionListPage.vue
+++ b/frontend/src/pages/WikiVersionListPage.vue
@@ -1,0 +1,115 @@
+<template>
+    <div class="container">
+        <h1 class="title">WIKI : {{ wikiTitle }}</h1>
+        <p class="category">category : {{ category }}</p>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>날짜</th>
+                    <th>버전 명</th>
+                    <th>작성자 명</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="(version, index) in wikiVersions" :key="index">
+                    <td>{{ version.createdAt }}</td>
+                    <td><a @click="goToVersionDetail(version.wikiContentId)" class="version-link">V{{ version.version }}</a></td>
+                    <td>{{ version.nickname }}</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <div v-if="!isLoading"></div>
+        <pagination-component v-else style="margin-top: 20px;" @updatePage="updatePage" :totalPage="totalPage" />
+    </div>
+</template>
+  
+<script>
+import PaginationComponent from "@/components/Common/PaginationComponent.vue";
+import { useWikiStore } from "@/store/useWikiStore";
+import { mapState, mapActions } from "pinia";
+
+export default {
+    name: "WikiVersionListPage",
+    components: {
+        PaginationComponent
+    },
+    computed: {
+        ...mapState(useWikiStore, ["wikiVersions", "wikiTitle", "category", "currentPage", "totalPages"]),
+    },
+    data() {
+        return {
+            selectedPage: 1,
+            totalPages: 1,
+            isLoading: true,
+        }
+    },
+    methods: {
+        ...mapActions(useWikiStore, ["fetchWikiVersionList", "fetchWikiDetail"]),
+
+        updatePage(page) {
+            this.page = page-1
+        },
+        goToVersionDetail(wikiContentId) {
+            // 해당 버전의 위키 상세 페이지로 이동
+            this.$router.push(`/wiki/version/detail?id=${wikiContentId}`);
+        },
+    },
+    async mounted() {
+        const id = this.$route.query.id;
+        await this.fetchWikiDetail(id);
+        await this.fetchWikiVersionList(id);
+    },
+};
+</script>
+  
+<style scoped>
+.container {
+    width: 80%;
+    margin: 50px auto;
+}
+
+.title {
+    font-size: 2.5rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+
+.category {
+    font-size: 1.2rem;
+    color: #666;
+    margin-bottom: 30px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: white;
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+table th,
+table td {
+    padding: 12px 15px;
+    text-align: center;
+    border-bottom: 1px solid #ddd;
+}
+
+table th {
+    background-color: #f1f1f1;
+    font-weight: bold;
+}
+
+.version-link {
+    color: #007bff;
+    text-decoration: none;
+}
+
+.version-link:hover {
+    text-decoration: underline;
+}
+</style>
+  

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -19,6 +19,8 @@ import InfoComponent from "@/components/Mypage/Info/InfoComponent.vue";
 import UserLogComponent from "@/components/Mypage/UserLogComponent.vue";
 import ScrapListComponent from "@/components/Mypage/ScrapListComponent.vue";
 import ErrorArchiveDetailPage from "@/pages/ErrorArchiveDetailPage.vue";
+import WikiVersionListPage from '@/pages/WikiVersionListPage.vue';
+import WikiVersionDetailPage from '@/pages/WikiVersionDetailPage.vue'; 
 
 
 const router = createRouter({
@@ -39,6 +41,8 @@ const router = createRouter({
       ]},
     { path: "/wiki/detail", name: "WikiDetail", component: WikiDetailPage },
     { path: "/wiki/update", name: "WikiUpdate", component: WikiUpdatePage },
+    { path: "/wiki/version/list", component: WikiVersionListPage },
+    { path: "/wiki/version/detail", component: WikiVersionDetailPage },
     { path: "/mypage", component: MypagePage, children: [
         { path: "info", component: InfoComponent },
         { path: "history", component: UserLogComponent },

--- a/frontend/src/store/useWikiStore.js
+++ b/frontend/src/store/useWikiStore.js
@@ -29,6 +29,12 @@ export const useWikiStore = defineStore("wiki", {
             content: '',
         },
         wikiDetail: null,
+        wikiVersions: [],  // Wiki 버전 목록
+        totalPages: 0,     // 전체 페이지 수
+        currentPage: 0,    // 현재 페이지
+        pageSize: 10,      // 한 페이지 당 항목 수
+        wikiTitle: '',     // Wiki 제목
+        category: '',      // Wiki 카테고리
     }),
 
     actions: {
@@ -44,19 +50,19 @@ export const useWikiStore = defineStore("wiki", {
                 const formData = new FormData();
                 const jsonBlob = new Blob([JSON.stringify(this.wikiRegisterReq)], { type: "application/json" });
                 formData.append("wikiRegisterReq", jsonBlob);
-        
+
                 if (thumbnail) {
                     formData.append("thumbnail", thumbnail);
                 }
-        
+
                 const response = await axios.post(backend + "/wiki", formData, {
                     withCredentials: true,
                     headers: { "Content-Type": "multipart/form-data" }
                 });
-        
+
                 if (response && response.data) {
                     console.log("응답 데이터:", response.data);
-                    
+
                     if (response.data.isSuccess) {
                         const newWikiId = response.data.result.wikiId; // 서버에서 반환된 ID 사용
                         return newWikiId; // 성공적으로 위키 등록되었을 때 ID 반환
@@ -119,11 +125,14 @@ export const useWikiStore = defineStore("wiki", {
                     withCredentials: true,
                 });
 
-                if (response && response.data) {
+                if (response && response.data.isSuccess) {
                     console.log('Wiki Detail Response:', response.data);
-                    this.wikiDetail = response.data.result;
+                    const result = response.data.result;
 
-                    
+                    this.wikiDetail = result;
+                    this.wikiTitle = result.title || 'Unknown Title';
+                    this.category = result.category || 'Unknown Category';
+
                 } else {
                     throw new Error("위키 상세 조회 실패");
                 }
@@ -131,6 +140,51 @@ export const useWikiStore = defineStore("wiki", {
                 console.error("위키 상세 조회 중 오류 발생:", error);
             }
         },
-        
+        // 위키 버전 목록 조회
+        async fetchWikiVersionList(wikiId, page = 0) {
+            try {
+                const response = await axios.get(backend + "/wiki/version/list", {
+                    params: { id: wikiId, page: page, size: this.pageSize },
+                    withCredentials: true,
+                });
+
+                console.log("API 응답:", response);
+
+                if (response && response.data.isSuccess) {
+                    const result = response.data.result;
+
+
+                    if (result && result.length > 0) {
+                        this.wikiVersions = result;
+                        this.totalPages = result[0].totalPages || 1;
+                    } else {
+                        console.error("Wiki 버전 데이터가 없습니다.");
+                        this.wikiVersions = [];
+                        this.totalPages = 0;
+                    }
+                } else {
+                    console.error("API 응답 오류:", response.data.message);
+                }
+            } catch (error) {
+                console.error('API 호출 중 오류 발생:', error);
+            }
+        },
+        // 위키 버전 상세 조회
+        async fetchWikiVersionDetail(id) {
+            try {
+                const response = await axios.get(backend + "/wiki/version/detail", {
+                    params: { id },
+                    withCredentials: true,
+                });
+
+                if (response && response.data.isSuccess) {
+                    this.wikiDetail = response.data.result; // 버전 상세 데이터 저장
+                } else {
+                    console.error("버전 상세 조회 실패:", response.data.message);
+                }
+            } catch (error) {
+                console.error('버전 상세 조회 중 오류 발생:', error);
+            }
+        },
     }
 });

--- a/frontend/src/store/useWikiStore.js
+++ b/frontend/src/store/useWikiStore.js
@@ -29,19 +29,19 @@ export const useWikiStore = defineStore("wiki", {
             content: '',
         },
         wikiDetail: null,
-        wikiVersions: [],  // Wiki 버전 목록
-        totalPages: 0,     // 전체 페이지 수
-        currentPage: 0,    // 현재 페이지
-        pageSize: 10,      // 한 페이지 당 항목 수
-        wikiTitle: '',     // Wiki 제목
-        category: '',      // Wiki 카테고리
+        wikiVersions: [], 
+        totalPages: 0,  
+        currentPage: 0,  
+        pageSize: 10,  
+        wikiTitle: '',
+        category: '',    
     }),
 
     actions: {
 
         // 위키 등록 기능
         async registerWiki(thumbnail) {
-            const userStore = useUserStore(); // 유저 스토어 사용
+            const userStore = useUserStore();
             if (!userStore.isLoggedIn) {
                 console.log("로그인이 필요합니다.");
                 return false;
@@ -64,8 +64,8 @@ export const useWikiStore = defineStore("wiki", {
                     console.log("응답 데이터:", response.data);
 
                     if (response.data.isSuccess) {
-                        const newWikiId = response.data.result.wikiId; // 서버에서 반환된 ID 사용
-                        return newWikiId; // 성공적으로 위키 등록되었을 때 ID 반환
+                        const newWikiId = response.data.result.wikiId;
+                        return newWikiId; 
                     } else {
                         throw new Error(response.data.message || "서버 응답 오류");
                     }
@@ -74,13 +74,13 @@ export const useWikiStore = defineStore("wiki", {
                 }
             } catch (error) {
                 console.error("위키 등록 중 오류 발생:", error);
-                return false; // 오류 발생 시 false 반환
+                return false; 
             }
         },
 
         // 위키 수정 기능
         async updateWiki(id, updatedContent, updatedThumbnail) {
-            const userStore = useUserStore(); // 유저 스토어 사용
+            const userStore = useUserStore();
             if (!userStore.isLoggedIn) {
                 console.log("로그인이 필요합니다.");
                 return false;
@@ -133,54 +133,37 @@ export const useWikiStore = defineStore("wiki", {
                     this.wikiTitle = result.title || 'Unknown Title';
                     this.category = result.category || 'Unknown Category';
 
-                } else {
-                    throw new Error("위키 상세 조회 실패");
                 }
             } catch (error) {
                 console.error("위키 상세 조회 중 오류 발생:", error);
             }
         },
         // 위키 버전 목록 조회
-        async fetchWikiVersionList(wikiId, page = 0) {
+        async fetchWikiVersionList(wikiId, page) {
             try {
                 const response = await axios.get(backend + "/wiki/version/list", {
                     params: { id: wikiId, page: page, size: this.pageSize },
                     withCredentials: true,
                 });
 
-                console.log("API 응답:", response);
-
-                if (response && response.data.isSuccess) {
-                    const result = response.data.result;
-
-
-                    if (result && result.length > 0) {
-                        this.wikiVersions = result;
-                        this.totalPages = result[0].totalPages || 1;
-                    } else {
-                        console.error("Wiki 버전 데이터가 없습니다.");
-                        this.wikiVersions = [];
-                        this.totalPages = 0;
-                    }
-                } else {
-                    console.error("API 응답 오류:", response.data.message);
+                if (response.data.isSuccess) {
+                    this.wikiVersions = response.data.result;
+                    this.totalPages = response.data.result[0]?.totalPages || 1;
                 }
             } catch (error) {
                 console.error('API 호출 중 오류 발생:', error);
             }
         },
         // 위키 버전 상세 조회
-        async fetchWikiVersionDetail(id) {
+        async fetchWikiVersionDetail(wikiContentId) {
             try {
                 const response = await axios.get(backend + "/wiki/version/detail", {
-                    params: { id },
+                    params: { wikiContentId },
                     withCredentials: true,
                 });
-
                 if (response && response.data.isSuccess) {
-                    this.wikiDetail = response.data.result; // 버전 상세 데이터 저장
-                } else {
-                    console.error("버전 상세 조회 실패:", response.data.message);
+                    this.wikiDetail = response.data.result;
+                    return response.data.result; 
                 }
             } catch (error) {
                 console.error('버전 상세 조회 중 오류 발생:', error);


### PR DESCRIPTION
## 연관 이슈
close #245 #246 


## 작업 내용
📌**이전버전 목록조회 기능, 이전버전 상세조회 기능**

- 위키의 이전 버전 목록을 조회하고 사용자가 특정 버전을 클릭 시, 해당 버전의 상세 페이지로 이동하는 기능 구현
- 특정 위키 버전의 상세 정보를 조회 시, 최신 버전으로 갈 수 있는 기능 구현
  - 페이지네이션 기능 추가
  - 각 버전 링크 클릭 시 해당 버전의 상세 페이지 routing 설정
  - [최신 위키 돌아가기] 버튼을 추가하여 사용자가 최신 버전으로 돌아갈 수 있도록 routing 설정
  - UI 수정
  - 그 외 위키 여러 컴포넌트 수정


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/41095cd1-3100-4c02-acfa-dfe8faae9b93)
최신 버전 위키 상세 페이지 UI
![image](https://github.com/user-attachments/assets/198df2f5-0654-4c58-8286-d7b9aa35e07c)
이전 버전 위키 클릭 시 UI
![image](https://github.com/user-attachments/assets/78e74d2c-c9ee-48de-aeca-9c0d40135a7d)
이전 버전(ex. V12) 클릭 시 UI



## 리뷰 요구사항 혹은 기타 (선택)
버전 롤백 API 미구현으로 아직 목록에 안 넣었습니다. 추후 추가 예정