### PR TITLE
[Feat] 통합 검색 구현 (#493)

### DIFF
--- a/frontend/src/components/Common/SearchComponent.vue
+++ b/frontend/src/components/Common/SearchComponent.vue
@@ -157,12 +157,12 @@ export default {
     }
   },
   async mounted() {
-    await this.getSuperCategory();
     this.selectedCategory = this.$route.query.selectedCategory || '';
     this.searchQuery = this.$route.query.keyword || "";
     this.selectedType = this.$route.query.type || "tc";
     this.selectedSubCategory.id = this.$route.query.selectedSubCategoryId || 0;
     this.selectedSubCategory.categoryName = this.$route.query.selectedSubCategoryName || "";
+    await this.getSuperCategory();
   },
   components: {
     SortTypeComponent

--- a/frontend/src/components/Common/WikiSearchComponent .vue
+++ b/frontend/src/components/Common/WikiSearchComponent .vue
@@ -59,6 +59,7 @@ export default {
     }
   },
   async mounted() {
+    this.searchQuery = this.$route.query.keyword || "";
     await this.categoryStore.loadSuperCategories();
   }
 };

--- a/frontend/src/components/Header/HeaderComponent.vue
+++ b/frontend/src/components/Header/HeaderComponent.vue
@@ -17,8 +17,8 @@
             </ul>
         </nav>
         <div class="search-bar">
-            <input type="text" placeholder="검색어를 입력하세요">
-            <button @click="showAlert"><i class="fas fa-search"></i></button>
+            <input type="text" v-model="keyword" @keydown.enter="totalSearch" placeholder="검색어를 입력하세요">
+            <button @click="totalSearch"><i class="fas fa-search"></i></button>
         </div>
         <div class="auth-navigation">
             <div v-if="!isLoggedIn">
@@ -64,9 +64,26 @@ export default {
             return this.userStore.isLoggedIn;
         },
     },
