### PR TITLE
[Fix] Dockerfile에 icon 주석처리

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ ADD ./nginx.conf /etc/nginx/nginx.conf
 ADD ./dist/css /usr/share/nginx/html/css
 ADD ./dist/js /usr/share/nginx/html/js
 ADD ./dist/img /usr/share/nginx/html/img
-ADD ./dist/icon /usr/share/nginx/html/icon
+#ADD ./dist/icon /usr/share/nginx/html/icon
 RUN rm -rf /usr/share/nginx/html/index.html
 ADD ./dist/index.html /usr/share/nginx/html/index.html
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## 연관 이슈
close #이슈번호


## 작업 내용
- dockerfile에 icon이 dist/icon 파일이 없어 오류나던 현상 해결
  - icon부분 주석처리


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
