### PR TITLE
[Feat] QnA 검색 엘라스틱 서치 도입 (#465)

### DIFF
--- a/back/backend/elasticsearch/config/index-settings.json
+++ b/back/backend/elasticsearch/config/index-settings.json
@@ -2,10 +2,17 @@
   "settings": {
     "number_of_replicas": 0,
     "analysis": {
+      "tokenizer": {
+        "nori_tokenizer": {
+          "type": "nori_tokenizer",
+          "decompound_mode": "mixed"
+        }
+      },
       "analyzer": {
         "nori_analyzer": {
-          "type": "nori",
-          "decompound_mode": "mixed"
+          "type": "custom",
+          "tokenizer": "nori_tokenizer",
+          "filter": ["lowercase"]
         }
       }
     }

--- a/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -71,6 +71,7 @@ public enum BaseResponseStatus {
     QNA_INVALID_OR_EMPTY_DATA(false, 7002, "데이터 값이 비어있거나, 유효하지 않은 데이터입니다."),
     QNA_NO_EDIT_PERMISSION(false, 7003, "수정 및 삭제 권한이 없습니다."),
     QNA_INVALID_SEARCH_TYPE(false, 7004, "존재하지 않은 타입의 검색 방식 입니다."),
+    QNA_INVALID_RESOLVE_TYPE(false, 7005, "존재하지 않은 해결 여부 타입 입니다."),
     QNA_CONFLICT_LIKE_DISLIKE(false, 7010, "좋아요와 싫어요는 동시에 표기할 수 없습니다."),
     // - QnA 질문 에러
     QNA_QUESTION_NOT_FOUND(false, 7101, "해당 질문이 존재하지 않습니다."),
@@ -84,7 +85,6 @@ public enum BaseResponseStatus {
     QNA_ADOPTED_EDIT(false, 7203, "이미 채택된 경우 답변을 수정 및 삭제할 수 없습니다."),
     // - QnA 검색 에러
     QNA_SEARCH_EMPTY_REQUEST(false, 7301, "검색 요청이 비어 있습니다."),
-
 
 
 

--- a/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -70,8 +70,9 @@ public enum BaseResponseStatus {
     QNA_FAIL(false, 7001, "요청이 실패하였습니다."),
     QNA_INVALID_OR_EMPTY_DATA(false, 7002, "데이터 값이 비어있거나, 유효하지 않은 데이터입니다."),
     QNA_NO_EDIT_PERMISSION(false, 7003, "수정 및 삭제 권한이 없습니다."),
-    QNA_INVALID_SEARCH_TYPE(false, 7004, "존재하지 않은 타입의 검색 방식 입니다."),
-    QNA_INVALID_RESOLVE_TYPE(false, 7005, "존재하지 않은 해결 여부 타입 입니다."),
+    QNA_INVALID_SEARCH_TYPE(false, 7004, "잘못된 검색 방식 입니다."),
+    QNA_INVALID_RESOLVE_TYPE(false, 7005, "잘못된 해결 여부 타입 입니다."),
+    QNA_INVALID_SORT_TYPE(false, 7005, "잘못된 정렬 타입 입니다."),
     QNA_CONFLICT_LIKE_DISLIKE(false, 7010, "좋아요와 싫어요는 동시에 표기할 수 없습니다."),
     // - QnA 질문 에러
     QNA_QUESTION_NOT_FOUND(false, 7101, "해당 질문이 존재하지 않습니다."),

--- a/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -82,6 +82,8 @@ public enum BaseResponseStatus {
     QNA_ANSWER_NOT_FOUND(false, 7201, "해당 답변이 존재하지 않습니다."),
     QNA_INVALID_ANSWER_FORMAT(false, 7202, "잘못된 형식의 답변입니다."),
     QNA_ADOPTED_EDIT(false, 7203, "이미 채택된 경우 답변을 수정 및 삭제할 수 없습니다."),
+    // - QnA 검색 에러
+    QNA_SEARCH_EMPTY_REQUEST(false, 7301, "검색 요청이 비어 있습니다."),
 
 
 

--- a/back/backend/src/main/java/org/example/backend/Config/ElasticSearchConfig.java
+++ b/back/backend/src/main/java/org/example/backend/Config/ElasticSearchConfig.java
@@ -32,12 +32,17 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
                 .build();
     }
 
+    // RestHighLevelClient
     @Bean
     public RestHighLevelClient restHighLevelClient() {
         String[] hostPort = host.split(":");
         return new RestHighLevelClient(
-                RestClient.builder(new HttpHost(hostPort[0], Integer.parseInt(hostPort[1]), "http"))
-                        .setDefaultHeaders(new BasicHeader[]{
-                                new BasicHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))}));
+                RestClient.builder(
+                        new HttpHost(hostPort[0], Integer.parseInt(hostPort[1]), "http")
+                ).setDefaultHeaders(new BasicHeader[]{
+                        new BasicHeader("Authorization",
+                                "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
+                })
+        );
     }
 }

--- a/back/backend/src/main/java/org/example/backend/Config/ElasticSearchConfig.java
+++ b/back/backend/src/main/java/org/example/backend/Config/ElasticSearchConfig.java
@@ -1,9 +1,16 @@
 package org.example.backend.Config;
 
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+import java.util.Base64;
 
 @Configuration
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
@@ -21,7 +28,16 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
                 .connectedTo(host)
-                .withBasicAuth(username,password)
+                .withBasicAuth(username, password)
                 .build();
+    }
+
+    @Bean
+    public RestHighLevelClient restHighLevelClient() {
+        String[] hostPort = host.split(":");
+        return new RestHighLevelClient(
+                RestClient.builder(new HttpHost(hostPort[0], Integer.parseInt(hostPort[1]), "http"))
+                        .setDefaultHeaders(new BasicHeader[]{
+                                new BasicHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))}));
     }
 }

