### PR TITLE
[Fix] 답변 채택 이후 데이터 전환 메커니즘과 버튼의 상태 수정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9039,14 +9039,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/i": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
-      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -13671,12 +13663,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semantic-ui-vue": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/semantic-ui-vue/-/semantic-ui-vue-0.11.0.tgz",
-      "integrity": "sha512-wQE7zn7TIOPbLzbUp5hhIzivEkV6qk/i+Vc/BCQCQH7thF7UWqsEAcWWrlskwMTD48uoqGGUHIEN+kxsy0W3mA==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/frontend/src/components/Common/AdditionalInfoComponent.vue
+++ b/frontend/src/components/Common/AdditionalInfoComponent.vue
@@ -13,10 +13,9 @@
       </button>
     </div>
     <div
-        class="absolute right-0 mt-2 w-[152px] origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none md:mt-4 dark:border dark:border-gray-700 dark:bg-gray-800"
+        class="absolute right-0 mt-2 w-[152px] origin-top-right rounded-md bg-white shadow-lg ring-black ring-opacity-5 focus:outline-none md:mt-4 dark:border dark:border-gray-700 dark:bg-gray-800"
         aria-labelledby="headlessui-menu-button-:r1:" id="headlessui-menu-items-:r5:" role="menu" tabindex="0"
         v-show="isOpen">
-      <div class="py-1" role="none">
         <button v-if="question"
                 class="text-blue-500 block px-4 py-2 text-sm" id="headlessui-menu-item-:r6:" role="menuitem"
                 tabindex="-1" data-headlessui-state="" @click="doQuestion">다른 질문하기
@@ -37,7 +36,6 @@
                 @click="doDeleting">
           삭제하기
         </button>
-      </div>
     </div>
   </div>
 </template>
@@ -55,6 +53,7 @@ export default {
       editedAndDelete: false,
       question: false,
       isEdit: false,
+      isAdopted: false,
     }
   },
   props: ["adopted", "detail", "isQuestion"],
