### PR TITLE
[Fix] qna에 비로그인 사용자의 접근 권한 범위 지정 및 좋아요 및 스크랩 조회 메커니즘 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -71,6 +71,7 @@ public enum BaseResponseStatus {
     QNA_INVALID_QUESTION_FORMAT(false, 7102, "잘못된 형식의 질문입니다."),
     QNA_ALREADY_ADOPTED(false, 7103, "해당 질문은 이미 채택된 답변이 존재합니다."),
     QNA_ANSWERED_EDIT(false, 7104, "답변이 작성된 질문글은 수정할 수 없습니다."),
+    QNA_NOT_QUESTIONER(false, 7105, "질문자가 아닌 사람은 답변을 채택할 수 없습니다.."),
     // - QnA 답변 에러
     QNA_ANSWER_NOT_FOUND(false, 7201, "해당 답변이 존재하지 않습니다."),
     QNA_INVALID_ANSWER_FORMAT(false, 7202, "잘못된 형식의 답변입니다."),

--- a/backend/src/main/java/org/example/backend/Qna/Controller/AnswerController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/AnswerController.java
@@ -3,6 +3,8 @@ package org.example.backend.Qna.Controller;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Qna.Service.QnaService;
+import org.example.backend.Qna.model.Res.GetAnswerStateRes;
+import org.example.backend.Qna.model.Res.GetQuestionStateRes;
 import org.example.backend.Qna.model.req.*;
 import org.example.backend.Security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -48,6 +50,12 @@ public class AnswerController {
 
         Long id = qnaService.checkAnswerHate(qnaBoardId, answerId, customUserDetails.getUserId());
         return new BaseResponse<>(id);
+    }
+
+    @GetMapping("/state")
+    public BaseResponse<GetAnswerStateRes> getAnswerState(Long answerId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        GetAnswerStateRes ansStateRes = qnaService.getAnswerState(answerId, customUserDetails.getUserId());
+        return new BaseResponse<>(ansStateRes);
     }
 
     //qna 답변 채택

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -6,6 +6,7 @@ import org.example.backend.Qna.Service.BasicQnaSearchService;
 import org.example.backend.Qna.Service.QnaService;
 import org.example.backend.Qna.model.Res.GetQnaListRes;
 import org.example.backend.Qna.model.Res.GetQuestionDetailRes;
+import org.example.backend.Qna.model.Res.GetQuestionStateRes;
 import org.example.backend.Qna.model.req.CreateQuestionReq;
 import org.example.backend.Qna.model.req.EditQuestionReq;
 import org.example.backend.Qna.model.req.GetQnaListReq;
@@ -42,10 +43,10 @@ public class QuestionController {
 
     //qna 상세 조회
     @GetMapping("/detail")
-    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId, @AuthenticationPrincipal Optional<CustomUserDetails> customUserDetails) {
+    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long userId;
         if (customUserDetails != null) {
-            userId = customUserDetails.get().getUserId();
+            userId = customUserDetails.getUserId();
         }
         else {
             userId = null;
@@ -74,6 +75,12 @@ public class QuestionController {
     public BaseResponse<Long> checkScrap(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long id = qnaService.checkQnaScrap(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
         return new BaseResponse<>(id);
+    }
+
+    @GetMapping("/state")
+    public BaseResponse<GetQuestionStateRes> getQuestionState(Long qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        GetQuestionStateRes qnaStateRes = qnaService.getQuestionState(qnaBoardId, customUserDetails.getUserId());
+        return new BaseResponse<>(qnaStateRes);
     }
 
     //qna 검색

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,10 +42,17 @@ public class QuestionController {
 
     //qna 상세 조회
     @GetMapping("/detail")
-    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        GetQuestionDetailRes questionDetailRes = qnaService.getQuestionDetail(qnaBoardId, customUserDetails.getUserId());
-        return new BaseResponse<>(questionDetailRes);
+    public BaseResponse<GetQuestionDetailRes> getQnaDetail(Integer qnaBoardId, @AuthenticationPrincipal Optional<CustomUserDetails> customUserDetails) {
+        Long userId;
+        if (customUserDetails != null) {
+            userId = customUserDetails.get().getUserId();
+        }
+        else {
+            userId = null;
+        }
+        GetQuestionDetailRes questionDetailRes = qnaService.getQuestionDetail(qnaBoardId, userId);
 
+        return new BaseResponse<>(questionDetailRes);
     }
 
     //qna 질문 좋아요

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -393,6 +393,10 @@ public class QnaService {
         Answer answer = answerRepository.findByIdAndEnableTrue(answerId)
                 .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_ANSWER_NOT_FOUND));
 
+        if (user != qnaBoard.getUser()){
+            throw new InvalidQnaException(BaseResponseStatus.QNA_NOT_QUESTIONER);
+        }
+
         if (answerRepository.countAdopted(qnaBoardId).equals(0)) {
             answer.adoptedAnswer(true);
             return answer.getId();
@@ -436,7 +440,11 @@ public class QnaService {
         QnaBoard qnaBoard = questionRepository.findByIdAndEnableTrue(editQuestionReq.getId())
                 .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND));
         User user = userRepository.findById(userId).orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
-        //후에 권한 처리
+
+        if (user != qnaBoard.getUser()){
+            throw new InvalidQnaException(BaseResponseStatus.QNA_NO_EDIT_PERMISSION);
+        }
+
         if(qnaBoard.getAnswerList().isEmpty()){
             qnaBoard.updateTitle(editQuestionReq.getTitle());
             qnaBoard.updateContent(editQuestionReq.getContent());
@@ -456,7 +464,10 @@ public class QnaService {
                 .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_ANSWER_NOT_FOUND));
 
         User user = userRepository.findById(userId).orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
-        //후에 권한 처리
+
+        if (user != answer.getUser()){
+            throw new InvalidQnaException(BaseResponseStatus.QNA_NO_EDIT_PERMISSION);
+        }
 
         if(!answer.isAdopted()) {
             answer.updateContent(editAnswerReq.getContent());
@@ -474,7 +485,10 @@ public class QnaService {
                 .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND));
 
         User user = userRepository.findById(userId).orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
-        //후에 권한 처리
+
+        if (user != qnaBoard.getUser()){
+            throw new InvalidQnaException(BaseResponseStatus.QNA_NO_EDIT_PERMISSION);
+        }
 
         qnaBoard.disable();
         questionRepository.save(qnaBoard);
@@ -489,7 +503,10 @@ public class QnaService {
                 .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_ANSWER_NOT_FOUND));
 
         User user = userRepository.findById(userId).orElseThrow(() -> new InvalidUserException(BaseResponseStatus.USER_NOT_FOUND));
-        //후에 권한 처리
+
+        if (user != answer.getUser()){
+            throw new InvalidQnaException(BaseResponseStatus.QNA_NO_EDIT_PERMISSION);
+        }
 
         qnaBoard.decreaseAnswerCount();
         questionRepository.save(qnaBoard);

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -88,8 +88,14 @@ public class QnaService {
     }
 
     public GetQuestionDetailRes getQuestionDetail(Integer qnaBoardId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.USER_NOT_FOUND));
+        User user;
+        if (userId != null){
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.USER_NOT_FOUND));
+        }
+        else {
+            user = null;
+        }
         QnaBoard qnaBoard = questionRepository.findByIdAndEnableTrue(qnaBoardId.longValue())
                 .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND));
 
