### PR TITLE
[Feat] 이메일 인증 페이지 생성, axios 연결, 닉네임 중복 확인 수정

### DIFF
--- a/frontend/src/components/user/SignUpComponent.vue
+++ b/frontend/src/components/user/SignUpComponent.vue
@@ -65,8 +65,7 @@ import axios from 'axios';
           alert("비밀번호가 일치하지 않습니다.");
           return;
         }
-        console.log("success");
-        this.$emit('signup', this.userInfo, this.selectedProfileFile);
+        this.$emit('signup', this.userInfo, this.selectedProfileFile || null);
       },
       handleProfileImageUpload(event) {
         const file = event.target.files[0];

--- a/frontend/src/pages/EmailVerifyPage.vue
+++ b/frontend/src/pages/EmailVerifyPage.vue
@@ -1,0 +1,95 @@
+<template>
+    <div class="full-page">
+        <div class="container">
+            <div class="message">이메일 인증이 완료되었습니다</div>
+            <router-link to="/login" class="login-btn" >로그인 하러 가기</router-link>
+        </div>
+    </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+    name: 'EmailVerifyPage',
+    data() {
+        return {
+            message: '',
+            isverified: false, // 인증 상태
+        };
+    },
+    methods: {
+        async verifyEmail() {
+            const email = this.$route.query.email;
+            const uuid = this.$route.query.uuid;
+
+            try {
+                const response = await axios.get(`http://localhost:8080/email/verify`, {
+                    params: {
+                        email,
+                        uuid,
+                    },
+                });
+                if (response.status === 302) {
+                    this.message = '이메일 인증이 완료되었습니다';
+                    this.isverified = true; // 인증 성공 상태로 변경
+                    alert('이메일 인증에 성공했습니다!');
+                }
+            } catch (error) {
+                this.message = '이메일 인증에 실패했습니다';
+                alert('이메일 인증에 실패했습니다.');
+            }
+        },
+    },
+    mounted() {
+        this.verifyEmail(); // 페이지 로드 시 이메일 인증 호출
+    },
+};
+</script>
+
+<style scoped>
+html, body {
+    height: 100%;
+    margin: 0;
+}
+
+.full-page {
+    display: flex;
+    justify-content: center; /* 수평 중앙 정렬 */
+    align-items: center; /* 수직 중앙 정렬 */
+    height: 100vh; /* 전체 화면 높이 설정 */
+    background-color: #f4f4f4;
+}
+
+.container {
+    background-color: #fff;
+    border-radius: 10px;
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.08), 0 10px 10px rgba(0, 0, 0, 0.08);
+    width: 25%; /* 너비를 4분의 1로 설정 */
+    max-width: 400px; /* 최대 너비 */
+    padding: 20px; /* 패딩 추가 */
+    text-align: center; /* 텍스트 중앙 정렬 */
+    min-height: 200px; /* 최소 높이 설정 */
+}
+.message {
+    font-size: 24px;
+    color: #333;
+    margin-bottom: 20px;
+}
+
+.login-btn {
+    display: inline-block;
+    padding: 10px 20px;
+    font-size: 16px;
+    color: white;
+    background-color: #737475;
+    border: none;
+    border-radius: 5px;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.login-btn:hover {
+    background-color: #545455;
+}
+</style>

--- a/frontend/src/pages/EmailVerifyPage.vue
+++ b/frontend/src/pages/EmailVerifyPage.vue
@@ -16,7 +16,6 @@ export default {
         return {
             email: '',
             uuid: '',
-            isVerified: false, // 인증 상태
         };
     },
     mounted() {
@@ -28,10 +27,9 @@ export default {
         async verifyEmail(email, uuid) {
             const userStore = useUserStore(); // UserStore 인스턴스 생성
             try {
-                await userStore.verifyEmail(email, uuid); // UserStore의 verifyEmail 메소드 호출
+               const result =  await userStore.verifyEmail(email, uuid); // UserStore의 verifyEmail 메소드 호출
                 
-                if (userStore.isverified) {
-                    this.isVerified = true; // 인증 성공 상태로 변경
+                if (result) {
                     alert('이메일 인증에 성공했습니다!');
                 }
             } catch (error) {

--- a/frontend/src/pages/EmailVerifyPage.vue
+++ b/frontend/src/pages/EmailVerifyPage.vue
@@ -2,47 +2,42 @@
     <div class="full-page">
         <div class="container">
             <div class="message">이메일 인증이 완료되었습니다</div>
-            <router-link to="/login" class="login-btn" >로그인 하러 가기</router-link>
+            <router-link to="/login?mode=login" class="login-btn">로그인 하러 가기</router-link>
         </div>
     </div>
 </template>
 
 <script>
-import axios from 'axios';
+import { useUserStore } from '@/store/useUserStore'; // UserStore를 가져옵니다.
 
 export default {
     name: 'EmailVerifyPage',
     data() {
         return {
-            message: '',
-            isverified: false, // 인증 상태
+            email: '',
+            uuid: '',
+            isVerified: false, // 인증 상태
         };
     },
+    mounted() {
+        const email = this.$route.query.email;
+        const uuid = this.$route.query.uuid;
+        this.verifyEmail(email, uuid); 
+    },
     methods: {
-        async verifyEmail() {
-            const email = this.$route.query.email;
-            const uuid = this.$route.query.uuid;
-
+        async verifyEmail(email, uuid) {
+            const userStore = useUserStore(); // UserStore 인스턴스 생성
             try {
-                const response = await axios.get(`http://localhost:8080/email/verify`, {
-                    params: {
-                        email,
-                        uuid,
-                    },
-                });
-                if (response.status === 302) {
-                    this.message = '이메일 인증이 완료되었습니다';
-                    this.isverified = true; // 인증 성공 상태로 변경
+                await userStore.verifyEmail(email, uuid); // UserStore의 verifyEmail 메소드 호출
+                
+                if (userStore.isverified) {
+                    this.isVerified = true; // 인증 성공 상태로 변경
                     alert('이메일 인증에 성공했습니다!');
                 }
             } catch (error) {
-                this.message = '이메일 인증에 실패했습니다';
                 alert('이메일 인증에 실패했습니다.');
             }
         },
-    },
-    mounted() {
-        this.verifyEmail(); // 페이지 로드 시 이메일 인증 호출
     },
 };
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,6 +11,8 @@ import PointInfoComponent from "@/components/Point/PointInfoComponent.vue";
 import PointRankingComponent from "@/components/Point/PointRankingComponent.vue";
 import WikiDetailPage from "@/pages/WikiDetailPage.vue";
 import QnaDetailPage from "@/pages/QnaDetailPage.vue";
+import ErrorArchiveListPage from "@/pages/ErrorArchiveListPage.vue";
+import EmailVerifyPage from "@/pages/EmailVerifyPage.vue";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -22,12 +24,15 @@ const router = createRouter({
     { path: "/wiki", component: WikiRegisterPage },
     { path: "/chat", component: ChatPage },
     { path: "/errorarchive", component: ErrorArchiveRegisterPage },
+    { path: "/errorarchive/list", component: ErrorArchiveListPage },
     { path: "/oauth", component: OAuthLoginPage, meta: { showHeader: false } },
     { path: "/point", component: PointPage, children: [
         { path: "info", component: PointInfoComponent },
         { path: "rank", component: PointRankingComponent },
       ]},
-    { path: "/wiki/detail", component: WikiDetailPage }
+    { path: "/wiki/detail", component: WikiDetailPage },
+    { path: "/email/verify", component: EmailVerifyPage },
+    
   ]
   
 });

--- a/frontend/src/store/useUserStore.js
+++ b/frontend/src/store/useUserStore.js
@@ -7,7 +7,6 @@ export const useUserStore = defineStore('user', {
     state: () => ({
         userId: null,
         isLoggedIn: false,
-        isverified: false,
     }),
     actions: {
         async login(user) {
@@ -135,16 +134,14 @@ export const useUserStore = defineStore('user', {
             },
             async verifyEmail(email, uuid) {
                 try {
-                    const response = await axios.get(`http://localhost:8080/email/verify`, {
-                        params: {
+                    const response = await axios.post(`http://localhost:8080/email/verify`, {
                             email,
                             uuid,
-                        },
                     });
+                    
             
                     // 응답 코드와 성공 여부 확인
                     if (response.data.code === 1000 && response.data.isSuccess) {
-                        this.isverified = true; // 인증 성공 상태로 변경
                         alert('이메일 인증에 성공했습니다!');
                     } else {
                         alert(response.data.message || '이메일 인증에 실패했습니다.');
@@ -154,10 +151,6 @@ export const useUserStore = defineStore('user', {
                     alert('이메일 인증에 실패했습니다.');
                 }
             }
-            
-            
-            
-
     },
 });
          

--- a/frontend/src/store/useUserStore.js
+++ b/frontend/src/store/useUserStore.js
@@ -69,6 +69,10 @@ export const useUserStore = defineStore('user', {
                 const blob = new Blob([JSON.stringify(userInfo)], { type: 'application/json'});
                 formData.append('userSignupReq', blob);
                 formData.append('profileImg',selectedProfileFile);
+
+                if(selectedProfileFile){
+                    formData.append('profileImg',selectedProfileFile);
+                }
             
                 // 요청 보내기
                 const response = await axios.post("http://localhost:8080/user/signup", formData, {

--- a/frontend/src/store/useUserStore.js
+++ b/frontend/src/store/useUserStore.js
@@ -7,6 +7,7 @@ export const useUserStore = defineStore('user', {
     state: () => ({
         userId: null,
         isLoggedIn: false,
+        isverified: false,
     }),
     actions: {
         async login(user) {
@@ -70,10 +71,6 @@ export const useUserStore = defineStore('user', {
                 formData.append('userSignupReq', blob);
                 formData.append('profileImg',selectedProfileFile);
 
-                if(selectedProfileFile){
-                    formData.append('profileImg',selectedProfileFile);
-                }
-            
                 // 요청 보내기
                 const response = await axios.post("http://localhost:8080/user/signup", formData, {
                     headers: {
@@ -135,7 +132,31 @@ export const useUserStore = defineStore('user', {
                   console.error("이메일 중복 확인 중 오류 발생:", error);
                   this.alert("이메일 확인 중 문제가 발생했습니다. 다시 시도해주세요");
                 }
+            },
+            async verifyEmail(email, uuid) {
+                try {
+                    const response = await axios.get(`http://localhost:8080/email/verify`, {
+                        params: {
+                            email,
+                            uuid,
+                        },
+                    });
+            
+                    // 응답 코드와 성공 여부 확인
+                    if (response.data.code === 1000 && response.data.isSuccess) {
+                        this.isverified = true; // 인증 성공 상태로 변경
+                        alert('이메일 인증에 성공했습니다!');
+                    } else {
+                        alert(response.data.message || '이메일 인증에 실패했습니다.');
+                    }
+                } catch (error) {
+                    console.error('이메일 인증 중 오류 발생:', error);
+                    alert('이메일 인증에 실패했습니다.');
+                }
             }
+            
+            
+            
 
     },
 });


### PR DESCRIPTION
## 연관 이슈
close #


## 작업 내용
닉네임 중복 수정 
이메일 인증 페이지 생성, axios 연결
1. 이메일 인증 페이지 만들고 routing 설정
2. 해당 페이지에서 api 호출
3. 이메일에서 링크를 클릭하면 우리 페이지가 뜨고 뜨는 순간 api 호출되어서 email, uuid 날라가고
4. 백엔드에서 확인한 후 결과값을 응답으로 보냄
5. 프론트에서 응답이 성공
6. 로그인 버튼을 누르면 /login 경로로 이동

## 스크린샷 (선택)
<img width="770" alt="image" src="https://github.com/user-attachments/assets/8fd35077-fa7e-4be1-b85d-eff803cc2c45">
<img width="986" alt="image" src="https://github.com/user-attachments/assets/8f483ae8-f247-4447-8ed1-a658e7727232">



## 리뷰 요구사항 혹은 기타 (선택)
