### PR TITLE
[Feat] Elasticsearch 라이브러리 설정 및 테스트 (#443)

### DIFF
--- a/back/backend/build.gradle
+++ b/back/backend/build.gradle
@@ -20,6 +20,9 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 에러 대응 코드
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 에러 대응 코드
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.24'
+
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/back/backend/docker-compose.yml
+++ b/back/backend/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - discovery.type=single-node
       - ELASTIC_PASSWORD=qwer1234
       - ES_JAVA_OPTS=-Xmx256m -Xms256m
+      - xpack.security.enabled=true
     container_name: elasticsearch
     volumes:
       - ./elasticsearch/data/:/usr/share/elasticsearch/data/

--- a/back/backend/src/main/java/org/example/backend/BackendApplication.java
+++ b/back/backend/src/main/java/org/example/backend/BackendApplication.java
@@ -3,6 +3,7 @@ package org.example.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
@@ -15,6 +16,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 		"com.example.common",
 		"org.example.backend"
 })
+@EnableElasticsearchRepositories(basePackages = {"org.example.backend"})
 public class BackendApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);

--- a/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -3,6 +3,7 @@ package org.example.backend.Qna.Controller;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Qna.Service.BasicQnaSearchService;
+import org.example.backend.Qna.Service.ElasticQnaSearchService;
 import org.example.backend.Qna.Service.QnaService;
 import org.example.backend.Qna.model.Res.GetQnaListRes;
 import org.example.backend.Qna.model.Res.GetQuestionDetailRes;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +25,7 @@ import java.util.Optional;
 public class QuestionController {
     private final QnaService qnaService;
     private final BasicQnaSearchService basicQnaSearchService;
+    private final ElasticQnaSearchService elasticQnaSearchService;
 
     //qna 등록
     @PostMapping()
@@ -87,6 +88,12 @@ public class QuestionController {
     @GetMapping("/search")
     public BaseResponse<List<GetQnaListRes>> getQnaSearch(GetQnaSearchReq getQnaSearchReq) {
         List<GetQnaListRes> qnaListRes = basicQnaSearchService.getQnaSearch(getQnaSearchReq);
+        return new BaseResponse<>(qnaListRes);
+    }
+
+    @GetMapping("/search2") //엘라스틱 서치 테스트 용도
+    public BaseResponse<List<GetQnaListRes>> getQnaSearch2(GetQnaSearchReq getQnaSearchReq) {
+        List<GetQnaListRes> qnaListRes = elasticQnaSearchService.getQnaSearch(getQnaSearchReq);
         return new BaseResponse<>(qnaListRes);
     }
 

--- a/back/backend/src/main/java/org/example/backend/Qna/Repository/ElasticsearchQuestionRepository.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Repository/ElasticsearchQuestionRepository.java
@@ -1,0 +1,7 @@
+package org.example.backend.Qna.Repository;
+
+import org.example.backend.Qna.model.Doc.QnaBoard;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ElasticsearchQuestionRepository extends ElasticsearchRepository<QnaBoard, Long> {
+}

--- a/back/backend/src/main/java/org/example/backend/Qna/Service/ElasticQnaSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Service/ElasticQnaSearchService.java
@@ -1,0 +1,39 @@
+package org.example.backend.Qna.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.Qna.Repository.ElasticsearchQuestionRepository;
+import org.example.backend.Qna.model.Doc.QnaBoard;
+import org.example.backend.Qna.model.Res.GetQnaListRes;
+import org.example.backend.Qna.model.req.GetQnaSearchReq;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ElasticQnaSearchService implements QnaSearchService {
+
+    private final ElasticsearchQuestionRepository elasticsearchQuestionRepository;
+
+    @Override
+    public List<GetQnaListRes> getQnaSearch(GetQnaSearchReq getQnaSearchReq) { // 테스트 용도
+        Iterable<QnaBoard> all = elasticsearchQuestionRepository.findAll();
+        List<GetQnaListRes> getQnaListRes = new ArrayList<>();
+        for (QnaBoard qnaBoard : all) {
+            getQnaListRes.add(GetQnaListRes.builder()
+                    .id(qnaBoard.getId())
+                    .title(qnaBoard.getTitle())
+                    .superCategoryName(qnaBoard.getSuperCategoryName())
+                    .subCategoryName(qnaBoard.getSubCategoryName())
+                    .likeCnt(qnaBoard.getLikeCnt())
+                    .createdAt(qnaBoard.getCreatedAt())
+                    .answerCnt(qnaBoard.getAnswerCnt())
+                    .nickname(qnaBoard.getNickname())
+                    .profileImage(qnaBoard.getProfileImg())
+                    .grade(qnaBoard.getGrade())
+                    .build());
+        }
+        return getQnaListRes;
+    }
+}

--- a/back/backend/src/main/java/org/example/backend/Qna/model/Doc/QnaBoard.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/model/Doc/QnaBoard.java
@@ -1,0 +1,41 @@
+package org.example.backend.Qna.model.Doc;
+
+import jakarta.persistence.Id;
+import lombok.Getter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "qna_board")
+@Getter
+public class QnaBoard {
+
+    @Id
+    private Long id;
+
+    private String title;
+    private String content;
+    @Field(name = "answer_cnt")
+    private Integer answerCnt;
+    @Field(name = "like_cnt")
+    private Integer likeCnt;
+    @Field(name = "created_at")
+    private LocalDateTime createdAt;
+    private Boolean enabled;
+    @Field(name = "sub_category_id")
+    private Long subCategoryId;
+    @Field(name = "sub_category_name")
+    private String subCategoryName;
+    @Field(name = "super_category_id")
+    private Long superCategoryId;
+    @Field(name = "super_category_name")
+    private String superCategoryName;
+    private String nickname;
+    @Field(name = "profile_img")
+    private String profileImg;
+    private String grade;
+    @Field(name = "input_id")
+    private String inputId;
+
+}

--- a/back/backend/src/main/resources/application.yml
+++ b/back/backend/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
       hibernate:
         format_sql: true
 
+  elasticsearch:
+    username: ${ELASTIC_USERNAME}
+    password: ${ELASTIC_PASSWORD}
+    host: ${ELASTIC_HOST}
+
   servlet:
     multipart:
       max-file-size: 20MB
@@ -80,3 +85,4 @@ frontend:
   url: ${FRONT_URL}
 kafka:
   url: ${KAFKA_URL}
+

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -27,8 +27,6 @@ subprojects {
         compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.30'
         annotationProcessor('org.projectlombok:lombok:1.18.30')
 
-        implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
-
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }


### PR DESCRIPTION
## 연관 이슈
close #443 


## 작업 내용
- Elasticsearch 라이브러리 위치 수정(common -> backend)
  - 라이브러리 설치시 같이 설치되는 다른 라이브러리의 버전 설정(엘라스틱서치 버전이 자주 바뀜)
- Elasticsearch를 통해 조회할 때 username, password를 입력해야 조회되도록 컨테이너 설정 수정
  - 그에 따른 환경변수 추가 -> 노션 확인
- Elasticsearch랑 연동 되는지 확인하기 위한 테스트 용도 코드 작성

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
- Elasticsearch 컨테이너 delete하고 다시 실행시켜주세요