### PR TITLE
[Fix] 제목이 길어져도 카드의 크기는 고정되게 수정

### DIFF
--- a/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveCardComponent.vue
@@ -72,6 +72,8 @@ export default {
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-height: 200px; /* 원하는 최대 높이 설정 */
+  overflow: hidden; /* 내용이 넘치면 숨김 */
   background: #fff;
   box-shadow: 5px 5px 7px 0 rgba(0, 0, 0, 0.08);
   transition: box-shadow .25s ease-in, transform .25s ease-in;
@@ -135,6 +137,9 @@ export default {
   line-height: 1.5;
   word-break: break-word;
   color: #212529;
+  overflow: hidden; /* 내용이 넘치면 숨김 */
+  text-overflow: ellipsis; /* 생략 부호 추가 */
+  white-space: nowrap; /* 한 줄로 표시 */
 }
 
 .PostCard_footer__9J5Wd {


### PR DESCRIPTION
## 연관 이슈
close #이슈번호


## 작업 내용
제목이 길어져도 카드의 크기는 고정되게 수정
제목의 길이가 넘치면 숨김

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b516df59-3e6a-439d-ba8c-6ccce4aa1c52)


## 리뷰 요구사항 혹은 기타 (선택)
