### PR TITLE
[Feat] 위키 검색 정렬 컴포넌트 추가 (#558)

### DIFF
--- a/frontend/src/components/Common/WikiSearchComponent .vue
+++ b/frontend/src/components/Common/WikiSearchComponent .vue
@@ -55,6 +55,7 @@ export default {
         type: this.selectedType || 'tc',
         page: 0,
         size: 16,
+        sort: "",
       };
 
       this.$emit("search", request);

--- a/frontend/src/components/Common/WikiSortTypeComponent.vue
+++ b/frontend/src/components/Common/WikiSortTypeComponent.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="radio-input">
+    <label>
+      <input value="accuracy" name="value-radio" id="value-2" type="radio" v-model="selectedSort"
+             @change="emitSortChange('accuracy')"/>
+      <span>정확도 순</span>
+    </label>
+    <label>
+      <input value="latest" name="value-radio" id="value-1" type="radio" v-model="selectedSort"
+             @change="emitSortChange('latest')"/>
+      <span>최신 순</span>
+    </label>
+    <span class="selection"></span>
+  </div>
+</template>
+
+<script>
+import {mapStores} from "pinia";
+import {useQnaStore} from "@/store/useQnaStore";
+
+export default {
+  name: "SortTypeComponent",
+  data() {
+    return {
+      selectedSort: null
+    };
+  },
+  computed: {
+    ...mapStores(useQnaStore),
+  },
+  mounted() {
+    this.selectedSort="accuracy"
+  },
+  methods: {
+    emitSortChange(sortType) {
+      this.$emit("emitSortType", sortType);
+    },
+  },
+  components: {
+  },
+};
+
+</script>
+
+<style>
+.radio-input input {
+  display: none;
+}
+
+.radio-input {
+  --container_width: 160px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  border-radius: 10px;
+  background-color: #fff;
+  color: #000;
+  width: var(--container_width);
+  overflow: hidden;
+  border: 2px solid rgba(53, 52, 52, 0.226);
+  margin-bottom: 20px;
+}
+
+.radio-input label {
+  width: 100%;
+  padding: 10px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
+  font-weight: 800;
+  letter-spacing: -1px;
+  font-size: 14px;
+}
+
+.selection {
+  display: none;
+  position: absolute;
+  height: 100%;
+  width: calc(var(--container_width) / 2);
+  z-index: 0;
+  left: 0;
+  top: 0;
+  transition: 0.15s ease;
+}
+
+.radio-input label:has(input:checked) {
+  color: #fff;
+}
+
+.radio-input label:has(input:checked) ~ .selection {
+  background-color: #60abda;
+  display: inline-block;
+}
+
+.radio-input label:nth-child(1):has(input:checked) ~ .selection {
+  transform: translateX(calc(var(--container_width) * 0 / 2));
+}
+
+.radio-input label:nth-child(2):has(input:checked) ~ .selection {
+  transform: translateX(calc(var(--container_width) * 1 / 2));
+}
+
+</style>

--- a/frontend/src/pages/WikiListPage.vue
+++ b/frontend/src/pages/WikiListPage.vue
@@ -119,7 +119,6 @@ export default {
     },
     async handleCheckSort(sortType) {
       this.sortType = sortType;
-      console.log(11111111111);
       await this.handleSearch(this.searchParams);
     }
   },

--- a/frontend/src/pages/WikiListPage.vue
+++ b/frontend/src/pages/WikiListPage.vue
@@ -4,8 +4,9 @@
     <div class="wiki-inner">
       <WikiSearchComponent @search="handleSearch" :keyword="$route.query.keyword"/>
 
-      <div class="create-wiki-btn-container">
-        <button @click="navigateToWikiRegister" class="create-wiki-btn">작성하기</button>
+      <div class="create-wiki-btn-container" :style="{ justifyContent: isSearchMode ? 'space-between' : 'flex-end' }">
+          <WikiSortTypeComponent v-if="isSearchMode" @emitSortType="handleCheckSort"/>
+          <button @click="navigateToWikiRegister" class="create-wiki-btn">작성하기</button>
       </div>
 
       <div class="wiki-list-grid" v-if="!wikiStore.isLoading">
@@ -34,6 +35,7 @@ import WikiSearchComponent from "@/components/Common/WikiSearchComponent .vue";
 import TagComponent from "@/components/Common/TagComponent.vue";
 import { mapStores } from "pinia";
 import LoadingComponent from '@/components/Common/LoadingComponent.vue';
+import WikiSortTypeComponent from "@/components/Common/WikiSortTypeComponent.vue";
 
 
 export default {
@@ -44,6 +46,7 @@ export default {
     PaginationComponent,
     WikiSearchComponent,
     TagComponent,
+    WikiSortTypeComponent,
   },
   data() {
     return {
@@ -51,14 +54,15 @@ export default {
       isSearchMode: false,
       searchParams: {},
       isLoading: true,
-      totalPage: 1
+      totalPage: 1,
+      sortType: "accuracy",
     };
   },
   computed: {
     ...mapStores(useWikiStore),
   },
   methods: {
-    handleSearch(searchParams) {
+    async handleSearch(searchParams) {
       if (this.isSingleChosung(searchParams.keyword)) {
         alert("초성검색은 한 글자가 불가합니다");
         return;
@@ -67,11 +71,12 @@ export default {
       this.selectedPage = 1;
       this.isLoading = true;
       this.searchParams = searchParams;
-      this.wikiStore.wikiSearch({ ...this.searchParams, page: 0 }).then(() => {
+      this.searchParams.sort = this.sortType;
+      await this.wikiStore.wikiSearch({ ...this.searchParams, page: 0 }).then(() => {
         this.totalPage = this.wikiStore.searchTotalPages;
         this.isLoading = false;
       });
-      this.$router.push({ path: "/wiki/list", query: { keyword: searchParams.keyword } });
+      this.$router.push({ path: "/wiki/list" });
     },
 
     isSingleChosung(keyword) {
@@ -111,6 +116,11 @@ export default {
       if (canProceed) {
         this.$router.push("/wiki/register");
       }
+    },
+    async handleCheckSort(sortType) {
+      this.sortType = sortType;
+      console.log(11111111111);
+      await this.handleSearch(this.searchParams);
     }
   },
 
@@ -153,8 +163,9 @@ export default {
 
 .create-wiki-btn-container {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   margin-bottom: 20px;
+  margin-top: 20px;
 }
 
 .create-wiki-btn {


### PR DESCRIPTION
## 연관 이슈
close #558 


## 작업 내용
- 위키 정렬 컴포넌트 생성
- 검색했을 때만 정렬 컴포넌트 보이도록 설정


## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7488ef20-968d-452e-980c-67c769e6d17e)


## 리뷰 요구사항 혹은 기타 (선택)
