### PR TITLE
[Refactor] 위키 검색 n+1 문제해결 (#378)

### DIFF
--- a/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
+++ b/backend/src/main/java/org/example/backend/Wiki/Repository/WikiRepository.java
@@ -3,6 +3,7 @@ package org.example.backend.Wiki.Repository;
 import org.example.backend.Wiki.Model.Entity.Wiki;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -23,6 +24,7 @@ public interface WikiRepository extends JpaRepository<Wiki, Long> {
             "JOIN w.latestWiki lw " +
             "WHERE LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(lw.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    @EntityGraph(attributePaths = {"latestWiki", "category"})
     Page<Wiki> findAllByKeyword(String keyword, Pageable pageable); // tc타입 검색
 
     // keyword + category 검색

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -57,6 +57,10 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+    org.springframework.security:
+    org.apache.kafka: OFF
+    kafka: OFF
+    org.springframework.kafka: OFF
 
 cloud:
   aws:


### PR DESCRIPTION
## 연관 이슈
close #378 

## 작업 내용
📌위키 검색 n+1 문제 해결
- 기존 : 결과 3개, 총 쿼리 5개
=> @EntityGraph 적용 후, 쿼리 1개


해결 전<details>
<summery></summery>

```
select
        w1_0.id,
        w1_0.category_id,
        w1_0.latest_wiki_id,
        w1_0.title 
    from
        wiki w1_0 
    join
        latest_wiki lw1_0 
            on lw1_0.id=w1_0.latest_wiki_id 
    where
        lower(w1_0.title) like replace(lower(concat('%', ?, '%')), '\\', '\\\\') 
        or lower(lw1_0.content) like replace(lower(concat('%', ?, '%')), '\\', '\\\\') 
    order by
        lw1_0.created_at desc 
    limit
        ?
2024-09-30T16:01:55.765+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:VARCHAR) <- [역사]
2024-09-30T16:01:55.768+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (2:VARCHAR) <- [역사]
2024-09-30T16:01:55.770+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (3:INTEGER) <- [15]
2024-09-30T16:01:55.870+09:00 DEBUG 16016 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    select
        c1_0.id,
        c1_0.category_name,
        sc1_0.id,
        sc1_0.category_name,
        sc1_0.super_category_id 
    from
        category c1_0 
    left join
        category sc1_0 
            on sc1_0.id=c1_0.super_category_id 
    where
        c1_0.id=?
2024-09-30T16:01:55.871+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [1]
2024-09-30T16:01:55.893+09:00 DEBUG 16016 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    select
        lw1_0.id,
        lw1_0.content,
        lw1_0.created_at,
        lw1_0.thumbnail_img_url,
        lw1_0.version 
    from
        latest_wiki lw1_0 
    where
        lw1_0.id=?
2024-09-30T16:01:55.893+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [16]
2024-09-30T16:01:55.945+09:00 DEBUG 16016 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    select
        lw1_0.id,
        lw1_0.content,
        lw1_0.created_at,
        lw1_0.thumbnail_img_url,
        lw1_0.version 
    from
        latest_wiki lw1_0 
    where
        lw1_0.id=?
2024-09-30T16:01:55.946+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [15]
2024-09-30T16:01:56.044+09:00 DEBUG 16016 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    select
        c1_0.id,
        c1_0.category_name,
        sc1_0.id,
        sc1_0.category_name,
        sc1_0.super_category_id 
    from
        category c1_0 
    left join
        category sc1_0 
            on sc1_0.id=c1_0.super_category_id 
    where
        c1_0.id=?
2024-09-30T16:01:56.044+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [2]
2024-09-30T16:01:56.080+09:00 DEBUG 16016 --- [nio-8080-exec-2] org.hibernate.SQL                        : 
    select
        lw1_0.id,
        lw1_0.content,
        lw1_0.created_at,
        lw1_0.thumbnail_img_url,
        lw1_0.version 
    from
        latest_wiki lw1_0 
    where
        lw1_0.id=?
2024-09-30T16:01:56.081+09:00 TRACE 16016 --- [nio-8080-exec-2] org.hibernate.orm.jdbc.bind              : binding parameter (1:BIGINT) <- [14]


```
</details>


해결 후<details>
<summery>@EntityGraph(attributePaths = {"latestWiki", "category"}) 적용 </summery>

```
select
        w1_0.id,
        c1_0.id,
        c1_0.category_name,
        c1_0.super_category_id,
        lw1_0.id,
        lw1_0.content,
        lw1_0.created_at,
        lw1_0.thumbnail_img_url,
        lw1_0.version,
        w1_0.title 
    from
        wiki w1_0 
    join
        latest_wiki lw1_0 
            on lw1_0.id=w1_0.latest_wiki_id 
    left join
        category c1_0 
            on c1_0.id=w1_0.category_id 
    where
        lower(w1_0.title) like replace(lower(concat('%', ?, '%')), '\\', '\\\\') 
        or lower(lw1_0.content) like replace(lower(concat('%', ?, '%')), '\\', '\\\\') 
    order by
        lw1_0.created_at desc 
    limit
        ?
2024-09-30T15:30:08.018+09:00 TRACE 9740 --- [nio-8080-exec-4] org.hibernate.orm.jdbc.bind              : binding parameter (1:VARCHAR) <- [역사]
2024-09-30T15:30:08.019+09:00 TRACE 9740 --- [nio-8080-exec-4] org.hibernate.orm.jdbc.bind              : binding parameter (2:VARCHAR) <- [역사]
2024-09-30T15:30:08.019+09:00 TRACE 9740 --- [nio-8080-exec-4] org.hibernate.orm.jdbc.bind              : binding parameter (3:INTEGER) <- [15]
```

</details>

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4599d885-9534-43c5-b414-25e37f0546f9)


## 리뷰 요구사항 혹은 기타 (선택)
