### PR TITLE
[Fix] Qna 검색 시 카테고리 미 선택 데이터에 대한 처리 방식 변경

### DIFF
--- a/backend/src/main/java/org/example/backend/Qna/Repository/QuestionRepository.java
+++ b/backend/src/main/java/org/example/backend/Qna/Repository/QuestionRepository.java
@@ -15,15 +15,15 @@ public interface QuestionRepository extends JpaRepository<QnaBoard, Long> {
     Page<QnaBoard> findByEnableTrue(Pageable pageable);
 
     // type이 tc일 때 검색 쿼리문
-    @Query("SELECT q FROM QnaBoard q WHERE (REPLACE(q.title, ' ', '') LIKE CONCAT('%', :keyword, '%') OR REPLACE(q.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) AND (q.category.id = :categoryId OR :notChosenCategory = true)  AND q.enable = true")
+    @Query("SELECT q FROM QnaBoard q WHERE (q.title LIKE CONCAT('%', :keyword, '%') OR q.content LIKE CONCAT('%', :keyword, '%')) AND (q.category.id = :categoryId OR :notChosenCategory = true)  AND q.enable = true")
     Page<QnaBoard> findByTC(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, @Param("notChosenCategory") boolean notChosenCategory, Pageable pageable);
 
     // type이 t일 때 검색 쿼리문
-    @Query("SELECT q FROM QnaBoard q WHERE REPLACE(q.title, ' ', '') LIKE CONCAT('%', :keyword, '%') AND (q.category.id = :categoryId OR :notChosenCategory = true)  AND q.enable = true")
+    @Query("SELECT q FROM QnaBoard q WHERE q.title LIKE CONCAT('%', :keyword, '%') AND (q.category.id = :categoryId OR :notChosenCategory = true)  AND q.enable = true")
     Page<QnaBoard> findByT(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, @Param("notChosenCategory") boolean notChosenCategory, Pageable pageable);
 
     // type이 c일때 검색 쿼리문
-    @Query("SELECT q FROM QnaBoard q WHERE REPLACE(q.content, ' ', '') LIKE CONCAT('%', :keyword, '%') AND (q.category.id = :categoryId OR :notChosenCategory = true) AND q.enable = true")
+    @Query("SELECT q FROM QnaBoard q WHERE q.content LIKE CONCAT('%', :keyword, '%') AND (q.category.id = :categoryId OR :notChosenCategory = true) AND q.enable = true")
     Page<QnaBoard> findByC(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, @Param("notChosenCategory") boolean notChosenCategory, Pageable pageable);
 
     Page<QnaBoard> findByUserIdAndEnableTrue(Long userId, Pageable pageable);

--- a/backend/src/main/java/org/example/backend/Qna/Repository/QuestionRepository.java
+++ b/backend/src/main/java/org/example/backend/Qna/Repository/QuestionRepository.java
@@ -14,18 +14,17 @@ public interface QuestionRepository extends JpaRepository<QnaBoard, Long> {
 
     Page<QnaBoard> findByEnableTrue(Pageable pageable);
 
-
     // type이 tc일 때 검색 쿼리문
-    @Query("SELECT q FROM QnaBoard q WHERE (q.title LIKE CONCAT('%', :keyword, '%') OR q.content LIKE CONCAT('%', :keyword, '%')) AND (:categoryId IS NULL OR q.category.id = :categoryId) AND q.enable = true")
-    Page<QnaBoard> findByTC(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, Pageable pageable);
+    @Query("SELECT q FROM QnaBoard q WHERE (REPLACE(q.title, ' ', '') LIKE CONCAT('%', :keyword, '%') OR REPLACE(q.content, ' ', '') LIKE CONCAT('%', :keyword, '%')) AND (q.category.id = :categoryId OR :notChosenCategory = true)  AND q.enable = true")
+    Page<QnaBoard> findByTC(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, @Param("notChosenCategory") boolean notChosenCategory, Pageable pageable);
 
     // type이 t일 때 검색 쿼리문
-    @Query("SELECT q FROM QnaBoard q WHERE q.title LIKE CONCAT('%', :keyword, '%') AND (:categoryId IS NULL OR q.category.id = :categoryId) AND q.enable = true")
-    Page<QnaBoard> findByT(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, Pageable pageable);
+    @Query("SELECT q FROM QnaBoard q WHERE REPLACE(q.title, ' ', '') LIKE CONCAT('%', :keyword, '%') AND (q.category.id = :categoryId OR :notChosenCategory = true)  AND q.enable = true")
+    Page<QnaBoard> findByT(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, @Param("notChosenCategory") boolean notChosenCategory, Pageable pageable);
 
     // type이 c일때 검색 쿼리문
-    @Query("SELECT q FROM QnaBoard q WHERE q.content LIKE CONCAT('%', :keyword, '%') AND (:categoryId IS NULL OR q.category.id = :categoryId) AND q.enable = true")
-    Page<QnaBoard> findByC(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, Pageable pageable);
+    @Query("SELECT q FROM QnaBoard q WHERE REPLACE(q.content, ' ', '') LIKE CONCAT('%', :keyword, '%') AND (q.category.id = :categoryId OR :notChosenCategory = true) AND q.enable = true")
+    Page<QnaBoard> findByC(@Param("keyword") String keyword, @Param("categoryId") Long categoryId, @Param("notChosenCategory") boolean notChosenCategory, Pageable pageable);
 
     Page<QnaBoard> findByUserIdAndEnableTrue(Long userId, Pageable pageable);
     Page<QnaBoard> findByUserAnswerListUserIdAndEnableTrue(Long id, Pageable pageable);

--- a/backend/src/main/java/org/example/backend/Qna/Service/BasicQnaSearchService.java
+++ b/backend/src/main/java/org/example/backend/Qna/Service/BasicQnaSearchService.java
@@ -1,10 +1,7 @@
 package org.example.backend.Qna.Service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.backend.Category.Model.Entity.Category;
-import org.example.backend.Category.Repository.CategoryRepository;
 import org.example.backend.Common.BaseResponseStatus;
-import org.example.backend.Exception.custom.InvalidCategoryException;
 import org.example.backend.Exception.custom.InvalidQnaException;
 import org.example.backend.Qna.Repository.QuestionRepository;
 import org.example.backend.Qna.model.Entity.QnaBoard;
@@ -17,23 +14,19 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
 public class BasicQnaSearchService implements QnaSearchService {
-    private final CategoryRepository categoryRepository;
     private final QuestionRepository questionRepository;
 
     @Override
     public List<GetQnaListRes> getQnaSearch(GetQnaSearchReq getQnaSearchReq) {
-        if (getQnaSearchReq.getCategoryId() != null) {
-            Optional<Category> category = categoryRepository.findById(getQnaSearchReq.getCategoryId());
-            if (category.isEmpty()) {
-                throw new InvalidCategoryException(BaseResponseStatus.CATEGORY_INVALID_CATEGORY_DATA);
-            }
+        boolean notChosenCategory = false;
+        if (getQnaSearchReq.getCategoryId() == null || getQnaSearchReq.getCategoryId() < 1) {
+            notChosenCategory = true;
         }
 
         Pageable pageable;
@@ -47,12 +40,13 @@ public class BasicQnaSearchService implements QnaSearchService {
         }
         // paging 처리 및 responseList 생성
         Page<QnaBoard> qnaBoardPage;
+
         if (getQnaSearchReq.getType().equals("tc")) {
-            qnaBoardPage = questionRepository.findByTC(getQnaSearchReq.getKeyword(), getQnaSearchReq.getCategoryId(), pageable);
+            qnaBoardPage = questionRepository.findByTC(getQnaSearchReq.getKeyword(), getQnaSearchReq.getCategoryId(), notChosenCategory, pageable);
         } else if (getQnaSearchReq.getType().equals("t")) {
-            qnaBoardPage = questionRepository.findByT(getQnaSearchReq.getKeyword(), getQnaSearchReq.getCategoryId(), pageable);
+            qnaBoardPage = questionRepository.findByT(getQnaSearchReq.getKeyword(), getQnaSearchReq.getCategoryId(), notChosenCategory, pageable);
         } else if (getQnaSearchReq.getType().equals("c")) {
-            qnaBoardPage = questionRepository.findByC(getQnaSearchReq.getKeyword(), getQnaSearchReq.getCategoryId(), pageable);
+            qnaBoardPage = questionRepository.findByC(getQnaSearchReq.getKeyword(), getQnaSearchReq.getCategoryId(), notChosenCategory, pageable);
         } else {
             throw new InvalidQnaException(BaseResponseStatus.QNA_INVALID_SEARCH_TYPE);
         }

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaBoard.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaBoard.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
+import org.example.backend.Qna.model.Res.BeforeDeleteSpaceRes;
 import org.example.backend.User.Model.Entity.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -115,5 +116,20 @@ public class QnaBoard {
 
     public void disable() {
         this.enable = false;
+    }
+
+    public BeforeDeleteSpaceRes deleteSpace() {
+        BeforeDeleteSpaceRes before = BeforeDeleteSpaceRes.builder()
+                .title(this.title)
+                .content(this.content)
+                .build();
+        this.title = title != null ? title.replaceAll("\\s+", "") : null;
+        this.content = content != null ? content.replaceAll("\\s+", "") : null;
+        return before;
+    }
+
+    public void BackupSpace(BeforeDeleteSpaceRes beforeDeleteSpaceRes) {
+        this.title = beforeDeleteSpaceRes.getTitle();
+        this.content = beforeDeleteSpaceRes.getContent();
     }
 }

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaBoard.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaBoard.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.Category.Model.Entity.Category;
 import org.example.backend.ErrorArchive.Model.Entity.ErrorArchive;
-import org.example.backend.Qna.model.Res.BeforeDeleteSpaceRes;
 import org.example.backend.User.Model.Entity.User;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -99,7 +98,7 @@ public class QnaBoard {
     public void increaseAnswerCount() {
         this.answerCount++;
     }
-  
+
     public void decreaseAnswerCount() {
         this.answerCount--;
     }
@@ -107,29 +106,16 @@ public class QnaBoard {
     public void updateTitle(String title) {
         this.title = title;
     }
+
     public void updateContent(String content) {
         this.content = content;
     }
+
     public void updateCategory(Category category) {
         this.category = category;
     }
 
     public void disable() {
         this.enable = false;
-    }
-
-    public BeforeDeleteSpaceRes deleteSpace() {
-        BeforeDeleteSpaceRes before = BeforeDeleteSpaceRes.builder()
-                .title(this.title)
-                .content(this.content)
-                .build();
-        this.title = title != null ? title.replaceAll("\\s+", "") : null;
-        this.content = content != null ? content.replaceAll("\\s+", "") : null;
-        return before;
-    }
-
-    public void BackupSpace(BeforeDeleteSpaceRes beforeDeleteSpaceRes) {
-        this.title = beforeDeleteSpaceRes.getTitle();
-        this.content = beforeDeleteSpaceRes.getContent();
     }
 }


### PR DESCRIPTION
## 연관 이슈
close #301 


## 작업 내용
검색 시 카테고리 미 선택 시, 카테고리 구분없이 검색되도록 쿼리 수정

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)