### PR TITLE
[Feat] 에러 아카이브 수정 권한 설정 추가(#537)

### DIFF
--- a/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
+++ b/back/backend/src/main/java/org/example/backend/Common/BaseResponseStatus.java
@@ -64,8 +64,7 @@ public enum BaseResponseStatus {
     ERROR_PERMISSION_DENIED(false,6029,"권한이 없습니다"),
     ERRORARCHIVE_FAIL(false, 6080, "요청이 실패하였습니다"),
     ERRORARCHIVE_SEARCH_CHOSUNG_LENGTH(false,6081,"초성 글자는 한글자로 할 수 없습니다."),
-
-
+    ERRORARCHIVE_NO_EDIT_PERMISSION(false,6082,"수정 및 삭제 권한이 없습니다."),
 
     // 에러 QnA 기능 - 7000
 

--- a/back/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
+++ b/back/backend/src/main/java/org/example/backend/ErrorArchive/Controller/ErrorArchiveController.java
@@ -67,6 +67,18 @@ public class ErrorArchiveController {
         }
         return new BaseResponse<>(errorArchiveService.detail(getErrorArchiveDetailReq, customUserDetails));
     }
+    @GetMapping("/edit-detail")
+    public BaseResponse<GetErrorArchiveEditDetailRes> getErrorArchiveEditDetail(Integer errorArchiveId, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long userId;
+        if(customUserDetails != null){
+            userId = customUserDetails.getUserId();
+        } else {
+            userId = null;
+        }
+        GetErrorArchiveEditDetailRes getErrorArchiveEditDetailRes =  errorArchiveService.getErrorArchiveEditDetail(errorArchiveId, userId);
+        return new BaseResponse<>(getErrorArchiveEditDetailRes);
+    }
+
     // 아카이브 검색
     @GetMapping("/search")
     public BaseResponse<List<ListErrorArchiveRes>> search(GetErrorArchiveSearchReq errorArchiveSearchReq)  {

--- a/back/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/GetErrorArchiveEditDetailRes.java
+++ b/back/backend/src/main/java/org/example/backend/ErrorArchive/Model/Res/GetErrorArchiveEditDetailRes.java
@@ -1,0 +1,17 @@
+package org.example.backend.ErrorArchive.Model.Res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetErrorArchiveEditDetailRes {
+    private Long id;
+    private Long userId;
+    private Long superCategoryId;
+    private Long subCategoryId;
+    private String title;
+    private String content;
+    private String superCategoryName;
+    private String subCategoryName;
+}

--- a/back/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
+++ b/back/backend/src/main/java/org/example/backend/ErrorArchive/Service/ErrorArchiveService.java
@@ -131,6 +131,36 @@ public class ErrorArchiveService {
                 .build();
         return ErrorArchiveDetailRes;
     }
+    // 상세 조회 (권한 추가)
+    public GetErrorArchiveEditDetailRes getErrorArchiveEditDetail(Integer errorArchiveId, Long userId){
+        User user;
+        // 유저가 있으면
+        if(userId != null) {
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new InvalidErrorBoardException(BaseResponseStatus.USER_NOT_FOUND));
+        } else {
+            user = null;
+        }
+        ErrorArchive errorArchive = errorArchiveReository.findByIdAndEnableTrue(errorArchiveId.longValue())
+                .orElseThrow(()-> new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NOT_FOUND));
+        if (user != errorArchive.getUser()){
+            throw new InvalidErrorBoardException(BaseResponseStatus.ERRORARCHIVE_NO_EDIT_PERMISSION);
+        }
+        return GetErrorArchiveEditDetailRes.builder()
+                .id(errorArchive.getId())
+                .userId(errorArchive.getId())
+                .superCategoryId(errorArchive.getCategory().getSuperCategory() != null ?
+                        errorArchive.getCategory().getSuperCategory().getId() : null)
+                .subCategoryId(errorArchive.getCategory().getId())
+                .title(errorArchive.getTitle())
+                .content(errorArchive.getContent())
+                .superCategoryName(errorArchive.getCategory().getSuperCategory() != null ?
+                        errorArchive.getCategory().getSuperCategory().getCategoryName() : null)
+                .subCategoryName(errorArchive.getCategory() != null ?
+                        errorArchive.getCategory().getCategoryName() : null)
+                .build();
+        }
+
     // 로그인한 사용자의 에러 아카이브 좋아요/싫어요 여부 조회 메소드
     public Optional<Boolean> ErrorArchiveLikeOrHate(Long errorArchiveId,Long userId) {
         ErrorArchive errorArchive = errorArchiveReository.findById(errorArchiveId)

--- a/back/common/src/main/java/com/example/common/ErrorArchive/Repository/ErrorArchiveReository.java
+++ b/back/common/src/main/java/com/example/common/ErrorArchive/Repository/ErrorArchiveReository.java
@@ -76,4 +76,6 @@ public interface ErrorArchiveReository extends JpaRepository<ErrorArchive, Long>
             "WHERE es.user.id = :userId AND e.enable = true")
     Page<ErrorArchive> findByErrorScrapListUserIdAndEnableTrueWithFetch(@Param("userId") Long userId, Pageable pageable);
 
+    Optional<ErrorArchive> findByIdAndEnableTrue(Long id);
+
 }


### PR DESCRIPTION
## 연관 이슈
close #537 

## 작업 내용
로그인한 사용자가 작성한 글 수정 가능하게끔 수정
로그인한 사용자가 본인이 작성한 글이 아니면 에러 처리

## 스크린샷 (선택)
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/cf383f91-2793-43cd-86df-fd46da472a1f">


## 리뷰 요구사항 혹은 기타 (선택)
프론트에서 404 뜨게 하려고 추가한 메소드