### PR TITLE
[Fix] 버전 리스트 테이블 수정 (#567)

### DIFF
--- a/frontend/src/pages/WikiVersionListPage.vue
+++ b/frontend/src/pages/WikiVersionListPage.vue
@@ -125,12 +125,13 @@ export default {
 }
 
 table {
-    width: 100%;
-    border-collapse: collapse;
-    background-color: white;
-    border-radius: 10px;
-    overflow: hidden;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  position: relative;
+  overflow: visible; /* 테이블이 자식 요소를 자르지 않도록 설정 */
+  width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 table th,


### PR DESCRIPTION
## 연관 이슈
close #567 


## 작업 내용
📌위키 버전리스트 테이블 사이즈 수정
- 리스트 컴포넌트가 짧으면 닉네임 컴포넌트가 짤리는 현상 수정


## 스크린샷 (선택)
변경전
![image](https://github.com/user-attachments/assets/bc2637e2-abc4-4f50-9ce4-cab172d6f5e3)
변경후
![image](https://github.com/user-attachments/assets/cbd4941a-399c-435b-af9e-54fc5d4efa4c)



## 리뷰 요구사항 혹은 기타 (선택)
리뷰어들이 참고해야할 사항이나 집중적으로 봐줬으면 하는 사항을 작성한다.