### PR TITLE
[Fix] 좋아요 버튼 충돌 시의 메커니즘 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/Qna/Controller/AnswerController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/AnswerController.java
@@ -34,22 +34,22 @@ public class AnswerController {
 
     //qna 답변 좋아요
     @PostMapping("/like")
-    public BaseResponse<Long> checkAnsLike(@RequestBody Map<String, Long> requestBody, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<GetAnswerStateRes> checkAnsLike(@RequestBody Map<String, Long> requestBody, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long qnaBoardId = requestBody.get("qnaBoardId");
         Long answerId = requestBody.get("answerId");
 
-        Long id = qnaService.checkAnswerLike(qnaBoardId, answerId, customUserDetails.getUserId());
-        return new BaseResponse<>(id);
+        GetAnswerStateRes answerStateRes = qnaService.checkAnswerLike(qnaBoardId, answerId, customUserDetails.getUserId());
+        return new BaseResponse<>(answerStateRes);
     }
 
     //qna 답변 싫어요
     @PostMapping("/hate")
-    public BaseResponse<Long> checkAnsHate(@RequestBody Map<String, Long> requestBody, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<GetAnswerStateRes> checkAnsHate(@RequestBody Map<String, Long> requestBody, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long qnaBoardId = requestBody.get("qnaBoardId");
         Long answerId = requestBody.get("answerId");
 
-        Long id = qnaService.checkAnswerHate(qnaBoardId, answerId, customUserDetails.getUserId());
-        return new BaseResponse<>(id);
+        GetAnswerStateRes answerStateRes = qnaService.checkAnswerHate(qnaBoardId, answerId, customUserDetails.getUserId());
+        return new BaseResponse<>(answerStateRes);
     }
 
     @GetMapping("/state")

--- a/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -58,23 +58,23 @@ public class QuestionController {
 
     //qna 질문 좋아요
     @PostMapping("/like")
-    public BaseResponse<Long> checkQnaLike(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        Long id = qnaService.checkQnaLike(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
-        return new BaseResponse<>(id);
+    public BaseResponse<GetQuestionStateRes> checkQnaLike(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        GetQuestionStateRes qnaStateRes = qnaService.checkQnaLike(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
+        return new BaseResponse<>(qnaStateRes);
     }
 
     //qna 질문 싫어요
     @PostMapping("/hate")
-    public BaseResponse<Long> checkQnaHate(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        Long id = qnaService.checkQnaHate(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
-        return new BaseResponse<>(id);
+    public BaseResponse<GetQuestionStateRes> checkQnaHate(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        GetQuestionStateRes qnaStateRes = qnaService.checkQnaHate(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
+        return new BaseResponse<>(qnaStateRes);
     }
 
     //qna 스크랩
     @PostMapping("/scrap")
-    public BaseResponse<Long> checkScrap(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        Long id = qnaService.checkQnaScrap(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
-        return new BaseResponse<>(id);
+    public BaseResponse<GetQuestionStateRes> checkScrap(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        GetQuestionStateRes qnaStateRes = qnaService.checkQnaScrap(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
+        return new BaseResponse<>(qnaStateRes);
     }
 
     @GetMapping("/state")

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/AnswerLike.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/AnswerLike.java
@@ -29,4 +29,8 @@ public class AnswerLike {
     @Column(name = "state", nullable = false)
     private boolean state;
 
+    public void changeState() {
+        this.state = !this.state;
+    }
+
 }

--- a/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaLike.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Entity/QnaLike.java
@@ -28,4 +28,8 @@ public class QnaLike {
 
     @Column(name = "state", nullable = false)
     private boolean state;
+
+    public void changeState() {
+        this.state = !this.state;
+    }
 }

--- a/backend/src/main/java/org/example/backend/Qna/model/Res/GetAnswerStateRes.java
+++ b/backend/src/main/java/org/example/backend/Qna/model/Res/GetAnswerStateRes.java
@@ -14,5 +14,4 @@ public class GetAnswerStateRes {
     private Integer likeCnt;
     private Integer hateCnt;
     private Boolean checkLikeOrHate;
-    private Boolean checkAdopted;
 }


### PR DESCRIPTION
## 연관 이슈
close #410 


## 작업 내용
좋아요 및 싫어요 상태가 충돌 날 경우 이후 상태로 강제 변경되도록 메커니즘 수정
좋아요 및 싫어요, 스크랩 컨트롤러 요청의 반환 테이터를 id에서 state 데이터로 수정


## 스크린샷 (선택)
화면이 변경되었다면 어떻게 수정되었는지 사진을 첨부한다.


## 리뷰 요구사항 혹은 기타 (선택)
기존 state를 가져오는 컨트롤러와 서비스 메소드는 예비용으로 남겨둠