### PR TITLE
[Feat] 위키 검색 API (#29)

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -42,6 +42,8 @@ public enum BaseResponseStatus {
     WIKI_CONTENT_DUPLICATION_FAIL(false, 5004,"중복되는 위키입니다."),
     WIKI_NOT_FOUND_DETAIL(false,5005,"위키 조회를 실패했습니다."),
     WIKI_PERMISSION_DENIED(false, 5006,"수정 권한이 없습니다."),
+    WIKI_SEARCH_EMPTY_REQUEST(false, 5007, "검색 요청이 비어 있습니다."),
+    WIKI_INVALID_SEARCH_TYPE(false, 5008, "존재하지 않은 타입의 검색 방식 입니다."),
 
     // 에러 아카이브 기능 - 6000
 

--- a/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -8,6 +8,7 @@ import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
 import org.example.backend.Wiki.Model.Req.*;
 import org.example.backend.Wiki.Model.Res.*;
+import org.example.backend.Wiki.Service.WikiSearchService;
 import org.example.backend.Wiki.Service.WikiService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +24,7 @@ import java.util.List;
 public class WikiController {
     private final WikiService wikiService;
     private final CloudFileUploadService cloudFileUploadService;
+    private final WikiSearchService wikiSearchService;
 
     // 위키 등록
     @PostMapping
@@ -134,6 +136,12 @@ public class WikiController {
 
         return new BaseResponse<>(wikiService.rollback(wikiRollbackReq, customUserDetails.getUserId()));
 
+    }
+
+    // 위키 검색
+    @GetMapping("/search")
+    public BaseResponse<List<WikiListRes>> search(GetWikiSearchReq getWikiSearchReq) {
+        return new BaseResponse<>(wikiSearchService.search(getWikiSearchReq));
     }
 }
 

--- a/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiSearchReq.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiSearchReq.java
@@ -1,0 +1,15 @@
+package org.example.backend.Wiki.Model.Req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetWikiSearchReq {
+
+    private Integer page; // 프론트에서 값을 지정해주지 않으면 자동으로 지정
+    private Integer size;
+    private String type = "tc"; // tc: 제목+내용 , t: 제목, c: 내용 으로 검색
+    private String keyword = ""; // keyword가 안들어오면 빈문자열로 처리됨(나중에 편함)
+    private Long categoryId;
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
@@ -1,10 +1,38 @@
 package org.example.backend.Wiki.Repository;
 
 import org.example.backend.Wiki.Model.Entity.Wiki;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface WikiRepository extends JpaRepository<Wiki, Long> {
+
     Optional<Wiki> findByTitle(String title);
+
+    Page<Wiki> findAllByCategoryId(Long categoryId, Pageable pageable); // 카테고리 검색
+
+    // keyword만 검색
+    Page<Wiki> findAllByTitleIsContainingIgnoreCase(String keyword, Pageable pageable); // t타입 검색
+
+    Page<Wiki> findAllByLatestWikiContentIsContainingIgnoreCase(String keyword, Pageable pageable); // c타입 검색
+
+    @Query("SELECT w FROM Wiki w " +
+            "JOIN w.latestWiki lw " +
+            "WHERE LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(lw.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Wiki> findAllByKeyword(String keyword, Pageable pageable); // tc타입 검색
+
+    // keyword + category 검색
+    Page<Wiki> findAllByTitleIsContainingIgnoreCaseAndCategoryId(String keyword, Long categoryId, Pageable pageable); // t타입
+
+    Page<Wiki> findAllByLatestWikiContentIsContainingIgnoreCaseAndCategoryId(String keyword, Long categoryId, Pageable pageable); // c타입
+
+    @Query("SELECT w FROM Wiki w " +
+            "JOIN w.latestWiki lw " +
+            "WHERE (LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(lw.content) LIKE LOWER(CONCAT('%', :keyword, '%')))" + "AND w.category.id = :categoryId")
+    Page<Wiki> findAllByKeywordAndCategory(String keyword, Long categoryId, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
@@ -1,0 +1,109 @@
+package org.example.backend.Wiki.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Category.Repository.CategoryRepository;
+import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Exception.custom.InvalidCategoryException;
+import org.example.backend.Exception.custom.InvalidWikiException;
+import org.example.backend.Wiki.Model.Entity.Wiki;
+import org.example.backend.Wiki.Model.Req.GetWikiSearchReq;
+import org.example.backend.Wiki.Model.Res.WikiListRes;
+import org.example.backend.Wiki.Repository.WikiRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Qualifier("WikiDbSearch")
+@RequiredArgsConstructor
+public class DbWikiSearchService implements WikiSearchService {
+    private final CategoryRepository categoryRepository;
+    private final WikiRepository wikiRepository;
+    private final static List<String> SEARCH_TYPE = List.of("tc", "t", "c");
+
+    @Override
+    public List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq) {
+        ValidateSearchReq(getWikiSearchReq);
+
+        if (getWikiSearchReq.getPage() == null) {
+            getWikiSearchReq.setPage(0);
+        }
+        if (getWikiSearchReq.getSize() == null || getWikiSearchReq.getSize() == 0) {
+            getWikiSearchReq.setSize(15);
+        }
+
+        Pageable pageable = PageRequest.of(getWikiSearchReq.getPage(), getWikiSearchReq.getSize(), Sort.by(Sort.Direction.DESC, "latestWiki.createdAt"));
+        Page<Wiki> wikiPage;
+
+        Long categoryId = getWikiSearchReq.getCategoryId();
+        String type = getWikiSearchReq.getType();
+        String keyword = getWikiSearchReq.getKeyword().toLowerCase().strip(); // 소문자로 변환, 문자열의 공백 삭제, keyword는 적어도 ''이므로 메서드에서 오류가 안남
+
+        if (categoryId == null || categoryId == 0) { // 검색어로만 검색
+            wikiPage = SearchByKeyword(getWikiSearchReq.getType(), keyword, pageable);
+        } else if (keyword.isEmpty()) { // 카테고리 id로만 검색
+            wikiPage = wikiRepository.findAllByCategoryId(categoryId, pageable);
+        } else {   //검색어 + 카테고리 검색
+            wikiPage = SearchByKeywordAndCategory(type,keyword,categoryId,pageable);
+    }
+        return getListWikiRes(wikiPage);
+}
+
+private void ValidateSearchReq(GetWikiSearchReq getWikiSearchReq) { // 유효성 확인 메서드
+String keyword = getWikiSearchReq.getKeyword().strip().toLowerCase();
+    if ((keyword.isEmpty()) // 검색어 && 카테고리 선택 X
+            && (getWikiSearchReq.getCategoryId() == null || getWikiSearchReq.getCategoryId() == 0)) {
+        throw new InvalidWikiException(BaseResponseStatus.WIKI_SEARCH_EMPTY_REQUEST);
+    }
+
+    if (!SEARCH_TYPE.contains(getWikiSearchReq.getType())) { // type이 유효하지 않으면
+        throw new InvalidWikiException(BaseResponseStatus.WIKI_INVALID_SEARCH_TYPE);
+    }
+
+    if (getWikiSearchReq.getCategoryId() != null && getWikiSearchReq.getCategoryId() != 0) { // 카테고리 ID가 유효하지 않으면
+        categoryRepository.findById(getWikiSearchReq.getCategoryId()).orElseThrow(() -> new InvalidCategoryException(BaseResponseStatus.CATEGORY_NOT_FOUND_CATEGORY));
+    }
+}
+
+private Page<Wiki> SearchByKeyword(String type, String keyword, Pageable pageable) { // 키워드로만 검색
+    if (type.equals("tc")) {
+        return wikiRepository.findAllByKeyword(keyword, pageable);
+    } else if (type.equals("t")) {
+        return wikiRepository.findAllByTitleIsContainingIgnoreCase(keyword, pageable);
+    }
+    return wikiRepository.findAllByLatestWikiContentIsContainingIgnoreCase(keyword, pageable);
+}
+
+private Page<Wiki> SearchByKeywordAndCategory(String type, String keyword, Long categoryId, Pageable pageable) { // 카테고리 + 키워드로 검색
+    if (type.equals("tc")) {
+        return wikiRepository.findAllByKeywordAndCategory(keyword, categoryId, pageable);
+    } else if (type.equals("t")) {
+        return wikiRepository.findAllByTitleIsContainingIgnoreCaseAndCategoryId(keyword, categoryId, pageable);
+    }
+    return wikiRepository.findAllByLatestWikiContentIsContainingIgnoreCaseAndCategoryId(keyword, categoryId, pageable);
+}
+
+private static List<WikiListRes> getListWikiRes(Page<Wiki> wikiPage) {
+    List<WikiListRes> wikiResList = new ArrayList<>();
+    for (Wiki wiki : wikiPage) {
+        wikiResList.add(WikiListRes.builder()
+                .id(wiki.getId())
+                .title(wiki.getTitle())
+                .category(wiki.getCategory().getCategoryName())
+                .content(wiki.getLatestWiki().getContent())
+                .thumbnail(wiki.getLatestWiki().getThumbnailImgUrl())
+                .createdAt(wiki.getLatestWiki().getCreatedAt())
+                .totalPages(wikiPage.getTotalPages())
+                .build());
+    }
+    return wikiResList;
+}
+
+
+}

--- a/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
@@ -43,7 +43,7 @@ public class DbWikiSearchService implements WikiSearchService {
 
         Long categoryId = getWikiSearchReq.getCategoryId();
         String type = getWikiSearchReq.getType();
-        String keyword = getWikiSearchReq.getKeyword().toLowerCase().strip(); // 소문자로 변환, 문자열의 공백 삭제, keyword는 적어도 ''이므로 메서드에서 오류가 안남
+        String keyword = getWikiSearchReq.getKeyword().toLowerCase().replaceAll("\\s", "");
 
         if (categoryId == null || categoryId == 0) { // 검색어로만 검색
             wikiPage = SearchByKeyword(getWikiSearchReq.getType(), keyword, pageable);
@@ -56,7 +56,7 @@ public class DbWikiSearchService implements WikiSearchService {
 }
 
 private void ValidateSearchReq(GetWikiSearchReq getWikiSearchReq) { // 유효성 확인 메서드
-String keyword = getWikiSearchReq.getKeyword().strip().toLowerCase();
+    String keyword = getWikiSearchReq.getKeyword().toLowerCase().replaceAll("\\s", "");
     if ((keyword.isEmpty()) // 검색어 && 카테고리 선택 X
             && (getWikiSearchReq.getCategoryId() == null || getWikiSearchReq.getCategoryId() == 0)) {
         throw new InvalidWikiException(BaseResponseStatus.WIKI_SEARCH_EMPTY_REQUEST);

--- a/backend/src/main/java/org/example/backend/Wiki/Service/WikiSearchService.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Service/WikiSearchService.java
@@ -1,0 +1,10 @@
+package org.example.backend.Wiki.Service;
+
+import org.example.backend.Wiki.Model.Req.GetWikiSearchReq;
+import org.example.backend.Wiki.Model.Res.WikiListRes;
+
+import java.util.List;
+
+public interface WikiSearchService {
+   List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq);
+}


### PR DESCRIPTION
## 연관 이슈
close #29 


## 작업 내용
📌 위키 검색 API 구현

유저는 제목/내용/ 제목+내용/ 검색 타입을 선택할 수 있다.
유저는 검색어/ 카테고리/ 검색어+카테고리 조건으로 선택하여 검색할 수있다.
- 검색어 공백 삭제, 소문자 변환 처리
- 유효성 확인 메서드 추가하여 type이 유효하지않거나, 검색 조건이 모두 null이면 예외처리
- 카테고리id는 wiki 테이블, 컨텐츠는 latestWiki 테이블에서 가져옴

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4f8c99a4-f77f-446a-9555-ba3957d0db28)



## 리뷰 요구사항 혹은 기타 (선택)
