### PR TITLE
[Fix] 에러아카이브 상세 페이지 글자 크기 수정(#548)

### DIFF
--- a/frontend/src/components/errorarchive/ErrorArchiveDetailComponent.vue
+++ b/frontend/src/components/errorarchive/ErrorArchiveDetailComponent.vue
@@ -310,6 +310,9 @@ export default {
     align-items: flex-start;
     justify-content: space-between;
 }
+.errorarchive-title h1 {
+    font-size: 40px !important; /* 원하는 크기로 설정 */
+}
 .sc-fvxzrP {
   display: flex;
   align-items: center; /* 세로 중앙 정렬 */
@@ -317,6 +320,7 @@ export default {
 }
 /* 제목이 짧을 때의 마진을 조정 */
 .header-container.short-title .errorarchive-title {
+    font-size: 50%; /* 기존 크기의 50%로 설정 */
     margin-right: 400px;
 }
 


### PR DESCRIPTION
## 연관 이슈
close #548 


## 작업 내용
css에 제목 관련한 클래스가 많아서!important 써서 크기를 줄임(우선수위 적용)



## 스크린샷 (선택)
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/454c6c71-939b-4d8a-9eab-4c043fa37744">



## 리뷰 요구사항 혹은 기타 (선택)
