### PR TITLE
[Feat] 위키 롤백 API (#31)

### DIFF
--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -120,5 +120,14 @@ public class WikiController {
         List<GetWikiVersionListRes> wikiVersionList = wikiService.versionList(getWikiVersionListReq);
         return new BaseResponse<>(wikiVersionList);
     }
+
+    // 위키 롤백
+    @PostMapping("/rollback")
+    public BaseResponse<WikiRollbackRes> rollback(@RequestBody WikiRollbackReq wikiRollbackReq,
+                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        return new BaseResponse<>(wikiService.rollback(wikiRollbackReq, customUserDetails.getUserId()));
+
+    }
 }
 

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiRollbackReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiRollbackReq.java
@@ -1,0 +1,12 @@
+package org.example.backend.Wiki.Model.Req;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WikiRollbackReq {
+
+    private Long wikiContentId;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiRollbackRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiRollbackRes.java
@@ -1,0 +1,11 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class WikiRollbackRes {
+
+    private Long id;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -207,7 +207,7 @@ public class WikiService {
                 .collect(Collectors.toList());
     }
 
-    // 위키 롤백 //해당 버전을 클릭하면 -> 해당 버전이 최신 버전으로 객체 생성 됨 -> 해당 버전이 latestWiki로 들어감
+    // 위키 롤백
     @Transactional
     public WikiRollbackRes rollback(WikiRollbackReq wikiRollbackReq, Long userId) {
 
@@ -223,8 +223,8 @@ public class WikiService {
         WikiContent rollbackWikiContent = WikiContent.builder()
                 .wiki(wiki)
                 .content(wikiContent.getContent())
-                .version(wikiContent.getVersion() + 1)
-                .user(wikiContent.getUser()) // 롤백한 사람이 아닌ㄴ 작성자가 나와야함
+                .version(latestWiki.getVersion()+1)
+                .user(wikiContent.getUser())
                 .thumbnail(wikiContent.getThumbnail())
                 .build();
         wikiContentRepository.save(rollbackWikiContent);

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -128,7 +128,7 @@ public class WikiService {
     @Transactional
     public GetWikiUpdateRes update(GetWikiUpdateReq getWikiUpdateReq, String thumbnailUrl, Long userId) {
 
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findById(userId).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_PERMISSION_DENIED));
 
         if (user.getGrade().equals("뉴비")) {
             throw new InvalidWikiException(BaseResponseStatus.WIKI_PERMISSION_DENIED);
@@ -205,6 +205,36 @@ public class WikiService {
                                 .totalPages(wikiVersionPage.getTotalPages())
                                 .build())
                 .collect(Collectors.toList());
+    }
+
+    // 위키 롤백 //해당 버전을 클릭하면 -> 해당 버전이 최신 버전으로 객체 생성 됨 -> 해당 버전이 latestWiki로 들어감
+    @Transactional
+    public WikiRollbackRes rollback(WikiRollbackReq wikiRollbackReq, Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_PERMISSION_DENIED));
+        if (user.getGrade().equals("뉴비")) {
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_PERMISSION_DENIED);
+        }
+
+        WikiContent wikiContent = wikiContentRepository.findById(wikiRollbackReq.getWikiContentId()).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
+        Wiki wiki = wikiContent.getWiki();
+        LatestWiki latestWiki = wiki.getLatestWiki();
+
+        WikiContent rollbackWikiContent = WikiContent.builder()
+                .wiki(wiki)
+                .content(wikiContent.getContent())
+                .version(wikiContent.getVersion() + 1)
+                .user(wikiContent.getUser()) // 롤백한 사람이 아닌ㄴ 작성자가 나와야함
+                .thumbnail(wikiContent.getThumbnail())
+                .build();
+        wikiContentRepository.save(rollbackWikiContent);
+
+        // LatestWiki 업데이트
+        latestWiki.updateContentAndVersion(rollbackWikiContent.getContent(), rollbackWikiContent.getVersion());
+        latestWiki.updateThumbnail(rollbackWikiContent.getThumbnail());
+        latestWikiRepository.save(latestWiki);
+
+        return WikiRollbackRes.builder().id(wiki.getId()).build();
     }
 }
 


### PR DESCRIPTION
## 연관 이슈
close #31 


## 작업 내용
📌 위키 롤백 기능
위키 이전버전 목록조회에서 원하는 버전을 선택하여 최신 버전으로 롤백 시킬 수 있다.

- 비로그인 유저, 뉴비 등급은 롤백 권한 제한
- 해당 버전의 위키는 최신 버전으로 갱신


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/60e69c41-81ba-408c-b2ab-4645be5d14a1)


## 리뷰 요구사항 혹은 기타 (선택)