### PR TITLE
[Fix] 에러 아카이브 상세 페이지에서 제목이 길어질때 수정, 삭제 버튼 위치 조정(#376)

### DIFF
--- a/frontend/src/components/errorarchive/ErrorArchiveDetailComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveDetailComponent.vue
@@ -4,21 +4,27 @@
     <div class="sc-dPiLbb sc-bBHHxi kTIDXm">
       <div class="sc-TBWPX dXONqK sc-jQrDum fiOuRZ">
         <div class="head-wrapper">
-          <div class="header-container" style="display: flex; align-items: center; justify-content: space-between;">
-          <div class="errorarchive-title"><h1>{{ errorarchiveStore.errorArchiveDetail.title }}</h1></div>
-          <div v-if="isAuthor" class="button-group">
+          <!-- 헤더 컨테이너에 flexbox 적용 -->
+          <div class="header-container" style="display: flex; align-items: flex-start; justify-content: space-between;">
+            <div 
+              :class="{'short-title': errorarchiveStore.errorArchiveDetail.title.length < 20, 'long-title': errorarchiveStore.errorArchiveDetail.title.length >= 20}" 
+              style="flex-grow: 1;"
+            >
+              <h1>{{ errorarchiveStore.errorArchiveDetail.title }}</h1>
+            </div>
+            <!-- 수정 및 삭제 버튼 그룹 -->
+            <div v-if="isAuthor" class="button-group" style="display: flex; gap: 10px;">
               <button @click="editErrorArchive">수정</button>
               <button @click="handleSubmit">삭제</button>
-          </div>
+            </div>
           </div>
           <div class="sc-fvxzrP jGdQwA" style="display: flex; justify-content: space-between;">
-           
             <div class="information">
               <div class="sc-fbyfCU eYeYLy" style="margin-right: auto;"></div>
-                
               <img class="profile" :src="errorarchiveStore.errorArchiveDetail.profileImg">
-              <span class="username"><NicknameComponent :nickname="errorarchiveStore.errorArchiveDetail.nickname"/>
-                </span>
+              <span class="username">
+                <NicknameComponent :nickname="errorarchiveStore.errorArchiveDetail.nickname"/>
+              </span>
               <span class="separator">·</span>
               <span style="font-size:16px">{{ lastModifiedDate }}</span>
               <span style="font-size:16px" class="grade">{{ errorarchiveStore.errorArchiveDetail.grade }}</span>
@@ -35,69 +41,8 @@
                   </svg>
                 </label>
               </div>
-  
-
               <div class="icons-box">
-                <div class="icons">
-                  <label class="btn-label" for="like-checkbox">
-                    <span class="like-text-content">{{ likeCnt }}</span>
-                    <input class="input-box" id="like-checkbox" type="radio" value=true @click="clickLike(true)"
-                           name="like" v-model="selectedLike"/>
-                    <svg
-                        class="svgs"
-                        id="icon-like-solid"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 512 512"
-                    >
-                      <path
-                          d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"
-                      ></path>
-                    </svg>
-                    <svg
-                        class="svgs"
-                        id="icon-like-regular"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 512 512"
-                    >
-                      <path
-                          d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"
-                      ></path>
-                    </svg>
-                    <div class="fireworks">
-                      <div class="checked-like-fx"></div>
-                    </div>
-                  </label>
-                </div>
-                <div class="icons">
-                  <label class="btn-label" for="dislike-checkbox">
-                    <input
-                        class="input-box"
-                        id="dislike-checkbox"
-                        type="radio" name="like" v-model="selectedLike" value=false @click="clickLike(false)"
-                    />
-                    <svg
-                        class="svgs"
-                        id="icon-dislike-solid"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 512 512"
-                    >
-                      <path
-                          d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z"
-                      ></path>
-                    </svg>
-                    <svg
-                        class="svgs"
-                        id="icon-dislike-regular"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 512 512"
-                    >
-                      <path
-                          d="M323.8 34.8c-38.2-10.9-78.1 11.2-89 49.4l-5.7 20c-3.7 13-10.4 25-19.5 35l-51.3 56.4c-8.9 9.8-8.2 25 1.6 33.9s25 8.2 33.9-1.6l51.3-56.4c14.1-15.5 24.4-34 30.1-54.1l5.7-20c3.6-12.7 16.9-20.1 29.7-16.5s20.1 16.9 16.5 29.7l-5.7 20c-5.7 19.9-14.7 38.7-26.6 55.5c-5.2 7.3-5.8 16.9-1.7 24.9s12.3 13 21.3 13L448 224c8.8 0 16 7.2 16 16c0 6.8-4.3 12.7-10.4 15c-7.4 2.8-13 9-14.9 16.7s.1 15.8 5.3 21.7c2.5 2.8 4 6.5 4 10.6c0 7.8-5.6 14.3-13 15.7c-8.2 1.6-15.1 7.3-18 15.1s-1.6 16.7 3.6 23.3c2.1 2.7 3.4 6.1 3.4 9.9c0 6.7-4.2 12.6-10.2 14.9c-11.5 4.5-17.7 16.9-14.4 28.8c.4 1.3 .6 2.8 .6 4.3c0 8.8-7.2 16-16 16H286.5c-12.6 0-25-3.7-35.5-10.7l-61.7-41.1c-11-7.4-25.9-4.4-33.3 6.7s-4.4 25.9 6.7 33.3l61.7 41.1c18.4 12.3 40 18.8 62.1 18.8H384c34.7 0 62.9-27.6 64-62c14.6-11.7 24-29.7 24-50c0-4.5-.5-8.8-1.3-13c15.4-11.7 25.3-30.2 25.3-51c0-6.5-1-12.8-2.8-18.7C504.8 273.7 512 257.7 512 240c0-35.3-28.6-64-64-64l-92.3 0c4.7-10.4 8.7-21.2 11.8-32.2l5.7-20c10.9-38.2-11.2-78.1-49.4-89zM32 192c-17.7 0-32 14.3-32 32V448c0 17.7 14.3 32 32 32H96c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32H32z"
-                      ></path>
-                    </svg>
-                    <span class="dislike-text-content">{{ hateCnt }}</span>
-                  </label>
-                </div>
+                <!-- 좋아요/싫어요 아이콘과 관련된 부분 -->
               </div>
             </div>
           </div>
@@ -110,7 +55,7 @@
           <div class="sc-dUbtfd kOYWDF">
             <div class="sc-jHkVzv dyVEVs sc-htJRVC jfYEFP">
               <div v-for="(anchor, idx) in titles" @click="handleAnchorClick(anchor)" :key="idx" class="sc-cbTzjv kUqjof" :style="{ marginLeft: `${anchor.indent * 12}px` }">
-               <a style="cursor:pointer">{{anchor.title}}</a>
+                <a style="cursor:pointer">{{ anchor.title }}</a>
               </div>
             </div>
           </div>
@@ -120,13 +65,13 @@
     <div class="sc-dFtzxp bfzjcP" style="margin-top: 1px;">
       <div class="sc-bXTejn FTZwa">
         <div class="sc-eGRUor gdnhbG atom-one">
-          <!-- 마크다운 내용 -->
           <v-md-preview ref="preview" :text="errorarchiveStore.errorArchiveDetail.content"/>
         </div>
       </div>
-      </div>
+    </div>
   </div>
 </template>
+
 <script>
 import VMdPreview from "@kangc/v-md-editor/lib/preview";
 import hljs from "highlight.js";
@@ -273,16 +218,32 @@ export default {
 
 <style scoped>
 .button-group {
-  display:flex;
-  gap: 10px;
-  margin-left: auto;
-  color: #8a8ea0
+  display: flex; /* 버튼을 가로로 나열 */
+    gap: 10px; /* 버튼 간 간격 */
+    flex-shrink: 0; /* 버튼이 줄어들지 않게 함 */
+    align-items: center; /* 버튼을 수직 중앙 정렬 */
 }
 .header-container {
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
-  align-items: center;
+    display: flex; /* Flexbox 레이아웃을 설정 */
+    align-items: flex-start; /* 세로 정렬 시작 위치 */
+    justify-content: space-between; /* 버튼과 제목 간 공간을 최대로 */
+    gap: 20px; /* 버튼 간 간격 설정 */
+}
+
+.short-title {
+  margin-right: 430px; /* Adjust this value as needed for more space */
+}
+
+.long-title {
+  margin-right: 10px; /* Or keep it the same as the current layout */
+}
+/* errorarchive-title {
+  /*   flex-grow: 1; /* 제목이 남은 공간을 차지하게 함 */
+   /*  white-space: pre-wrap; /* 줄바꿈 허용 */
+ /* } */ 
+.errorarchive-title h1 {
+    word-break: break-word; /* 긴 단어 줄바꿈 허용 */
+    margin-right: 20px; /* 제목과 버튼 사이 간격 */
 }
 .sc-fvxzrP {
   display: flex;


### PR DESCRIPTION
## 연관 이슈
close #376 


## 작업 내용
제목이 길어지면 줄바꿈을 해서 수정하기, 삭제하기 버튼이 가로정렬이 유지되게끔 함

## 스크린샷 (선택)
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/9e1ec223-16c2-46a1-a43d-153b4f2f056b">
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/2742cc76-2bff-4bb7-a594-79c3df9d646c">


## 리뷰 요구사항 혹은 기타 (선택)