@@ -332,16 +338,25 @@ public class QnaService {
     // 현재 접속한 사용자의 좋아요/싫어요/선택 X 상태를 알아내는 함수
     //userID-qnaBoardId를 활용해서 해당 사용자가 답변글에 어떤 상태를 표시했는지 나타내는 함수
     public Boolean isQuestionLikeORHate(QnaBoard qnaBoard, User user) {
+        if (user == null){
+            return null;
+        }
         Optional<Boolean> state = qnaLikeRepository.findState(qnaBoard.getId(), user.getId());
         return state.orElse(null);
     }
     // userID-qnaBoardId를 활용해서 해당 사용자가 답변글에 어떤 상태를 표시했는지 나타내는 함수
     public Boolean isAnswerLikeORHate(Answer answer, User user) {
+        if (user == null){
+            return null;
+        }
         Optional<Boolean> state = answerLikeRepository.findState(answer.getId(), user.getId());
         return state.orElse(null);
     }
     // 현재 접속한 사용자의 질문에 대한 스크랩 상태를 알아내는 함수
-    private boolean isQuestionScarp(QnaBoard qnaBoard, User user) {
+    private Boolean isQuestionScarp(QnaBoard qnaBoard, User user) {
+        if (user == null){
+            return null;
+        }
         Optional<QnaScrap> qnaScrap = qnaScrapRepository.findByQnaBoardEnableTrueAndQnaBoardIdAndUserId(qnaBoard.getId(), user.getId());
         if (qnaScrap.isPresent()) {
             return true;

--- a/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -9,10 +9,7 @@ import org.example.backend.Exception.custom.InvalidQnaException;
 import org.example.backend.Exception.custom.InvalidUserException;
 import org.example.backend.Qna.Repository.*;
 import org.example.backend.Qna.model.Entity.*;
-import org.example.backend.Qna.model.Res.GetAnswerCommentDetailListRes;
-import org.example.backend.Qna.model.Res.GetAnswerDetailListRes;
-import org.example.backend.Qna.model.Res.GetQnaListRes;
-import org.example.backend.Qna.model.Res.GetQuestionDetailRes;
+import org.example.backend.Qna.model.Res.*;
 import org.example.backend.Qna.model.req.*;
 import org.example.backend.User.Model.Entity.User;
 import org.example.backend.User.Repository.UserRepository;
@@ -157,6 +154,49 @@ public class QnaService {
                         .createdAt(answerComment.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public GetQuestionStateRes getQuestionState(Long qnaBoardId, Long userId) {
+        User user;
+        if (userId != null) {
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.USER_NOT_FOUND));
+        } else {
+            user = null;
+        }
+        QnaBoard qnaBoard = questionRepository.findByIdAndEnableTrue(qnaBoardId.longValue())
+                .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND));
+
+        return GetQuestionStateRes.builder()
+                .id(qnaBoard.getId())
+                .userId(qnaBoard.getUser().getId())
+                .likeCnt(qnaBoard.getLikeCount())
+                .hateCnt(qnaBoard.getHateCount())
+                .checkLikeOrHate(isQuestionLikeORHate(qnaBoard, user))
+                .checkScrap(isQuestionScarp(qnaBoard, user))
+                .build();
+    }
+
+    public GetAnswerStateRes getAnswerState(Long answerId, Long userId) {
+        User user;
+        if (userId != null) {
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.USER_NOT_FOUND));
+        } else {
+            user = null;
+        }
+       Answer answer = answerRepository.findByIdAndEnableTrue(answerId)
+                .orElseThrow(() -> new InvalidQnaException(BaseResponseStatus.QNA_QUESTION_NOT_FOUND));
+
+        System.out.print(isAnswerLikeORHate(answer, user));
+
+        return GetAnswerStateRes.builder()
+                .id(answer.getId())
+                .userId(answer.getUser().getId())
+                .likeCnt(answer.getLikeCount())
+                .hateCnt(answer.getHateCount())
+                .checkLikeOrHate(isAnswerLikeORHate(answer, user))
+                .build();
     }
 
     @Transactional

--- a/backend/src/main/java/org/example/backend/Qna/model/Res/GetAnswerStateRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Res/GetAnswerStateRes.java
@@ -1,0 +1,18 @@
+package org.example.backend.Qna.model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetAnswerStateRes {
+    private Long id;
+    private Long userId;
+    private Integer likeCnt;
+    private Integer hateCnt;
+    private Boolean checkLikeOrHate;
+    private Boolean checkAdopted;
+}

--- a/backend/src/main/java/org/example/backend/Qna/model/Res/GetQuestionStateRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Res/GetQuestionStateRes.java
@@ -1,0 +1,18 @@
+package org.example.backend.Qna.model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetQuestionStateRes {
+    private Long id;
+    private Long userId;
+    private Integer likeCnt;
+    private Integer hateCnt;
+    private Boolean checkLikeOrHate;
+    private Boolean checkScrap;
+}


### PR DESCRIPTION
## 연관 이슈
close #215 


## 작업 내용
비 로그인 사용 자의 접근 권한 부여 (채택, 등록, 좋아요 scrap 제외 단순 조회 기능)
질문 및 답변의 좋아요 및 싫어요와 그 수 및 질문의 스크랩 여부를 조회하는 api 구현




## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)