### PR TITLE
[Fix] 회원가입 닉네임 중복 api 연결

### DIFF
--- a/frontend/src/components/user/SignUpComponent.vue
+++ b/frontend/src/components/user/SignUpComponent.vue
@@ -25,8 +25,8 @@
 
       <p class="explanation">닉네임</p>
       <div class="half-form">
-        <input type="text" placeholder="닉네임" v-model="userInfo.nickname" />
-        <button type="button" class="check-button" @click="validateNickname">중복 확인</button>
+        <input type="text" placeholder="닉네임" v-model="userInfo.nickname" @input="validateNickname"/>
+        <button type="button" class="check-button" @click="checkNickname">중복 확인</button>
         <span v-if="nicknameAvailable">✔️ 사용 가능합니다</span>
         <span v-else></span>
       </div>

--- a/frontend/src/store/useUserStore.js
+++ b/frontend/src/store/useUserStore.js
@@ -105,6 +105,7 @@ export const useUserStore = defineStore('user', {
               } else {
                 alert("중복되지 않는 닉네임입니다.");
               }
+              return response.data.result;
             } catch (error) {
               console.error("닉네임 중복 확인 중 오류 발생:", error);
               alert("닉네임 확인 중 문제가 발생했습니다. 다시 시도해주세요");
@@ -114,14 +115,13 @@ export const useUserStore = defineStore('user', {
             // 서버에 이메일 중복 여부 확인 요청
             const response = await axios.get(backend + "/user/duplicate/email", {params: {email: email}}
             );
-            console.log(response);  // 응답 데이터 확인
-
             // 서버로부터 받은 응답에 따라 처리
             if (response.data.result === true) {
                 alert("사용 가능한 이메일입니다.");
             } else {
                 alert("중복되는 이메일입니다.");
             }
+            return response.data.result;
         },
         async verifyEmail(email, uuid) {
             try {

--- a/frontend/src/store/useWikiStore.js
+++ b/frontend/src/store/useWikiStore.js
@@ -120,7 +120,7 @@ export const useWikiStore = defineStore("wiki", {
         // 위키 상세 조회
         async fetchWikiDetail(id) {
             try {
-                const response = await axios.get(backend + "wiki/detail", {
+                const response = await axios.get(backend + "/wiki/detail", {
                     params: { id },
                     withCredentials: true,
                 });


### PR DESCRIPTION
## 연관 이슈


## 작업 내용
- 위키 디테일 api에 / 안붙어서 생기는 오류 해결
- 닉네임 중복 확인 버튼 눌렀을 때 api호출하도록 수정


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
