### PR TITLE
[Fix] 위키 카드 사이즈 수정, 위키 버전 목록 등급 안내 css 수정 (#380,#362)

### DIFF
--- a/frontend/src/components/wiki/WikiCardComponent.vue
+++ b/frontend/src/components/wiki/WikiCardComponent.vue
@@ -1,29 +1,19 @@
 <template>
   <div class="wiki-card">
-      <router-link :to="computedLink" class="wiki-card-link">
+    <router-link :to="computedLink" class="wiki-card-link">
       <div class="wiki-card-image-wrapper">
-        <img
-          v-if="wikiCard.thumbnail"
-          :src="wikiCard.thumbnail"
-          alt="Wiki Thumbnail"
-          class="wiki-card-image"
-        />
-        <img
-          v-else
-          src="/path-to-default-thumbnail.png"
-          alt="Default Thumbnail"
-          class="wiki-card-image"
-        />
+        <img v-if="wikiCard.thumbnail" :src="wikiCard.thumbnail" alt="Wiki Thumbnail" class="wiki-card-image" />
+        <img v-else src="/path-to-default-thumbnail.png" alt="Default Thumbnail" class="wiki-card-image" />
       </div>
       <div class="wiki-card-content">
         <h3 class="wiki-card-title">"{{ wikiCard.title }}"</h3>
         <p class="wiki-card-description">{{ truncatedContent }}</p>
         <div class="wiki-card-category">
           {{ wikiCard.category }}
-            <div class="wiki-link-underline"></div>
+          <div class="wiki-link-underline"></div>
         </div>
       </div>
-      </router-link>
+    </router-link>
   </div>
 </template>
 
@@ -58,13 +48,15 @@ export default {
   flex-direction: column;
   width: 100%;
   max-width: 270px;
-  min-width: 200px;
-  height: 90%;
+  min-width: 270px;
+  height: 450px;
   border-radius: 20px;
   background-color: white;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   transition: box-shadow 0.3s ease;
+  margin-bottom: 30px;
+
 }
 
 .wiki-card-link {
@@ -109,8 +101,13 @@ export default {
   color: #666;
   margin-bottom: 15px;
   line-height: 1.4;
-  flex-grow: 1; 
+  flex-grow: 1;
   overflow: hidden;
+  /* 내용이 넘치면 숨김 */
+  text-overflow: ellipsis;
+  /* 말줄임표(...) 처리 */
+  white-space: nowrap;
+  /* 한 줄로 고정 */
 }
 
 .wiki-card-category {
@@ -123,13 +120,13 @@ export default {
 }
 
 .wiki-card .wiki-link-underline {
-    width: 0;
-    height: 1px;
-    background-color: #999;
-    transition: .3s ease-out;
+  width: 0;
+  height: 1px;
+  background-color: #999;
+  transition: .3s ease-out;
 }
 
 .wiki-card:hover .wiki-link-underline {
-    width: 100%;
+  width: 100%;
 }
 </style>

--- a/frontend/src/components/wiki/WikiCardComponent.vue
+++ b/frontend/src/components/wiki/WikiCardComponent.vue
@@ -48,8 +48,8 @@ export default {
   flex-direction: column;
   width: 100%;
   max-width: 270px;
-  min-width: 270px;
-  height: 450px;
+  min-width: 200px;
+  height: 394px;
   border-radius: 20px;
   background-color: white;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -103,11 +103,8 @@ export default {
   line-height: 1.4;
   flex-grow: 1;
   overflow: hidden;
-  /* 내용이 넘치면 숨김 */
   text-overflow: ellipsis;
-  /* 말줄임표(...) 처리 */
   white-space: nowrap;
-  /* 한 줄로 고정 */
 }
 
 .wiki-card-category {

--- a/frontend/src/pages/WikiVersionListPage.vue
+++ b/frontend/src/pages/WikiVersionListPage.vue
@@ -156,13 +156,11 @@ table th {
     position: relative;
     display: flex;
     justify-content: center;
-    /* 페이지네이션을 중앙에 고정 */
-    margin-bottom: 10px;
+    margin-bottom: 50px;
 }
 
 .rollback-button {
     color: #e81f1f;
-    /* 어두운 빨간색 */
     border: none;
     background-color: transparent;
     cursor: pointer;


### PR DESCRIPTION
## 연관 이슈
close #380 #362


## 작업 내용
📌위키 카드 사이즈 css 수정
- 본문 내용에 따라 사이즈가 유동적이었는데, 고정 사이즈로 수정

📌위키 버전 목록 등급 안내 css 수정
- 페이지네이션 css 수정에 따른 안내 멘트 깨짐 오류 해결


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a8ccabfa-701a-47e3-ae09-a7c0fed1bffe)


## 리뷰 요구사항 혹은 기타 (선택)