--- a/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -89,13 +89,13 @@ public class QuestionController {
 
     //qna 검색
     @GetMapping("/search/deprecated")
-    public BaseResponse<List<GetQnaListRes>> getQnaSearch(GetQnaSearchReq getQnaSearchReq) {
+    public BaseResponse<List<GetQnaListRes>> getQnaSearchDeprecated(GetQnaSearchReq getQnaSearchReq) {
         List<GetQnaListRes> qnaListRes = basicQnaSearchService.getQnaSearch(getQnaSearchReq);
         return new BaseResponse<>(qnaListRes);
     }
 
     @GetMapping("/search") //엘라스틱 서치 테스트 용도
-    public BaseResponse<List<GetQnaListRes>> getQnaSearch2(GetQnaSearchReq getQnaSearchReq) {
+    public BaseResponse<List<GetQnaListRes>> getQnaSearch(GetQnaSearchReq getQnaSearchReq) {
         try {
             return new BaseResponse<>(elasticQnaSearchService.getQnaSearch(getQnaSearchReq));
         } catch (IOException e) {

--- a/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -1,11 +1,9 @@
 package org.example.backend.Qna.Controller;
 
-import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidQnaException;
-import org.example.backend.Qna.Service.BasicQnaSearchService;
-import org.example.backend.Qna.Service.ElasticQnaSearchService;
+import org.example.backend.Qna.Service.QnaSearchService;
 import org.example.backend.Qna.Service.QnaService;
 import org.example.backend.Qna.model.Res.GetQnaListRes;
 import org.example.backend.Qna.model.Res.GetQuestionDetailRes;
@@ -15,6 +13,7 @@ import org.example.backend.Qna.model.req.EditQuestionReq;
 import org.example.backend.Qna.model.req.GetQnaListReq;
 import org.example.backend.Qna.model.req.GetQnaSearchReq;
 import org.example.backend.Security.CustomUserDetails;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,12 +22,15 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/qna")
 public class QuestionController {
     private final QnaService qnaService;
-    private final BasicQnaSearchService basicQnaSearchService;
-    private final ElasticQnaSearchService elasticQnaSearchService;
+    private final QnaSearchService qnaSearchService;
+
+    public QuestionController(QnaService qnaService, @Qualifier("QnaElasticSearch") QnaSearchService qnaSearchService) {
+        this.qnaService = qnaService;
+        this.qnaSearchService = qnaSearchService;
+    }
 
     //qna 등록
     @PostMapping()
@@ -51,8 +53,7 @@ public class QuestionController {
         Long userId;
         if (customUserDetails != null) {
             userId = customUserDetails.getUserId();
-        }
-        else {
+        } else {
             userId = null;
         }
         GetQuestionDetailRes questionDetailRes = qnaService.getQuestionDetail(qnaBoardId, userId);
@@ -62,21 +63,21 @@ public class QuestionController {
 
     //qna 질문 좋아요
     @PostMapping("/like")
-    public BaseResponse<GetQuestionStateRes> checkQnaLike(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<GetQuestionStateRes> checkQnaLike(@RequestBody Map<String, Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         GetQuestionStateRes qnaStateRes = qnaService.checkQnaLike(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
         return new BaseResponse<>(qnaStateRes);
     }
 
     //qna 질문 싫어요
     @PostMapping("/hate")
-    public BaseResponse<GetQuestionStateRes> checkQnaHate(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<GetQuestionStateRes> checkQnaHate(@RequestBody Map<String, Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         GetQuestionStateRes qnaStateRes = qnaService.checkQnaHate(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
         return new BaseResponse<>(qnaStateRes);
     }
 
     //qna 스크랩
     @PostMapping("/scrap")
-    public BaseResponse<GetQuestionStateRes> checkScrap(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<GetQuestionStateRes> checkScrap(@RequestBody Map<String, Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         GetQuestionStateRes qnaStateRes = qnaService.checkQnaScrap(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
         return new BaseResponse<>(qnaStateRes);
     }
@@ -88,16 +89,10 @@ public class QuestionController {
     }
 
     //qna 검색
-    @GetMapping("/search/deprecated")
+    @GetMapping("/search")
     public BaseResponse<List<GetQnaListRes>> getQnaSearchDeprecated(GetQnaSearchReq getQnaSearchReq) {
-        List<GetQnaListRes> qnaListRes = basicQnaSearchService.getQnaSearch(getQnaSearchReq);
-        return new BaseResponse<>(qnaListRes);
-    }
-
-    @GetMapping("/search") //엘라스틱 서치 테스트 용도
-    public BaseResponse<List<GetQnaListRes>> getQnaSearch(GetQnaSearchReq getQnaSearchReq) {
         try {
-            return new BaseResponse<>(elasticQnaSearchService.getQnaSearch(getQnaSearchReq));
+            return new BaseResponse<>(qnaSearchService.getQnaSearch(getQnaSearchReq));
         } catch (IOException e) {
             throw new InvalidQnaException(BaseResponseStatus.QNA_FAIL);
         }
@@ -110,7 +105,7 @@ public class QuestionController {
     }
 
     @PatchMapping("/removal")
-    public BaseResponse<Long> disableQuestion(@RequestBody Map<String,Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<Long> disableQuestion(@RequestBody Map<String, Long> qnaBoardId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long id = qnaService.disableQuestion(qnaBoardId.get("qnaBoardId"), customUserDetails.getUserId());
         return new BaseResponse<>(id);
     }

--- a/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Controller/QuestionController.java
@@ -2,6 +2,8 @@ package org.example.backend.Qna.Controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.Common.BaseResponse;
+import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Exception.custom.InvalidQnaException;
 import org.example.backend.Qna.Service.BasicQnaSearchService;
 import org.example.backend.Qna.Service.ElasticQnaSearchService;
 import org.example.backend.Qna.Service.QnaService;
@@ -16,6 +18,7 @@ import org.example.backend.Security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -85,16 +88,19 @@ public class QuestionController {
     }
 
     //qna 검색
-    @GetMapping("/search")
+    @GetMapping("/search/deprecated")
     public BaseResponse<List<GetQnaListRes>> getQnaSearch(GetQnaSearchReq getQnaSearchReq) {
         List<GetQnaListRes> qnaListRes = basicQnaSearchService.getQnaSearch(getQnaSearchReq);
         return new BaseResponse<>(qnaListRes);
     }
 
-    @GetMapping("/search2") //엘라스틱 서치 테스트 용도
+    @GetMapping("/search") //엘라스틱 서치 테스트 용도
     public BaseResponse<List<GetQnaListRes>> getQnaSearch2(GetQnaSearchReq getQnaSearchReq) {
-        List<GetQnaListRes> qnaListRes = elasticQnaSearchService.getQnaSearch(getQnaSearchReq);
-        return new BaseResponse<>(qnaListRes);
+        try {
+            return new BaseResponse<>(elasticQnaSearchService.getQnaSearch(getQnaSearchReq));
+        } catch (IOException e) {
+            throw new InvalidQnaException(BaseResponseStatus.QNA_FAIL);
+        }
     }
 
     @PatchMapping()

--- a/back/backend/src/main/java/org/example/backend/Qna/Repository/ElasticsearchQuestionRepository.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Repository/ElasticsearchQuestionRepository.java
@@ -1,7 +1,0 @@
-package org.example.backend.Qna.Repository;
-
-import org.example.backend.Qna.model.Doc.QnaBoard;
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-
-public interface ElasticsearchQuestionRepository extends ElasticsearchRepository<QnaBoard, Long> {
-}

--- a/back/backend/src/main/java/org/example/backend/Qna/Service/BasicQnaSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Service/BasicQnaSearchService.java
@@ -5,13 +5,10 @@ import com.example.common.Category.Repository.CategoryRepository;
 import com.example.common.Qna.Repository.QnaRepositoryCustomImpl;
 import com.example.common.Qna.model.Entity.QnaBoard;
 import lombok.RequiredArgsConstructor;
-
 import org.example.backend.Common.BaseResponseStatus;
 import org.example.backend.Exception.custom.InvalidQnaException;
-
 import org.example.backend.Qna.model.Res.GetQnaListRes;
 import org.example.backend.Qna.model.req.GetQnaSearchReq;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,12 +16,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 
-@Service
+@Service("QnaDbSearch")
 @RequiredArgsConstructor
 public class BasicQnaSearchService implements QnaSearchService {
     private final CategoryRepository categoryRepository;

--- a/back/backend/src/main/java/org/example/backend/Qna/Service/ElasticQnaSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Service/ElasticQnaSearchService.java
@@ -8,6 +8,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.*;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -90,8 +91,8 @@ public class ElasticQnaSearchService implements QnaSearchService {
             boolQueryBuilder.should(titleQueryBuilder);
         }
         if (getQnaSearchReq.getType().contains("c")) {
-            MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery("content", getQnaSearchReq.getKeyword()).minimumShouldMatch("2<75%");
-            boolQueryBuilder.should(matchQueryBuilder);
+            MatchQueryBuilder contentQueryBuilder = QueryBuilders.matchQuery("content", getQnaSearchReq.getKeyword()).minimumShouldMatch("2<75%").fuzziness(Fuzziness.AUTO);
+            boolQueryBuilder.should(contentQueryBuilder);
         }
     }
 

--- a/back/backend/src/main/java/org/example/backend/Qna/Service/ElasticQnaSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Service/ElasticQnaSearchService.java
@@ -44,6 +44,8 @@ public class ElasticQnaSearchService implements QnaSearchService {
 
         setQnaEnableQuery(boolQueryBuilder);
 
+        setQnaResolvedQuery(getQnaSearchReq, boolQueryBuilder);
+
         SearchResponse searchResponse = getSearchResponse(getQnaSearchReq, boolQueryBuilder);
         return makeQnaListRes(getQnaSearchReq, searchResponse);
     }
@@ -91,6 +93,16 @@ public class ElasticQnaSearchService implements QnaSearchService {
         if (getQnaSearchReq.getType().contains("c")) {
             MatchPhraseQueryBuilder contentQueryBuilder = QueryBuilders.matchPhraseQuery("content", getQnaSearchReq.getKeyword()).slop(2);
             boolQueryBuilder.should(contentQueryBuilder);
+        }
+    }
+
+    private static void setQnaResolvedQuery(GetQnaSearchReq getQnaSearchReq, BoolQueryBuilder boolQueryBuilder) {
+        if (getQnaSearchReq.getResolved().equals("RESOLVED")){
+            boolQueryBuilder.must(QueryBuilders.matchQuery("resolved", 0));
+        } else if (getQnaSearchReq.getResolved().equals("UNSOLVED")) {
+            boolQueryBuilder.must(QueryBuilders.matchQuery("resolved", 1));
+        } else {
+            boolQueryBuilder.mustNot(QueryBuilders.matchQuery("resolved", 2));
         }
     }
 

--- a/back/backend/src/main/java/org/example/backend/Qna/Service/QnaSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/Service/QnaSearchService.java
@@ -3,8 +3,9 @@ package org.example.backend.Qna.Service;
 import org.example.backend.Qna.model.Res.GetQnaListRes;
 import org.example.backend.Qna.model.req.GetQnaSearchReq;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface QnaSearchService {
-    public List<GetQnaListRes> getQnaSearch(GetQnaSearchReq getQnaSearchReq);
+    public List<GetQnaListRes> getQnaSearch(GetQnaSearchReq getQnaSearchReq) throws IOException;
 }

--- a/back/backend/src/main/java/org/example/backend/Qna/model/Doc/QnaBoard.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/model/Doc/QnaBoard.java
@@ -31,7 +31,7 @@ public class QnaBoard {
     @JsonProperty("created_at")
     private LocalDateTime createdAt;
 
-    private Boolean enabled;
+    private Boolean enable;
 
     @Field(name = "sub_category_id")
     @JsonProperty("sub_category_id")

--- a/back/backend/src/main/java/org/example/backend/Qna/model/Doc/QnaBoard.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/model/Doc/QnaBoard.java
@@ -1,5 +1,6 @@
 package org.example.backend.Qna.model.Doc;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -15,27 +16,49 @@ public class QnaBoard {
     private Long id;
 
     private String title;
+
     private String content;
+
     @Field(name = "answer_cnt")
+    @JsonProperty("answer_cnt")
     private Integer answerCnt;
+
     @Field(name = "like_cnt")
+    @JsonProperty("like_cnt")
     private Integer likeCnt;
+
     @Field(name = "created_at")
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
     private Boolean enabled;
+
     @Field(name = "sub_category_id")
+    @JsonProperty("sub_category_id")
     private Long subCategoryId;
+
     @Field(name = "sub_category_name")
+    @JsonProperty("sub_category_name")
     private String subCategoryName;
+
     @Field(name = "super_category_id")
+    @JsonProperty("super_category_id")
     private Long superCategoryId;
+
     @Field(name = "super_category_name")
+    @JsonProperty("super_category_name")
     private String superCategoryName;
+
     private String nickname;
+
     @Field(name = "profile_img")
+    @JsonProperty("profile_img")
     private String profileImg;
+
     private String grade;
+
     @Field(name = "input_id")
+    @JsonProperty("input_id")
     private String inputId;
 
 }

--- a/back/backend/src/main/java/org/example/backend/Qna/model/req/GetQnaSearchReq.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/model/req/GetQnaSearchReq.java
@@ -1,19 +1,17 @@
 package org.example.backend.Qna.model.req;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class GetQnaSearchReq {
-    private String type;
+    private String type = "tc";
     private String keyword;
     private Long categoryId;
 
-    private String sort;
-    private Integer page;
-    private Integer size;
+    private String sort = "latest";
+    private Integer page = 0;
+    private Integer size = 12;
     private String resolved;
 }

--- a/back/backend/src/main/java/org/example/backend/Qna/model/req/GetQnaSearchReq.java
+++ b/back/backend/src/main/java/org/example/backend/Qna/model/req/GetQnaSearchReq.java
@@ -7,11 +7,11 @@ import lombok.Setter;
 @Setter
 public class GetQnaSearchReq {
     private String type = "tc";
-    private String keyword;
+    private String keyword = "";
     private Long categoryId;
 
     private String sort = "latest";
     private Integer page = 0;
     private Integer size = 12;
-    private String resolved;
+    private String resolved = "ALL";
 }


### PR DESCRIPTION
## 연관 이슈
close #465 


## 작업 내용
- QnA 검색 엘라스틱 서치 도입
- RestHighLevelClient를 사용하여 elasticsearch에서 조회
- title은 각 단어 사이에 두 단어 허용
- content는 검색어의 75%가 포함되는 것만 검색되도록

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
