### PR TITLE
[Fix] qna search 검색 범위 resolved 범위 지정

### DIFF
--- a/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustomImpl.java
+++ b/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustomImpl.java
@@ -58,10 +58,10 @@ public class QnaRepositoryCustomImpl implements QnaRepositoryCustom {
         }
 
         switch (resolved) {
-            case "ALL" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")))
-                    .or(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
-            case "RESOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
-            case "UNSOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")));
+            case "ALL" -> builder.and(qQnaBoard.resolved.eq(Resolved.UNSOLVED))
+                    .or(qQnaBoard.resolved.eq(Resolved.RESOLVED));
+            case "RESOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.RESOLVED));
+            case "UNSOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.UNSOLVED));
         }
 
         JPAQuery<QnaBoard> query = queryFactory.selectFrom(qQnaBoard)
@@ -97,10 +97,10 @@ public class QnaRepositoryCustomImpl implements QnaRepositoryCustom {
         builder.and(qQnaBoard.enable.isTrue());
 
         switch (resolved) {
-            case "ALL" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")))
-                    .or(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
-            case "RESOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
-            case "UNSOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")));
+            case "ALL" -> builder.and(qQnaBoard.resolved.eq(Resolved.UNSOLVED))
+                    .or(qQnaBoard.resolved.eq(Resolved.RESOLVED));
+            case "RESOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.RESOLVED));
+            case "UNSOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.UNSOLVED));
         }
 
         JPAQuery<QnaBoard> query = queryFactory.selectFrom(qQnaBoard)

--- a/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustomImpl.java
+++ b/back/common/src/main/java/com/example/common/Qna/Repository/QnaRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.example.common.Qna.Repository;
 
+import com.example.common.Qna.model.Resolved;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
@@ -57,10 +58,10 @@ public class QnaRepositoryCustomImpl implements QnaRepositoryCustom {
         }
 
         switch (resolved) {
-            case "ALL" -> builder.and(qQnaBoard.adoptedAnswerId.isNull())
-                    .or(qQnaBoard.adoptedAnswerId.gt(0));
-            case "RESOLVED" -> builder.and(qQnaBoard.adoptedAnswerId.gt(0));
-            case "UNSOLVED" -> builder.and(qQnaBoard.adoptedAnswerId.isNull());
+            case "ALL" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")))
+                    .or(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
+            case "RESOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
+            case "UNSOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")));
         }
 
         JPAQuery<QnaBoard> query = queryFactory.selectFrom(qQnaBoard)
@@ -96,10 +97,10 @@ public class QnaRepositoryCustomImpl implements QnaRepositoryCustom {
         builder.and(qQnaBoard.enable.isTrue());
 
         switch (resolved) {
-            case "ALL" -> builder.and(qQnaBoard.adoptedAnswerId.isNull())
-                    .or(qQnaBoard.adoptedAnswerId.gt(0));
-            case "RESOLVED" -> builder.and(qQnaBoard.adoptedAnswerId.gt(0));
-            case "UNSOLVED" -> builder.and(qQnaBoard.adoptedAnswerId.isNull());
+            case "ALL" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")))
+                    .or(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
+            case "RESOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("RESOLVED")));
+            case "UNSOLVED" -> builder.and(qQnaBoard.resolved.eq(Resolved.valueOf("UNSOLVED")));
         }
 
         JPAQuery<QnaBoard> query = queryFactory.selectFrom(qQnaBoard)


### PR DESCRIPTION
## 연관 이슈
close #468 


## 작업 내용
검색 조건에서 adoptedAnswerId가 아닌 resolved/unsolved로 판단


## 스크린샷 (선택)



## 리뷰 요구사항 혹은 기타 (선택)