@@ -71,9 +70,14 @@ export default {
     doAdopting() {
       useQnaStore().adoptAnswer(this.$route.params.id, this.detail.id);
       useQnaStore().getQnaDetail(this.$route.params.id);
+      alert("해당 답변이 채택되었습니다.");
+      this.isAdopted = true;
+      this.isOpen = false;
+      this.$emit("clickAdopt", this.isAdopted);
     },
     doEditing() {
-      this.isEdit = true
+      this.isEdit = true;
+      this.isOpen = false;
       this.$emit("clickEdit", this.isEdit);
     },
     doQuestion() {

--- a/frontend/src/components/Qna/Detail/QnaAnswerDetailComponent.vue
+++ b/frontend/src/components/Qna/Detail/QnaAnswerDetailComponent.vue
@@ -244,16 +244,14 @@ export default {
         window.location.reload();
       } else {
         if (this.isCheckedAnsHate === true) {
-          this.isCheckedAnsLike = !this.isCheckedAnsLike;
-          alert("좋아요와 싫어요는 동시에 입력할 수 없습니다.");
-          window.location.reload();
+          this.isCheckedAnsHate = !this.isCheckedAnsHate;
         }
         this.isReLoading = true;
         await useQnaStore().answerLike(this.$route.params.id, this.qnaAnswer.id);
-        await useQnaStore().answerState(this.qnaAnswer.id);
         console.log("like" + useQnaStore().ansState.checkLikeOrHate);
         this.isCheckedAnsLike = !this.isCheckedAnsLike;
         this.ansLikeCnt = useQnaStore().ansState.likeCnt;
+        this.ansHateCnt = useQnaStore().ansState.hateCnt;
         this.isReLoading = false;
       }
 
@@ -265,15 +263,13 @@ export default {
         window.location.reload();
       } else {
         if (this.isCheckedAnsLike === true) {
-          this.isCheckedAnsHate = !this.isCheckedAnsHate;
-          alert("좋아요와 싫어요는 동시에 입력할 수 없습니다.");
-          window.location.reload();
+          this.isCheckedAnsLike = !this.isCheckedAnsLike;
         }
         this.isReLoading = true;
         await useQnaStore().answerHate(this.$route.params.id, this.qnaAnswer.id);
-        await useQnaStore().answerState(this.qnaAnswer.id);
         console.log("hate" + useQnaStore().ansState.checkLikeOrHate);
         this.isCheckedAnsHate = !this.isCheckedAnsHate;
+        this.ansLikeCnt = useQnaStore().ansState.likeCnt;
         this.ansHateCnt = useQnaStore().ansState.hateCnt;
         this.isReLoading = false;
       }

--- a/frontend/src/components/Qna/Detail/QnaAnswerDetailComponent.vue
+++ b/frontend/src/components/Qna/Detail/QnaAnswerDetailComponent.vue
@@ -36,6 +36,7 @@
                                    v-bind:adopted="isShowAdopted"
                                    v-bind:detail="qnaAnswer"
                                    @clickEdit="handleEditUpdate"
+                                   @clickAdopt="handleAdoptUpdate"
           />
         </div>
       </div>
@@ -293,6 +294,10 @@ export default {
     },
     handleEditUpdate(newIsEdit) {
       this.isEdited = newIsEdit;
+    },
+    handleAdoptUpdate(newIsEdit) {
+      this.isAdopted = false;
+      this.isAdopted = newIsEdit;
     },
     handleCommentRegistered(success) {
       if (success) {

--- a/frontend/src/components/Qna/Detail/QnaDetailHeaderComponent.vue
+++ b/frontend/src/components/Qna/Detail/QnaDetailHeaderComponent.vue
@@ -9,8 +9,8 @@
   <span class="datetime-text">{{ formatDateTime(qnaDetail.createdAt) }}</span>
   <div class="label-custom">
     <div class="ui tag labels">
-        <CategoryComponent v-if="qnaDetail.superCategoryName !== null" :category=qnaDetail.superCategoryName />
-        <CategoryComponent v-if="qnaDetail.subCategoryName !== null" :category=qnaDetail.subCategoryName :is-sub="true" />
+      <CategoryComponent v-if="qnaDetail.superCategoryName !== null" :category=qnaDetail.superCategoryName />
+      <CategoryComponent v-if="qnaDetail.subCategoryName !== null" :category=qnaDetail.subCategoryName :is-sub="true"/>
     </div>
   </div>
   <div class="qna-detail-top-items" v-if="isLoggedIn">
@@ -23,10 +23,12 @@
             @click="clickScrap" :checked="isCheckedScrap"
         />
         <label for="bookmark-toggle" class="bookmark-checkbox__label">
-            <svg data-v-00557fae="" class="bookmark-checkbox__icon" viewBox="0 0 24 24">
-                <path data-v-00557fae="" class="bookmark-checkbox__icon-back" d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" stroke-width="1.5" stroke="#767676"></path>
-                <path data-v-00557fae="" class="bookmark-checkbox__icon-check" d="M8 11l3 3 5-5" stroke-width="1.5" stroke="#767676"></path>
-            </svg>
+          <svg data-v-00557fae="" class="bookmark-checkbox__icon" viewBox="0 0 24 24">
+            <path data-v-00557fae="" class="bookmark-checkbox__icon-back"
+                  d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" stroke-width="1.5" stroke="#767676"></path>
+            <path data-v-00557fae="" class="bookmark-checkbox__icon-check" d="M8 11l3 3 5-5" stroke-width="1.5"
+                  stroke="#767676"></path>
+          </svg>
         </label>
       </div>
       <div class="icons-box">
@@ -131,18 +133,17 @@ export default {
       if (!useUserStore().isLoggedIn) {
         alert("좋아요와 싫어요는 로그인하지 않으면 선택할 수 없습니다.");
         window.location.reload();
-      } else {
+      }
+      else {
         if (this.isCheckedHate === true) {
-          this.isCheckedLike = !this.isCheckedLike;
-          alert("좋아요와 싫어요는 동시에 입력할 수 없습니다.");
-          window.location.reload();
+          this.isCheckedHate = !this.isCheckedHate;
         }
         this.isReLoading = true;
         await useQnaStore().questionLike(this.$route.params.id);
-        await useQnaStore().questionState(this.$route.params.id);
         console.log("like" + useQnaStore().qnaState.checkLikeOrHate);
         this.isCheckedLike = !this.isCheckedLike;
         this.qnaLikeCnt = useQnaStore().qnaState.likeCnt;
+        this.qnaHateCnt = useQnaStore().qnaState.hateCnt;
         this.isReLoading = false;
       }
     },
@@ -153,15 +154,13 @@ export default {
         window.location.reload();
       } else {
         if (this.isCheckedLike === true) {
-          this.isCheckedHate = !this.isCheckedHate;
-          alert("좋아요와 싫어요는 동시에 입력할 수 없습니다.");
-          window.location.reload();
+          this.isCheckedLike = !this.isCheckedLike;
         }
         this.isReLoading = true;
         await useQnaStore().questionHate(this.$route.params.id);
-        await useQnaStore().questionState(this.$route.params.id);
         console.log("hate" + useQnaStore().qnaState.checkLikeOrHate);
         this.isCheckedHate = !this.isCheckedHate;
+        this.qnaLikeCnt = useQnaStore().qnaState.likeCnt;
         this.qnaHateCnt = useQnaStore().qnaState.hateCnt;
         this.isReLoading = false;
       }
@@ -172,7 +171,6 @@ export default {
         alert("좋아요와 싫어요는 로그인하지 않으면 선택할 수 없습니다.");
       } else {
         await useQnaStore().questionScrap(this.$route.params.id);
-        await useQnaStore().questionState(this.$route.params.id);
         console.log("scrap" + useQnaStore().qnaState.checkScrap);
         this.isCheckedScrap = !this.isCheckedScrap;
       }
@@ -205,7 +203,7 @@ export default {
     this.checking();
   },
   components: {
-      CategoryComponent,
+    CategoryComponent,
     NicknameComponent
   },
   computed: {
@@ -249,6 +247,7 @@ export default {
 .test.ui.label:hover {
   background-color: #1EBDE5FF; /* superCategoryName 태그 호버 시 색상 */
 }
+
 /* 카테고리 태그*/
 .qna-detail-top-title {
   display: flex;

--- a/frontend/src/store/useQnaStore.js
+++ b/frontend/src/store/useQnaStore.js
@@ -32,7 +32,12 @@ export const useQnaStore = defineStore("qna", {
             hateCnt:0,
             checkLikeOrHate:null,
         },
-        qnaState: {},
+        qnaState: {
+            likeCnt:0,
+            hateCnt:0,
+            checkLikeOrHate:null,
+            checkScrap:null,
+        },
         registered: 0,
         totalPage:0
     }),
@@ -143,7 +148,7 @@ export const useQnaStore = defineStore("qna", {
                         'Content-Type': 'application/json'
                     }, withCredentials: true
                 });
-                this.checkQnaLike = res.data.result;
+                this.qnaState = res.data.result;
             } catch (error) {
                 alert("서버에 등록하는 과정에서 문제가 발생했습니다.")
             }
@@ -159,7 +164,7 @@ export const useQnaStore = defineStore("qna", {
                         'Content-Type': 'application/json'
                     }, withCredentials: true
                 });
-                this.checkQnaHate = res.data.result;
+                this.qnaState = res.data.result;
             } catch (error) {
                 alert("서버에 등록하는 과정에서 문제가 발생했습니다.")
             }
@@ -175,7 +180,7 @@ export const useQnaStore = defineStore("qna", {
                         'Content-Type': 'application/json'
                     }, withCredentials: true
                 });
-                this.checkScrap = res.data.result;
+                this.qnaState = res.data.result;
             } catch (error) {
                 alert("서버에 등록하는 과정에서 문제가 발생했습니다.")
             }
