### PR TITLE
[Fix] FRONT_URL 상수에 static 삭제

### DIFF
--- a/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
+++ b/backend/src/main/java/org/example/backend/EmailVerify/Service/EmailVerifyService.java
@@ -23,7 +23,7 @@ public class EmailVerifyService {
     private final UserService userService;
 
     @Value("${frontend.url}")
-    private static String FRONT_URL;
+    private String FRONT_URL;
 
     public void sendEmail(String email) {
         String uuid = UUID.randomUUID().toString();


### PR DESCRIPTION
## 연관 이슈


## 작업 내용
- FRONT_URL 에 static이 설정되어있었는데 @Value 어노테이션을 쓸라면 static이 붙으면 안돼서 제거해줬다.

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
