### PR TITLE
[Fix] 위키 수정 컴포넌트 수정 (#402)

### DIFF
--- a/frontend/src/components/wiki/WikiUpdateComponent.vue
+++ b/frontend/src/components/wiki/WikiUpdateComponent.vue
@@ -12,17 +12,17 @@
                 <div class="grid grid-cols-1 gap-y-7">
                   
                   <div class="space-y-1">
-                    <label for="title" class="text-sm font-medium text-gray-700">제목</label>
-                    <input type="text" v-model="updatedTitle" class="form-control" readonly />
+                    <label for="title" class="text-sm font-medium text-gray-700" style="font-size: 1rem;">제목</label>
+                    <input type="text" v-model="updatedTitle" class="form-control circular-input" readonly style="pointer-events: none;padding-left: 15px;" />
                   </div>
 
                   <div class="space-y-1">
-                    <label for="category" class="text-sm font-medium text-gray-700">카테고리</label>
-                    <input type="text" v-model="updatedCategory" class="form-control" readonly />
+                    <label for="category" class="text-sm font-medium text-gray-700" style="font-size: 1rem;">카테고리</label>
+                    <input type="text" v-model="updatedCategory" class="form-control circular-input" readonly style="pointer-events: none;padding-left: 15px;" />
                   </div>
 
                   <div class="space-y-1">
-                    <label for="content" class="text-sm font-medium text-gray-700">내용</label>
+                    <label for="content" class="text-sm font-medium text-gray-700" style="font-size: 1rem;">내용</label>
                     <v-md-editor v-model="updatedContent" :disabled-menus="[]" height="400px" @upload-image="commonStore.imageUpload"></v-md-editor>
                   </div>
 
@@ -143,4 +143,5 @@ export default {
 #rowGapZero {
   row-gap: 0;
 }
+
 </style>


### PR DESCRIPTION
## 연관 이슈
close #402 


## 작업 내용
📌 위키 수정 컴포넌트 수정
- 제목, 카테고리란에 pointer-events: none; 추가해서 더블 클릭 시, 인풋창 안보이게 처리


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6100999a-e2db-4dab-9bfe-2b99c8cc0bf1)
변경 전
![image](https://github.com/user-attachments/assets/5d594a33-20dd-45e1-879d-24e678611016)
변경 후

## 리뷰 요구사항 혹은 기타 (선택)
리뷰어들이 참고해야할 사항이나 집중적으로 봐줬으면 하는 사항을 작성한다.