@@ -203,7 +208,7 @@ export const useQnaStore = defineStore("qna", {
                         'Content-Type': 'application/json'
                     }, withCredentials: true
                 });
-                this.checkAnsLike = res.data.result;
+                this.ansState = res.data.result;
             } catch (error) {
                 alert("서버에 등록하는 과정에서 문제가 발생했습니다.")
             }
@@ -220,7 +225,7 @@ export const useQnaStore = defineStore("qna", {
                         'Content-Type': 'application/json'
                     }, withCredentials: true
                 });
-                this.checkAnsHate = res.data.result;
+                this.ansState = res.data.result;
             } catch (error) {
                 alert("서버에 등록하는 과정에서 문제가 발생했습니다.")
             }
@@ -231,7 +236,6 @@ export const useQnaStore = defineStore("qna", {
                 const res = await axios.get(backend + "/ans/state?answerId=" + answerId,
                     {withCredentials: true});
                 this.ansState = res.data.result;
-                console.log(this.ansState);
             } catch (error) {
                 alert("서버에 등록하는 과정에서 문제가 발생했습니다.")
             }


### PR DESCRIPTION
## 연관 이슈
close #289 


## 작업 내용
채택 마크 생성 메커니즘 수정
버튼 태그의 채택 또는 수정을 통해 답변 데이터를 변경 했을 때, 버튼이 종료되도록 설정
이미 채택된 답변에서 더 이상 선택할 수 있는 항목이 없을 때 뜨는 css 제거 

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/360f70c9-2e7f-4ec9-8c6e-34a283f3387c)
.=> 이거 수정


## 리뷰 요구사항 혹은 기타 (선택)