### PR TITLE
[Feat] qna 목록조회 및 검색에서의 resolved-state 정렬 조건 구현

### DIFF
--- a/back/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Service/QnaService.java
@@ -1,5 +1,6 @@
 package org.example.backend.Qna.Service;
 
+import com.example.common.Qna.model.Resolved;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import com.example.common.Category.Model.Entity.Category;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class QnaService {
     private final QuestionRepository questionRepository;
+    private final QnaRepositoryCustomImpl qnaRepositoryCustom;
     private final AnswerRepository answerRepository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
@@ -64,7 +66,7 @@ public class QnaService {
             throw new InvalidQnaException(BaseResponseStatus.QNA_INVALID_SEARCH_TYPE);
         }
         // paging 처리 및 responseList 생성
-        Page<QnaBoard> qnaBoardPage = questionRepository.findByEnableTrue(pageable);
+        Page<QnaBoard> qnaBoardPage = qnaRepositoryCustom.getQnaList(getQnaListReq.getResolved(), pageable);
 
         return qnaBoardPage.getContent().stream().map(qnaBoard -> GetQnaListRes.builder()
                         .id(qnaBoard.getId())
@@ -492,6 +494,7 @@ public class QnaService {
         if (answerRepository.countAdopted(qnaBoardId).equals(0)) {
             answer.adoptedAnswer(true);
             qnaBoard.adopted(answerId);
+            qnaBoard.changeResolved(Resolved.RESOLVED);
             answerRepository.save(answer);
             questionRepository.save(qnaBoard);
             return answer.getId();

--- a/back/backend/src/main/java/org/example/backend/Qna/model/req/GetQnaListReq.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/model/req/GetQnaListReq.java
@@ -1,8 +1,6 @@
 package org.example.backend.Qna.model.req;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
@@ -11,4 +9,5 @@ public class GetQnaListReq {
     private String sort;
     private Integer page;
     private Integer size;
+    private String resolved;
 }

--- a/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustom.java
+++ b/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustom.java
@@ -6,4 +6,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface QnaRepositoryCustom {
     public Page<QnaBoard> findByKeyword(String keyword, boolean useSuperCategory, Long categoryId, String type, Pageable pageable);
+
+    public Page<QnaBoard> getQnaList(String resolved, Pageable pageable);
+
 }

--- a/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustomImpl.java
+++ b/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustomImpl.java
@@ -65,4 +65,31 @@ public class QnaRepositoryCustomImpl implements QnaRepositoryCustom {
 
         return new PageImpl<>(results, pageable, total);
     }
+
+    @Override
+    public Page<QnaBoard> getQnaList(String resolved, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(qQnaBoard.enable.isTrue());
+
+        switch (resolved) {
+            case "ALL" -> builder.and(qQnaBoard.adoptedAnswerId.isNull())
+                    .or(qQnaBoard.adoptedAnswerId.gt(0));
+            case "RESOLVED" -> builder.and(qQnaBoard.adoptedAnswerId.gt(0));
+            case "UNSOLVED" -> builder.and(qQnaBoard.adoptedAnswerId.isNull());
+        }
+
+        List<QnaBoard> results = queryFactory.selectFrom(qQnaBoard)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 페이징 처리 위해 보내는 값
+        long total = queryFactory.selectFrom(qQnaBoard)
+                .where(builder)
+                .fetchCount();
+
+        return new PageImpl<>(results, pageable, total);
+
+    }
 }

--- a/back/common/src/main/java/com/example/common/Qna/model/Entity/QnaBoard.java
+++ b/back/common/src/main/java/com/example/common/Qna/model/Entity/QnaBoard.java
@@ -1,5 +1,6 @@
 package com.example.common.Qna.model.Entity;
 
+import com.example.common.Qna.model.Resolved;
 import jakarta.persistence.*;
 import lombok.*;
 import com.example.common.Category.Model.Entity.Category;
@@ -58,6 +59,10 @@ public class QnaBoard {
     @Builder.Default()
     @Column(name = "enable", nullable = false)
     private boolean enable = true;
+
+    @Builder.Default()
+    @Column(name = "resolved", nullable = false)
+    private Resolved resolved = Resolved.UNSOLVED;
 
     @Builder.Default()
     @Column(name = "like_cnt", nullable = false)
@@ -122,5 +127,9 @@ public class QnaBoard {
 
     public void adopted(Long answerId) {
         this.adoptedAnswerId = answerId;
+    }
+
+    public void changeResolved(Resolved resolved) {
+        this.resolved = resolved;
     }
 }

--- a/back/common/src/main/java/com/example/common/Qna/model/Resolved.java
+++ b/back/common/src/main/java/com/example/common/Qna/model/Resolved.java
@@ -1,0 +1,10 @@
+package com.example.common.Qna.model;
+
+import lombok.Getter;
+
+@Getter
+public enum Resolved {
+    RESOLVED,
+    UNSOLVED,
+    ENDED
+}


### PR DESCRIPTION
## 연관 이슈
close #460 


## 작업 내용
enum 형태의 resolve-state를 qnaBoard에 추가
해당 질문 하위의 답변 리스트의 채택 여부를 확인하여 state 지정 메커니즘 구현
목록 조회 및 검색에서의 resolve-state 연결



## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)