### PR TITLE
[Refactor] 백엔드 cicd 스크립트 rollout 확인 시간 단축

### DIFF
--- a/cicd/back/backend.sh
+++ b/cicd/back/backend.sh
@@ -20,7 +20,7 @@ fi
 echo $color
 # 두 번째 for 루프: Pod 상태 확인 (5회 반복)
 result=true
-for i in {1..10}; do
+for i in {1..20}; do
 
     kubectl rollout status deployment | grep be-$color-deployment
     rollout_status=$?
@@ -32,7 +32,7 @@ for i in {1..10}; do
     else
         echo "Waiting for deployment to complete..."
         result=false
-        sleep 10  # 다음 시도 전에 대기
+        sleep 5  # 다음 시도 전에 대기
     fi
 
 done


### PR DESCRIPTION
## 연관 이슈

## 작업 내용
- 백엔드 배포 시 작동되는 script에서 배포된  pod들이 정상 작동하는지 확인하는 rollout 명령어 실행하는 시간 단축 (10초 -> 5초)
  - 대신 총 횟수를 10번에서 20번으로 늘림

## 스크린샷 (선택)


## 리뷰 요구사항 혹은 기타 (선택)
