### PR TITLE
[Feat] 위키 스크랩 API (#32)

### DIFF
--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -119,5 +119,12 @@ public class WikiController {
         List<GetWikiVersionListRes> wikiVersionList = wikiService.versionList(getWikiVersionListReq);
         return new BaseResponse<>(wikiVersionList);
     }
+
+    // 위키 스크랩
+    @PostMapping("/scrap")
+    public BaseResponse<WikiScrapRes> scrap(WikiScrapReq wikiScrapReq,
+                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return new BaseResponse<>(wikiService.scrap(wikiScrapReq, customUserDetails.getUserId()));
+    }
 }
 

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiScrapReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/WikiScrapReq.java
@@ -1,0 +1,11 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WikiScrapReq {
+
+    private Long wikiContentId;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiDetailRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/GetWikiDetailRes.java
@@ -14,5 +14,6 @@ public class GetWikiDetailRes {
     private Integer version;
     private Boolean checkScrap;
     private String userGrade;
+    private Long wikiContentId;
 
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiScrapRes.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Res/WikiScrapRes.java
@@ -1,0 +1,11 @@
+package org.example.backend.Wiki.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class WikiScrapRes {
+
+    private Long wikiContentId;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiService.java
@@ -12,6 +12,7 @@ import org.example.backend.User.Repository.UserRepository;
 import org.example.backend.Wiki.Model.Entity.LatestWiki;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.example.backend.Wiki.Model.Entity.WikiContent;
+import org.example.backend.Wiki.Model.Entity.WikiScrap;
 import org.example.backend.Wiki.Model.Req.*;
 import org.example.backend.Wiki.Model.Res.*;
 import org.example.backend.Wiki.Repository.LatestWikiRepository;
@@ -110,6 +111,7 @@ public class WikiService {
 
         Wiki wiki = wikiRepository.findById(id).orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
         LatestWiki latestWiki = wiki.getLatestWiki(); //최신 위키
+        WikiContent wikiContent = wikiContentRepository.findByWikiIdAndVersion(wiki.getId(), latestWiki.getVersion()).get();
 
         GetWikiDetailRes wikiDetailRes = GetWikiDetailRes.builder()
                 .id(wiki.getId())
@@ -119,6 +121,7 @@ public class WikiService {
                 .version(latestWiki.getVersion())
                 .checkScrap(ischeckScrap(wiki.getId(), latestWiki.getVersion(), userId))
                 .userGrade(userGrade)
+                .wikiContentId(wikiContent.getId())
                 .build();
         return wikiDetailRes;
 
@@ -205,6 +208,33 @@ public class WikiService {
                                 .totalPages(wikiVersionPage.getTotalPages())
                                 .build())
                 .collect(Collectors.toList());
+    }
+
+    // 위키 스크랩
+    @Transactional
+    public WikiScrapRes scrap(WikiScrapReq wikiScrapReq, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_LOGIN));
+
+        WikiContent wikiContent = wikiContentRepository.findById(wikiScrapReq.getWikiContentId())
+                .orElseThrow(() -> new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL));
+
+        Optional<WikiScrap> checkScrap = wikiScrapRepository.findByUserIdAndWikiContentId(userId, wikiContent.getId());
+
+        if(checkScrap.isPresent()){
+            wikiScrapRepository.delete(checkScrap.get());
+            return WikiScrapRes.builder().wikiContentId(wikiContent.getId()).build();
+
+        } else {
+            WikiScrap wikiScrap = WikiScrap.builder()
+                    .user(user)
+                    .wikiContent(wikiContent)
+                    .build();
+            wikiScrapRepository.save(wikiScrap);
+        }
+        return WikiScrapRes.builder().wikiContentId(wikiContent.getId()).build();
+
     }
 }
 


### PR DESCRIPTION
## 연관 이슈
close #32 


## 작업 내용
📌위키 스크랩 API 구현
- contentId로 스크랩 실행
- 재스크랩 시, 취소 처리 (DB에서 삭제)
- 첫 스크랩 시, Scrap DB에 contentId, userId 값 삽입 


## 스크린샷 (선택)
화면이 변경되었다면 어떻게 수정되었는지 사진을 첨부한다.


## 리뷰 요구사항 혹은 기타 (선택)
리뷰어들이 참고해야할 사항이나 집중적으로 봐줬으면 하는 사항을 작성한다.