+    data(){
+        return {
+            keyword: "",
+        }
+    },
+    watch: {
+        '$route.query': {
+            handler(newQuery) {
+                if (window.location.pathname !== "/search"){
+                    this.keyword = '';
+                } else {
+                    this.keyword = newQuery.keyword || '';
+                }
+            },
+            immediate: true
+        }
+    },
     methods: {
-        showAlert() {
-            alert("통합 검색은 추후 추가 예정입니다.")
+        totalSearch(){
+            window.location.href = "/search?keyword="+this.keyword;
         },
         logout() {
             if (window.confirm("로그아웃 하시겠습니까?")) {

--- a/frontend/src/pages/QnaListPage.vue
+++ b/frontend/src/pages/QnaListPage.vue
@@ -72,10 +72,24 @@ export default {
   },
   mounted() {
     // this.selectedSort = "latest";
-    this.selectedPage = 1;
-    this.selectedSolvedStatus = "ALL"
-    this.isSearched = false;
-    this.fetchQnaList();
+    if(this.$route.query.keyword){
+      console.log(this.$route.query.keyword);
+      this.selectedPage = 1;
+      this.selectedSolvedStatus = "ALL"
+      this.isSearched = true;
+      const query = {
+          searchQuery: this.$route.query.keyword.trim(),
+          selectedSuperCategoryId: '',
+          selectedSubCategoryId: 0,
+          selectedType: "tc",
+      }
+      this.handleSearch(query);
+    } else {
+      this.selectedPage = 1;
+      this.selectedSolvedStatus = "ALL"
+      this.isSearched = false;
+      this.fetchQnaList();
+    }
   },
   methods: {
     handleCheckLatest() {
@@ -112,6 +126,7 @@ export default {
 
         this.totalPages = await useQnaStore().searchedTotalPage || 1;
         this.isLoading = false;
+        this.$router.push("/qna/list")
       }
     },
     async fetchQnaList() {

--- a/frontend/src/pages/TotalSearchPage.vue
+++ b/frontend/src/pages/TotalSearchPage.vue
@@ -5,8 +5,8 @@
         <div v-if="isLoading" style="text-align:center;"></div>
         <div v-else class="subject-container">
             <div class="subject-box">
-                <router-link to="/errorarchive/list" class="subject">에러 아카이브</router-link>
-                <router-link to="/errorarchive/list" class="show-all-button">더 보기</router-link>
+                <router-link :to="'/errorarchive/list?type=tc&keyword='+keyword" class="subject">에러 아카이브</router-link>
+                <router-link :to="'/errorarchive/list?type=tc&keyword='+keyword" class="show-all-button">더 보기</router-link>
             </div>
             <div class="errorarchive-inner">
                 <div class="errorarchive-list-flex">
@@ -27,8 +27,8 @@
         <div v-if="isLoading" style="text-align:center;"></div>
         <div v-else class="subject-container">
             <div class="subject-box">
-                <router-link to="/wiki/list" class="subject">위키</router-link>
-                <router-link to="/wiki/list" class="show-all-button">더 보기</router-link>
+                <router-link :to="'/wiki/list?keyword='+keyword" class="subject">위키</router-link>
+                <router-link :to="'/wiki/list?keyword='+keyword" class="show-all-button">더 보기</router-link>
             </div>
             <div class="wiki-list-grid" v-if="!isLoading">
                 <WikiCardComponent v-for="wikiCard in mainStore.searchInfo.wikiListResList" :key="wikiCard.id"
@@ -44,8 +44,8 @@
         <LoadingComponent v-if="isLoading"/>
         <div v-else class="subject-container">
             <div class="subject-box">
-                <router-link to="/qna/list" class="subject">QnA</router-link>
-                <router-link to="/qna/list" class="show-all-button">더 보기</router-link>
+                <router-link :to="'/qna/list?keyword='+keyword" class="subject">QnA</router-link>
+                <router-link :to="'/qna/list?keyword='+keyword" class="show-all-button">더 보기</router-link>
             </div>
             <div class="qna-inner">
                 <div class="qna-list-flex">
@@ -76,12 +76,14 @@ import WikiCardComponent from "@/components/wiki/WikiCardComponent.vue";
 import QnaCardComponent from "@/components/Qna/List/QnaListCardComponent.vue";
 import LoadingComponent from "@/components/Common/LoadingComponent.vue";
 import TagComponent from "@/components/Common/TagComponent.vue";
+import {useQnaStore} from "@/store/useQnaStore";
+import {useWikiStore} from "@/store/useWikiStore";
 
 export default {
     name: "TotalSearchPage",
     components: {TagComponent, LoadingComponent, QnaCardComponent, WikiCardComponent, ErrorArchiveCardComponent},
     computed: {
-        ...mapStores(useMainStore),
+        ...mapStores(useMainStore,useWikiStore,useQnaStore),
     },
     data() {
         return {

--- a/frontend/src/pages/TotalSearchPage.vue
+++ b/frontend/src/pages/TotalSearchPage.vue
@@ -1,0 +1,166 @@
+<template>
+    <TagComponent :tagTitle="'통합 검색 결과'" :tagSubTitle="'한번에 모두 검색'"/>
+    <div class="custom-container" style="margin-top: 0;">
+
+        <div v-if="isLoading" style="text-align:center;"></div>
+        <div v-else class="subject-container">
+            <div class="subject-box">
+                <router-link to="/errorarchive/list" class="subject">에러 아카이브</router-link>
+                <router-link to="/errorarchive/list" class="show-all-button">더 보기</router-link>
+            </div>
+            <div class="errorarchive-inner">
+                <div class="errorarchive-list-flex">
+                    <ErrorArchiveCardComponent
+                        v-for="errorarchiveCard in mainStore.searchInfo.errorArchiveResList"
+                        :key="errorarchiveCard.id"
+                        v-bind:errorarchiveCard="errorarchiveCard"
+                    />
+                </div>
+            </div>
+            <div v-if="mainStore.searchInfo.errorArchiveResList.length === 0" style="display:flex">
+                <div style="margin:auto;">
+                    <span style="font-size: 20px; color: rgb(111, 111, 111);">검색 결과가 없습니다.</span>
+                </div>
+            </div>
+        </div>
+
+        <div v-if="isLoading" style="text-align:center;"></div>
+        <div v-else class="subject-container">
+            <div class="subject-box">
+                <router-link to="/wiki/list" class="subject">위키</router-link>
+                <router-link to="/wiki/list" class="show-all-button">더 보기</router-link>
+            </div>
+            <div class="wiki-list-grid" v-if="!isLoading">
+                <WikiCardComponent v-for="wikiCard in mainStore.searchInfo.wikiListResList" :key="wikiCard.id"
+                                   :wikiCard="wikiCard"/>
+            </div>
+            <div v-if="mainStore.searchInfo.wikiListResList.length === 0" style="display:flex">
+                <div style="margin:auto;">
+                    <span style="font-size: 20px; color: rgb(111, 111, 111);">검색 결과가 없습니다.</span>
+                </div>
+            </div>
+        </div>
+
+        <LoadingComponent v-if="isLoading"/>
+        <div v-else class="subject-container">
+            <div class="subject-box">
+                <router-link to="/qna/list" class="subject">QnA</router-link>
+                <router-link to="/qna/list" class="show-all-button">더 보기</router-link>
+            </div>
+            <div class="qna-inner">
+                <div class="qna-list-flex">
+                    <QnaCardComponent
+                        v-for="qnaCard in mainStore.searchInfo.qnaListResList"
+                        :key="qnaCard.id"
+                        v-bind:qnaCard="qnaCard"
+                    />
+                </div>
+            </div>
+            <div v-if="mainStore.searchInfo.qnaListResList.length === 0" style="display:flex">
+                <div style="margin:auto;">
+                    <span style="font-size: 20px; color: rgb(111, 111, 111);">검색 결과가 없습니다.</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+
+<script>
+
+
+import {mapStores} from "pinia";
+import {useMainStore} from "@/store/useMainStore";
+import ErrorArchiveCardComponent from "@/components/errorarchive/ErrorArchiveCardComponent.vue";
+import WikiCardComponent from "@/components/wiki/WikiCardComponent.vue";
+import QnaCardComponent from "@/components/Qna/List/QnaListCardComponent.vue";
+import LoadingComponent from "@/components/Common/LoadingComponent.vue";
+import TagComponent from "@/components/Common/TagComponent.vue";
+
+export default {
+    name: "TotalSearchPage",
+    components: {TagComponent, LoadingComponent, QnaCardComponent, WikiCardComponent, ErrorArchiveCardComponent},
+    computed: {
+        ...mapStores(useMainStore),
+    },
+    data() {
+        return {
+            isLoading: true,
+            keyword: "",
+        }
+    },
+    methods: {
+        async getTotalSearchPageInfo() {
+            await this.mainStore.getTotalSearchInfo(this.keyword);
+            this.isLoading = false;
+        }
+    },
+    mounted() {
+        this.keyword = this.$route.query.keyword;
+        this.getTotalSearchPageInfo();
+    }
+}
+</script>
+
+
+<style scoped>
+.subject-container {
+    margin-bottom: 70px;
+}
+
+.subject-box {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: 15px;
+    font-weight: bold;
+}
+
+.subject {
+    font-size: 25px;
+}
+
+.qna-list-flex {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    grid-auto-rows: auto;
+    gap: 26px 36px;
+    justify-items: stretch;
+    max-width: 100%;
+    margin: 0 auto
+}
+
+.qna-inner {
+    width: auto;
+    height: max-content;
+    background-color: #fff;
+}
+
+.errorarchive-inner {
+    width: auto;
+    height: max-content;
+    background-color: #fff;
+}
+
+.errorarchive-list-flex {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-auto-rows: auto;
+    gap: 26px 36px;
+    justify-items: stretch;
+    max-width: 100%;
+    margin: 0 auto
+}
+
+
+.wiki-list-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-auto-rows: auto;
+    gap: 0 36px;
+    justify-items: stretch;
+    max-width: 100%;
+    margin: 0 auto;
+}
+</style>

--- a/frontend/src/pages/WikiListPage.vue
+++ b/frontend/src/pages/WikiListPage.vue
@@ -1,154 +1,166 @@
 <template>
-  <TagComponent :tagTitle="'WIKI'" :tagSubTitle="'당신의 위키를 만들어보세요'" />
-  <div class="custom-container" style="margin-top: 0;">
-    <div class="wiki-inner">
-      <WikiSearchComponent @search="handleSearch" />
+    <TagComponent :tagTitle="'WIKI'" :tagSubTitle="'당신의 위키를 만들어보세요'"/>
+    <div class="custom-container" style="margin-top: 0;">
+        <div class="wiki-inner">
+            <WikiSearchComponent @search="handleSearch" :keyword="$route.query.keyword"/>
 
-      <div class="create-wiki-btn-container">
-        <button @click="navigateToWikiRegister" class="create-wiki-btn">작성하기</button>
-      </div>
+            <div class="create-wiki-btn-container">
+                <button @click="navigateToWikiRegister" class="create-wiki-btn">작성하기</button>
+            </div>
 
-      <div v-if="wikiStore.isLoading" style="text-align:center;">
-        <p>로딩 중...</p>
-      </div>
+            <div v-if="wikiStore.isLoading" style="text-align:center;">
+                <p>로딩 중...</p>
+            </div>
 
-      <div class="wiki-list-grid" v-if="!wikiStore.isLoading">
-        <WikiCardComponent v-for="wikiCard in wikiStore.wikiCards" :key="wikiCard.id" :wikiCard="wikiCard" />
-      </div>
+            <div class="wiki-list-grid" v-if="!wikiStore.isLoading">
+                <WikiCardComponent v-for="wikiCard in wikiStore.wikiCards" :key="wikiCard.id" :wikiCard="wikiCard"/>
+            </div>
 
-      <div v-if="!wikiStore.isLoading && wikiStore.wikiCards.length === 0" style="text-align: center;">
-        <p>검색 결과가 없습니다.</p>
-      </div>
+            <div v-if="!wikiStore.isLoading && wikiStore.wikiCards.length === 0" style="text-align: center;">
+                <p>검색 결과가 없습니다.</p>
+            </div>
+        </div>
+
+        <div class="pagination-container" v-if="!isLoading && totalPage > 0">
+            <PaginationComponent :totalPage="totalPage" :nowPage="selectedPage" @updatePage="handlePageUpdate"/>
+        </div>
     </div>
-
-    <div class="pagination-container" v-if="!isLoading && totalPage > 0">
-      <PaginationComponent :totalPage="totalPage" :nowPage="selectedPage" @updatePage="handlePageUpdate" />
-    </div>
-  </div>
 </template>
 
 <script>
-import { useWikiStore } from "@/store/useWikiStore";
+import {useWikiStore} from "@/store/useWikiStore";
 import WikiCardComponent from "@/components/wiki/WikiCardComponent.vue";
 import PaginationComponent from "@/components/Common/PaginationComponent.vue";
 import WikiSearchComponent from "@/components/Common/WikiSearchComponent .vue";
 import TagComponent from "@/components/Common/TagComponent.vue";
-import { mapStores } from "pinia";
+import {mapStores} from "pinia";
 
 export default {
-  name: "WikiListPage",
-  components: {
-    WikiCardComponent,
-    PaginationComponent,
-    WikiSearchComponent,
-    TagComponent,
-  },
-  data() {
-    return {
-      selectedPage: 1,
-      isSearchMode: false,
-      searchParams: {},
-      isLoading: true,
-      totalPage: 1
-    };
-  },
-  computed: {
-    ...mapStores(useWikiStore),
-  },
-  methods: {
-    handleSearch(searchParams) {
-      this.isSearchMode = true;
-      this.selectedPage = 1;
-      this.isLoading = true;
-      this.searchParams = searchParams;
-      this.wikiStore.wikiSearch(this.searchParams).then(() => {
-        this.totalPage = this.wikiStore.searchTotalPages;
-        this.isLoading = false;
-      });
+    name: "WikiListPage",
+    components: {
+        WikiCardComponent,
+        PaginationComponent,
+        WikiSearchComponent,
+        TagComponent,
     },
-
-    async fetchWikiList(page) {
-      this.isSearchMode = false;
-      this.isLoading = true;
-
-      await this.wikiStore.fetchWikiList(page);
-      this.totalPage = this.wikiStore.totalPages;
-      this.isLoading = false;
+    data() {
+        return {
+            selectedPage: 1,
+            isSearchMode: false,
+            searchParams: {},
+            isLoading: true,
+            totalPage: 1
+        };
     },
+    computed: {
+        ...mapStores(useWikiStore),
+    },
+    methods: {
+        handleSearch(searchParams) {
+            this.isSearchMode = true;
+            this.selectedPage = 1;
+            this.isLoading = true;
+            this.searchParams = searchParams;
+            this.wikiStore.wikiSearch(this.searchParams).then(() => {
+                this.totalPage = this.wikiStore.searchTotalPages;
+                this.isLoading = false;
+            });
+            this.$router.push("/wiki/list");
+        },
 
-    async handlePageUpdate(newPage) {
-      if (newPage !== this.selectedPage) {
-        this.selectedPage = newPage;
-        this.isLoading = true;
+        async fetchWikiList(page) {
+            this.isSearchMode = false;
+            this.isLoading = true;
 
-        if (this.isSearchMode) {
-          this.searchParams.page = newPage - 1;
-          this.wikiStore.wikiSearch(this.searchParams).then(() => {
+            await this.wikiStore.fetchWikiList(page);
+            this.totalPage = this.wikiStore.totalPages;
             this.isLoading = false;
-          });
-        } else {
-          this.fetchWikiList(this.selectedPage);
-          this.isLoading = false;
+        },
 
+        async handlePageUpdate(newPage) {
+            if (newPage !== this.selectedPage) {
+                this.selectedPage = newPage;
+                this.isLoading = true;
+
+                if (this.isSearchMode) {
+                    this.searchParams.page = newPage - 1;
+                    this.wikiStore.wikiSearch(this.searchParams).then(() => {
+                        this.isLoading = false;
+                    });
+                } else {
+                    this.fetchWikiList(this.selectedPage);
+                    this.isLoading = false;
+
+                }
+            }
+        },
+
+        async navigateToWikiRegister() {
+            const canProceed = await this.wikiStore.fetchUserDetails();
+
+            if (canProceed) {
+                this.$router.push("/wiki/register");
+            }
         }
-      }
     },
 
-    async navigateToWikiRegister() {
-      const canProceed = await this.wikiStore.fetchUserDetails();
-
-      if (canProceed) {
-        this.$router.push("/wiki/register");
-      }
+    mounted() {
+        if (this.$route.query.keyword) {
+            const request = {
+                keyword: this.$route.query.keyword,
+                categoryId: null,
+                type: this.selectedType || 'tc',
+                page: 0,
+                size: 16
+            };
+            this.handleSearch(request);
+        } else {
+            this.fetchWikiList(this.selectedPage);
+        }
     }
-  },
-
-  mounted() {
-    this.fetchWikiList(this.selectedPage);
-  }
 };
 </script>
 
 <style scoped>
 .wiki-list-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  grid-auto-rows: auto;
-  gap: 0 36px;
-  justify-items: stretch;
-  max-width: 100%;
-  margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-auto-rows: auto;
+    gap: 0 36px;
+    justify-items: stretch;
+    max-width: 100%;
+    margin: 0 auto;
 }
 
 .pagination-container {
-  margin-top: 20px;
-  display: flex;
-  justify-content: center;
+    margin-top: 20px;
+    display: flex;
+    justify-content: center;
 }
 
 .create-wiki-btn-container {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 20px;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 20px;
 }
 
 .create-wiki-btn {
-  margin-bottom: 0.875rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  height: 2rem;
-  display: inline-flex;
-  -webkit-box-align: center;
-  align-items: center;
-  margin-right: 0.875rem;
-  color: #3899de;
-  text-decoration: none;
-  font-weight: 700;
-  font-size: 1rem;
-  cursor: pointer;
+    margin-bottom: 0.875rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    height: 2rem;
+    display: inline-flex;
+    -webkit-box-align: center;
+    align-items: center;
+    margin-right: 0.875rem;
+    color: #3899de;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
 }
 
 .create-wiki-btn:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -27,6 +27,7 @@ import UserLogPage from "@/pages/UserLogPage.vue";
 import ErrorArchiveUpdatePage from "@/pages/ErrorArchiveUpdatePage.vue";
 import { useUserStore } from "@/store/useUserStore";
 import RankingPage from "@/pages/RankingPage.vue";
+import TotalSearchPage from "@/pages/TotalSearchPage.vue";
 
 const router = createRouter({
     history: createWebHistory(),
@@ -72,6 +73,7 @@ const router = createRouter({
         { path: "/user/log/:nickname", component: UserLogPage },
         { path: "/errorarchive/detail", component: ErrorArchiveDetailPage },
         { path: "/", component: MainPage },
+        { path: "/search", component: TotalSearchPage },
     ]
 });
 

--- a/frontend/src/store/useMainStore.js
+++ b/frontend/src/store/useMainStore.js
@@ -9,6 +9,11 @@ export const useMainStore = defineStore('main', {
             wikiListResList: [],
             errorArchiveListResList: [],
             qnaListResList: []
+        },
+        searchInfo: {
+            wikiListResList: [],
+            errorArchiveResList: [],
+            qnaListResList: []
         }
     }),
     actions: {
@@ -31,6 +36,30 @@ export const useMainStore = defineStore('main', {
                 }
             } catch (error) {
                 console.error('메인 페이지 로딩 실패:', error);
+                return null;
+            }
+        },
+
+        async getTotalSearchInfo(keyword) {
+            const request = {
+                errorArchiveSize: 8,
+                wikiSize: 4,
+                qnaSize: 8,
+                keyword: keyword
+            }
+            try {
+                const response= await axios.get(backend+'/main/search',{
+                    params: request,
+                    headers: { 'Content-Type': 'multipart/form-data' },
+                    withCredentials: true
+                });
+                if (response.data.isSuccess){
+                    this.searchInfo = response.data.result;
+                } else {
+                    throw new Error(response.data.message);
+                }
+            } catch (error) {
+                console.error('통합 검색 페이지 로딩 실패:', error);
                 return null;
             }
         }


### PR DESCRIPTION
## 연관 이슈
close #493 


## 작업 내용
- 통합 검색 api 호출
- 통합 검색 결과 페이지 생성
- 통합 검색 결과 페이지에서 각 게시판으로 이동 시, 검색이 유지되도록 설정


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f3695326-43ae-422c-bf6c-0d0daba3117e)
![image](https://github.com/user-attachments/assets/932a0ff9-414b-4d67-b986-1ace86e9296a)
![image](https://github.com/user-attachments/assets/2271c72a-ee22-43cd-baa1-716e3a3fce38)
![image](https://github.com/user-attachments/assets/11a0634f-93a5-4b6e-8fc9-57643c26cbe1)


## 리뷰 요구사항 혹은 기타 (선택)
- 아직 백이 완전하지 않음