### PR TITLE
[Refactor] 에러 아카이브 등록 userId를 직접 가지고오지 않고 시큐리티 이용(#359)

### DIFF
--- a/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
@@ -11,7 +11,10 @@ import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,8 +38,10 @@ public class ErrorArchiveController {
     // 아카이브 등록
     @PostMapping()
     public BaseResponse<RegisterErrorArchiveRes> register(
-            @RequestBody RegisterErrorArchiveReq registerErrorArchiveReq,
-            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+            @RequestBody RegisterErrorArchiveReq registerErrorArchiveReq) {
+        // spring security에서 인증된 사용자 정보 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         RegisterErrorArchiveRes registerErrorArchiveRes = errorArchiveService.register(registerErrorArchiveReq, customUserDetails);
         return new BaseResponse<>(registerErrorArchiveRes);
 

--- a/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorArchiveReository.java
+++ b/backend/src/main/java/org/example/backend/ErrorArchive/Repository/ErrorArchiveReository.java
@@ -44,5 +44,9 @@ public interface ErrorArchiveReository extends JpaRepository<ErrorArchive, Long>
 
     Page<ErrorArchive> findByErrorScrapListUserIdAndEnableTrue(Long id, Pageable pageable);
 
+    @Query("SELECT ea FROM ErrorArchive ea JOIN FETCH ea.user u JOIN FETCH ea.category c WHERE ea.id = :id")
+    Optional<ErrorArchive> findByIdWithUserAndCategory(@Param("id") Long id);
+
+
 
 }


### PR DESCRIPTION
## 연관 이슈
close #359 


## 작업 내용
userId를 직접 가져오지 않고 스프링 시큐리티에서 제공하는 Authentication 객체를 사용하여 인증된 사용자 정보를 가져오기
@AuthenticationPrincipal을 사용하여 CustomUserDetails를 바로 주입하는 방식이 아닌, SecurityContextHolder를 이용하여
Authentication 객체를 통해 접근하기


## 스크린샷 (선택)
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/a6d26d75-241f-4b80-95d1-e78827a2cc58">



## 리뷰 요구사항 혹은 기타 (선택)