### PR TITLE
[Feat] 위키 검색에 Elasticsearch 도입 (#466)

### DIFF
--- a/back/backend/elasticsearch/config/index-settings.json
+++ b/back/backend/elasticsearch/config/index-settings.json
@@ -2,10 +2,17 @@
   "settings": {
     "number_of_replicas": 0,
     "analysis": {
+      "tokenizer": {
+        "nori_tokenizer": {
+          "type": "nori_tokenizer",
+          "decompound_mode": "mixed"
+        }
+      },
       "analyzer": {
         "nori_analyzer": {
-          "type": "nori",
-          "decompound_mode": "mixed"
+          "type": "custom",
+          "tokenizer": "nori_tokenizer",
+          "filter": ["lowercase"]
         }
       }
     }

--- a/back/backend/src/main/java/org/example/backend/Config/ElasticSearchConfig.java
+++ b/back/backend/src/main/java/org/example/backend/Config/ElasticSearchConfig.java
@@ -1,9 +1,16 @@
 package org.example.backend.Config;
 
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+import java.util.Base64;
 
 @Configuration
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
@@ -21,7 +28,21 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
                 .connectedTo(host)
-                .withBasicAuth(username,password)
+                .withBasicAuth(username, password)
                 .build();
+    }
+
+    // RestHighLevelClient
+    @Bean
+    public RestHighLevelClient restHighLevelClient() {
+        String[] hostPort = host.split(":");
+        return new RestHighLevelClient(
+                RestClient.builder(
+                        new HttpHost(hostPort[0], Integer.parseInt(hostPort[1]), "http")
+                ).setDefaultHeaders(new BasicHeader[]{
+                        new BasicHeader("Authorization",
+                                "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
+                })
+        );
     }
 }

--- a/back/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -8,7 +8,6 @@ import org.example.backend.File.Service.CloudFileUploadService;
 import org.example.backend.Security.CustomUserDetails;
 import org.example.backend.Wiki.Model.Req.*;
 import org.example.backend.Wiki.Model.Res.*;
-import org.example.backend.Wiki.Service.ElasticWikiSearchService;
 import org.example.backend.Wiki.Service.WikiSearchService;
 import org.example.backend.Wiki.Service.WikiService;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -58,14 +57,14 @@ public class WikiController {
 
     // 위키 목록 조회
     @GetMapping("/list")
-    public BaseResponse<List<WikiListRes>> list(Integer page,Integer size) {
+    public BaseResponse<List<WikiListRes>> list(Integer page, Integer size) {
         if (page == null) {
             page = 0;
         }
         if (size == null || size == 0) {
-            size =20;
+            size = 20;
         }
-        List<WikiListRes> wikiList = wikiService.wikiList(page,size);
+        List<WikiListRes> wikiList = wikiService.wikiList(page, size);
         return new BaseResponse<>(wikiList);
     }
 
@@ -112,6 +111,7 @@ public class WikiController {
 
         return new BaseResponse<>(wikiService.versionDetail(wikiContentId, userId));
     }
+
     // 위키 (이전버전) 목록 조회
     @GetMapping("/version/list")
     public BaseResponse<List<GetWikiVersionListRes>> versionList(GetWikiVersionListReq getWikiVersionListReq) {
@@ -141,14 +141,18 @@ public class WikiController {
 
     // 위키 검색
     @GetMapping("/search1")
-    public BaseResponse<List<WikiListRes>> search1(GetWikiSearchReq getWikiSearchReq)throws IOException {
+    public BaseResponse<List<WikiListRes>> search1(GetWikiSearchReq getWikiSearchReq) throws IOException {
         return new BaseResponse<>(dbWikiSearchService.search(getWikiSearchReq));
     }
 
     // 위키 검색(엘라스틱서치)
     @GetMapping("/search")
-    public BaseResponse<List<WikiListRes>> search(@ModelAttribute GetWikiSearchReq getWikiSearchReq)throws IOException {
-        return new BaseResponse<>(elasticWikiSearchService.search(getWikiSearchReq));
+    public BaseResponse<List<WikiListRes>> search(@ModelAttribute GetWikiSearchReq getWikiSearchReq) {
+        try {
+            return new BaseResponse<>(elasticWikiSearchService.search(getWikiSearchReq));
+        } catch (IOException e) {
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_NOT_FOUND_DETAIL);
+        }
     }
 }
 

--- a/back/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Controller/WikiController.java
@@ -147,7 +147,7 @@ public class WikiController {
 
     // 위키 검색(엘라스틱서치)
     @GetMapping("/search")
-    public BaseResponse<List<WikiListRes>> search(@ModelAttribute GetWikiSearchReq getWikiSearchReq) {
+    public BaseResponse<List<WikiListRes>> search(GetWikiSearchReq getWikiSearchReq) {
         try {
             return new BaseResponse<>(elasticWikiSearchService.search(getWikiSearchReq));
         } catch (IOException e) {

--- a/back/backend/src/main/java/org/example/backend/Wiki/Model/Doc/Wiki.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Model/Doc/Wiki.java
@@ -1,0 +1,40 @@
+package org.example.backend.Wiki.Model.Doc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "wiki")
+@Getter
+public class Wiki {
+
+    @Id
+    private Long id;
+    private String title;
+    private String content;
+
+    @Field(name = "created_at")
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @Field(name = "category_id")
+    @JsonProperty("category_id")
+    private Long categoryId;
+
+    @Field(name = "category_name")
+    @JsonProperty("category_name")
+    private String categoryName;
+
+    @Field(name = "thumbnail_img_url")
+    @JsonProperty("thumbnail_img_url")
+    private String thumbnailImgUrl;
+
+    @Field(name = "input_id")
+    private String inputId;
+
+
+}

--- a/back/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiSearchReq.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Model/Req/GetWikiSearchReq.java
@@ -7,8 +7,8 @@ import lombok.Setter;
 @Setter
 public class GetWikiSearchReq {
 
-    private Integer page; // 프론트에서 값을 지정해주지 않으면 자동으로 지정
-    private Integer size;
+    private Integer page = 0;
+    private Integer size = 16;
     private String type = "tc"; // tc: 제목+내용 , t: 제목, c: 내용 으로 검색
     private String keyword = ""; // keyword가 안들어오면 빈문자열로 처리됨(나중에 편함)
     private Long categoryId;

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
@@ -22,6 +22,7 @@ import java.util.List;
 @Service
 @Qualifier("WikiDbSearch")
 @RequiredArgsConstructor
+//db에서 검색
 public class DbWikiSearchService implements WikiSearchService {
     private final CategoryRepository categoryRepository;
     private final WikiRepository wikiRepository;

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/DbWikiSearchService.java
@@ -9,7 +9,6 @@ import org.example.backend.Exception.custom.InvalidCategoryException;
 import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.Wiki.Model.Req.GetWikiSearchReq;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,8 +18,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-@Service
-@Qualifier("WikiDbSearch")
+@Service("WikiDbSearch")
 @RequiredArgsConstructor
 //db에서 검색
 public class DbWikiSearchService implements WikiSearchService {

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
@@ -39,12 +39,14 @@ public class ElasticWikiSearchService implements WikiSearchService {
 
     @Override
     public List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq) throws IOException {
+
+
         validateSearchReq(getWikiSearchReq);
-        
+
         BoolQueryBuilder boolQuery = QueryBuilders.boolQuery(); // bool 쿼리를 사용하면 그 안에 다른 쿼리들을 넣는 식으로 사용이 가능!
 
         if (getWikiSearchReq.getKeyword() != null && !getWikiSearchReq.getKeyword().isEmpty()) {
-            String keyword = getWikiSearchReq.getKeyword().toLowerCase(); // 다 소문자 변환
+            String keyword = getWikiSearchReq.getKeyword();
             boolQuery.minimumShouldMatch(1);
 
             if ((getWikiSearchReq.getType()).contains("t")) { // 제목 검색
@@ -88,6 +90,14 @@ public class ElasticWikiSearchService implements WikiSearchService {
 
     // 유효성 검사
     private void validateSearchReq(GetWikiSearchReq getWikiSearchReq) {
+
+        if (getWikiSearchReq.getPage() == null) {
+            getWikiSearchReq.setPage(0);
+        }
+        if (getWikiSearchReq.getSize() == null || getWikiSearchReq.getSize() == 0) {
+            getWikiSearchReq.setSize(15);
+        }
+
         String keyword = getWikiSearchReq.getKeyword().toLowerCase().replaceAll("\\s", "");
         if ((keyword.isEmpty())
                 && (getWikiSearchReq.getCategoryId() == null || getWikiSearchReq.getCategoryId() == 0)) {

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
@@ -14,20 +14,18 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Exception.custom.InvalidWikiException;
 import org.example.backend.Wiki.Model.Doc.Wiki;
 import org.example.backend.Wiki.Model.Req.GetWikiSearchReq;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.example.backend.Exception.custom.InvalidWikiException;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Service
-@Qualifier("WikiElasticSearch")
+@Service("WikiElasticSearch")
 @RequiredArgsConstructor
 //es에서 검색
 public class ElasticWikiSearchService implements WikiSearchService {

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
@@ -93,7 +93,7 @@ public class ElasticWikiSearchService implements WikiSearchService {
             getWikiSearchReq.setPage(0);
         }
         if (getWikiSearchReq.getSize() == null || getWikiSearchReq.getSize() == 0) {
-            getWikiSearchReq.setSize(15);
+            getWikiSearchReq.setSize(16);
         }
 
         String keyword = getWikiSearchReq.getKeyword().toLowerCase().replaceAll("\\s", "");

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
@@ -1,0 +1,116 @@
+package org.example.backend.Wiki.Service;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.example.backend.Common.BaseResponseStatus;
+import org.example.backend.Wiki.Model.Doc.Wiki;
+import org.example.backend.Wiki.Model.Req.GetWikiSearchReq;
+import org.example.backend.Wiki.Model.Res.WikiListRes;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.example.backend.Exception.custom.InvalidWikiException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Qualifier("WikiElasticSearch")
+@RequiredArgsConstructor
+//es에서 검색
+public class ElasticWikiSearchService implements WikiSearchService {
+
+    private final RestHighLevelClient restHighLevelClient;
+    private final ObjectMapper objectMapper;
+    private final static List<String> SEARCH_TYPE = List.of("tc", "t", "c");
+
+    @Override
+    public List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq) throws IOException {
+        ValidateSearchReq(getWikiSearchReq);
+
+        if (getWikiSearchReq.getPage() == null) {
+            getWikiSearchReq.setPage(0);
+        }
+        if (getWikiSearchReq.getSize() == null) {
+            getWikiSearchReq.setSize(16);
+        }
+
+        BoolQueryBuilder boolQuery = QueryBuilders.boolQuery(); // bool 쿼리를 사용하면 그 안에 다른 쿼리들을 넣는 식으로 사용이 가능!
+
+        if (getWikiSearchReq.getKeyword() != null && !getWikiSearchReq.getKeyword().isEmpty()) { // 키워드 값이 있는데
+            String keyword = getWikiSearchReq.getKeyword().toLowerCase(); // 다 소문자 변환
+
+            if ("t".equals(getWikiSearchReq.getType())) { // 제목 검색
+                boolQuery.must(QueryBuilders.matchQuery("title", keyword));
+            } else if ("c".equals(getWikiSearchReq.getType())) { // 내용 검색
+                boolQuery.must(QueryBuilders.matchQuery("content", keyword));
+            } else if ("tc".equals(getWikiSearchReq.getType())) { // 제목+내용 검색
+                boolQuery.must(QueryBuilders.multiMatchQuery(keyword, "title", "content"));
+            }
+        }
+
+        if (getWikiSearchReq.getCategoryId() != null && getWikiSearchReq.getCategoryId() != 0) { // 카테고리 값이 있으면
+            boolQuery.filter(QueryBuilders.termQuery("category_id", getWikiSearchReq.getCategoryId()));
+        }
+
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder() // Elasticsearch에 보낼 검색 쿼리를 설정하는 빌더
+                .query(boolQuery)
+                .from(getWikiSearchReq.getPage() * getWikiSearchReq.getSize())  // 페이지 설정
+                .size(getWikiSearchReq.getSize())  // 페이지 크기 설정
+                .sort("created_at", SortOrder.DESC);  // 최신순 정렬
+
+        // SearchRequest = Elasticsearch에서 검색 요청을 정의하는 객체
+        SearchRequest searchRequest = new SearchRequest("wiki");  // 인덱스 설정
+        searchRequest.source(searchSourceBuilder);
+
+        // Elasticsearch 검색 실행
+        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+
+        // 검색 결과를 WikiListRes로 변환
+        return searchResponseToWikiListRes(searchResponse);
+    }
+
+    // 유효성 검사
+    private void ValidateSearchReq(GetWikiSearchReq getWikiSearchReq) {
+        String keyword = getWikiSearchReq.getKeyword().toLowerCase().replaceAll("\\s", "");
+        if ((keyword.isEmpty())
+                && (getWikiSearchReq.getCategoryId() == null || getWikiSearchReq.getCategoryId() == 0)) {
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_SEARCH_EMPTY_REQUEST);
+        }
+
+        if (!SEARCH_TYPE.contains(getWikiSearchReq.getType())) {
+            throw new InvalidWikiException(BaseResponseStatus.WIKI_INVALID_SEARCH_TYPE);
+        }
+
+        if (getWikiSearchReq.getCategoryId() != null && getWikiSearchReq.getCategoryId() != 0) {
+            // 카테고리 유효성 체크 (categoryRepository를 추가해서 처리하거나 별도의 로직 추가)
+        }
+    }
+
+    // SearchResponse를 WikiListRes로 변환하는 메서드
+    private List<WikiListRes> searchResponseToWikiListRes(SearchResponse searchResponse) {
+        return Arrays.stream(searchResponse.getHits().getHits())
+                .map(hit -> {
+                    Wiki wiki = objectMapper.convertValue(hit.getSourceAsMap(), Wiki.class);
+                    return WikiListRes.builder()
+                            .id(wiki.getId())
+                            .title(wiki.getTitle())
+                            .content(wiki.getContent())
+                            .category(wiki.getCategoryName())
+                            .createdAt(wiki.getCreatedAt())
+                            .thumbnail(wiki.getThumbnailImgUrl())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/ElasticWikiSearchService.java
@@ -34,6 +34,7 @@ public class ElasticWikiSearchService implements WikiSearchService {
     private final RestHighLevelClient restHighLevelClient;
     private final ObjectMapper objectMapper;
     private final static List<String> SEARCH_TYPE = List.of("tc", "t", "c");
+    private final static String INDEX = "wiki";
 
     @Override
     public List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq) throws IOException {
@@ -73,7 +74,7 @@ public class ElasticWikiSearchService implements WikiSearchService {
                 .sort("created_at", SortOrder.DESC);  // 최신순 정렬
 
         // SearchRequest = Elasticsearch에서 검색 요청을 정의하는 객체
-        SearchRequest searchRequest = new SearchRequest("wiki");  // 인덱스 설정
+        SearchRequest searchRequest = new SearchRequest(INDEX);  // 인덱스 설정
         searchRequest.source(searchSourceBuilder);
 
         // Elasticsearch 검색 실행

--- a/back/backend/src/main/java/org/example/backend/Wiki/Service/WikiSearchService.java
+++ b/back/backend/src/main/java/org/example/backend/Wiki/Service/WikiSearchService.java
@@ -3,8 +3,9 @@ package org.example.backend.Wiki.Service;
 import org.example.backend.Wiki.Model.Req.GetWikiSearchReq;
 import org.example.backend.Wiki.Model.Res.WikiListRes;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface WikiSearchService {
-   List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq);
+    List<WikiListRes> search(GetWikiSearchReq getWikiSearchReq) throws IOException;
 }


### PR DESCRIPTION
## 연관 이슈
close #466 


## 작업 내용
📌위키 검색에 엘라스틱서치 적용
- RestHighLevelClient를 사용하여 elasticsearch에서 조회
- content에 Fuzziness.AUTO, minimumShouldMatch("75%") 적용
  - 검색어의 75%가 포함되는 것만 검색되도록 
- title에 slop(2) 적용
  - 각 단어 사이에 두 단어 허용


## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)